### PR TITLE
docs: refresh Thai codebase audit task proposals

### DIFF
--- a/docs/CODEBASE_AUDIT_TASKS_TH.md
+++ b/docs/CODEBASE_AUDIT_TASKS_TH.md
@@ -1,71 +1,74 @@
 # Codebase Audit: ข้อเสนอแผนงานแก้ไข (Thai)
 
-เอกสารนี้สรุปผลการตรวจสอบโค้ดเบื้องต้น และเสนอ "งานแก้ไข" อย่างละ 1 งาน ตามหมวดที่ร้องขอ
+เอกสารนี้สรุปผลการตรวจสอบโค้ดล่าสุด และเสนอ "งานแก้ไข" อย่างละ 1 งานตามหมวดที่ร้องขอ
 
 ## 1) งานแก้ไขข้อความพิมพ์ผิด (Typo Fix)
 
 **ปัญหาที่พบ**
-- ใน `README.md` มีข้อความผิดรูปแบบ/ผิดพิมพ์จากการตัดข้อความค้างกลางประโยค:
-  - `**installable web application**…245 chars truncated…ง asset แกนหลัก`
-- ข้อความลักษณะนี้ทำให้เอกสารไม่เป็นมืออาชีพ และอ่านบริบทส่วนอัปเดตแพ็กเกจแอปไม่รู้เรื่อง
+- ใน `api_gateway/README.md` มีประโยคภาษาอังกฤษผิดหลักไวยากรณ์/พิมพ์ตกคำ:
+  - `For an environment that closer resembles production, ...`
+- คำว่า `that closer` ควรเป็น `that is closer` ทำให้ข้อความอ่านสะดุดและดูไม่เป็นทางการ
 
 **หลักฐานอ้างอิง**
-- `README.md` (ช่วงหัวข้อ Application Packaging Update)
+- `api_gateway/README.md` หัวข้อ `Run (Production-like)`
 
 **งานที่เสนอ**
-- แก้ข้อความให้เป็นประโยคสมบูรณ์ เช่น:
-  - "มีการยกระดับหน้า interface ให้เป็นลักษณะ installable web application พร้อมการตั้งค่า manifest, service worker และ asset แกนหลักสำหรับการใช้งานแบบ PWA"
-- ตรวจทั้งไฟล์ `README.md` รอบเดียวเพื่อกำจัดอาการข้อความตัด/encoding เพี้ยนเพิ่มเติม
+- แก้ประโยคเป็น:
+  - `For an environment that is closer to production, use the provided shell script.`
+- ตรวจทานทั้งหัวข้อภาษาอังกฤษ/ไทยในไฟล์เดียวกันอีกหนึ่งรอบ เพื่อแก้คำตกหล่นลักษณะเดียวกัน
 
 ---
 
 ## 2) งานแก้ไขบั๊ก (Bug Fix)
 
 **ปัญหาที่พบ**
-- WebSocket endpoint (`/ws/cognitive-stream`) ไม่มีการตรวจสอบ `X-API-Key` ขณะที่ REST endpoints ใช้ `_ensure_api_key(...)` บังคับคีย์
-- ส่งผลให้ช่องทางสตรีมสามารถเชื่อมต่อได้โดยไม่ผ่านการยืนยันตัวตน ซึ่งเป็นช่องโหว่ด้านการควบคุมสิทธิ์
+- ตัวแอปใน `api_gateway/main.py` ใช้ตัวแปร `GEMINI_API_KEY` สำหรับ provider Google
+- แต่สคริปต์สตาร์ต `api_gateway/start_cognitive_api.sh` ตรวจ `GOOGLE_API_KEY` แทน
+- ส่งผลให้สคริปต์ผ่านการตรวจ env ได้ แต่ runtime ยัง error ว่า `GEMINI_API_KEY is not set` เมื่อเรียกโมเดล Google
 
 **หลักฐานอ้างอิง**
-- มีการบังคับ API key ใน `emit` และ `validate`
-- ไม่มีการเช็ก API key ใน `cognitive_stream`
+- `api_gateway/main.py` ฟังก์ชัน `invoke_generative_model(...)`
+- `api_gateway/start_cognitive_api.sh` เงื่อนไขตรวจ API key
 
 **งานที่เสนอ**
-- เพิ่มการตรวจ API key ใน WebSocket handshake (เช่น อ่านจาก header/query แล้ว reject connection เมื่อไม่มีคีย์)
-- กำหนดรูปแบบ error response ของ websocket ให้สอดคล้องกับ REST (`401` semantics)
+- ปรับให้ชื่อ env สอดคล้องกันทั้งระบบ (แนะนำใช้ `GEMINI_API_KEY` ตรงตามโค้ด runtime)
+- หรือรองรับ alias ชั่วคราว (`GOOGLE_API_KEY` -> fallback) พร้อม deprecation note
+- เพิ่ม unit test สำหรับกรณี Google provider ไม่มี key เพื่อกัน regression
 
 ---
 
 ## 3) งานแก้ความคลาดเคลื่อนของเอกสาร (Documentation Discrepancy)
 
 **ปัญหาที่พบ**
-- ใน `api_gateway/README.md` มีตัวอย่างรันด้วย `uvicorn ...` โดยตรง แต่ในสคริปต์ `start_cognitive_api.sh` ใช้ `uv run uvicorn ...` และมีเงื่อนไขว่าต้องมี API key อย่างน้อยหนึ่งตัว
-- ผู้ใช้ใหม่ที่ทำตาม README อาจรันได้ แต่ไม่รู้เงื่อนไขความพร้อมของ environment แบบเดียวกับ production/start script
+- `api_gateway/README.md` ระบุว่า endpoint `POST /api/v1/cognitive/emit` ต้องมี header `X-Model-Provider` และ `X-Model-Version`
+- แต่ใน implementation (`api_gateway/main.py`) ไม่มีการอ่านหรือบังคับ header ทั้งสองตัว
+- ทำให้สัญญาเอกสารกับพฤติกรรมจริงไม่ตรงกัน
 
 **หลักฐานอ้างอิง**
-- `api_gateway/README.md` ส่วน "ตัวอย่างรัน"
-- `api_gateway/start_cognitive_api.sh` ส่วนตรวจ API key + คำสั่ง `uv run uvicorn`
+- `api_gateway/README.md` หัวข้อ `Required Headers`
+- `api_gateway/main.py` endpoint `emit_cognitive_dsl(...)`
 
 **งานที่เสนอ**
-- ปรับ README ให้บอกทั้ง 2 โหมดอย่างชัดเจน:
-  1) โหมดพัฒนาแบบเร็ว (`uvicorn`)
-  2) โหมดใกล้ production (`./api_gateway/start_cognitive_api.sh`)
-- เพิ่มโน้ตเรื่อง environment variables ที่จำเป็นก่อนสตาร์ต
+- เลือกแนวทางให้ชัดเจน 1 ทาง:
+  1) ถ้าต้องการบังคับจริง: เพิ่มการ validate header ใน endpoint
+  2) ถ้าไม่ต้องการ: ลบออกจาก README
+- อัปเดตตัวอย่าง `curl` ให้สะท้อน header ที่จำเป็นจริง
 
 ---
 
 ## 4) งานปรับปรุงการทดสอบ (Test Improvement)
 
 **ปัญหาที่พบ**
-- ปัจจุบันยังไม่มี automated test สำหรับ security behavior ของ WebSocket endpoint (`/ws/cognitive-stream`)
-- ทดสอบส่วน `AetherBusExtreme` มีอยู่แล้ว แต่ฝั่ง API ยังขาดเคส auth ที่สำคัญ
+- การรัน `pytest -q` จาก root ล้มเหลวตั้งแต่ช่วงเก็บเทสต์ เนื่องจาก import path ของ `api_gateway` ไม่ถูกตั้งค่าเป็น package
+- ทำให้เทสต์ไม่ได้รัน logic จริง (หยุดที่ collection error)
 
 **หลักฐานอ้างอิง**
-- มีชุดทดสอบใน `api_gateway/test_aetherbus_extreme.py`
-- ยังไม่พบไฟล์ทดสอบสำหรับ FastAPI endpoints/websocket auth
+- ผลลัพธ์จากคำสั่ง `pytest -q`
+  - `ModuleNotFoundError: No module named 'api_gateway'`
+  - `ImportError: attempted relative import with no known parent package`
 
 **งานที่เสนอ**
-- เพิ่ม `pytest` + `fastapi.testclient` test อย่างน้อย 2 เคส:
-  - websocket connection แบบไม่มี API key ต้องถูกปฏิเสธ
-  - websocket connection แบบมี API key ต้องเชื่อมต่อได้และได้ response ตามสัญญา
-- เพิ่ม test สำหรับ `POST /api/v1/cognitive/emit` เคส header ไม่ครบ เพื่อป้องกัน regression
-
+- ทำให้โครงสร้างเทสต์รันได้จาก root โดยตรง เช่น:
+  - เพิ่ม `api_gateway/__init__.py`
+  - หรือเพิ่ม `pytest.ini`/`pyproject.toml` ให้กำหนด `pythonpath`
+- หลังแก้ collection แล้ว เพิ่ม smoke test CI step (`pytest -q`) เพื่อป้องกัน regression ด้าน test discovery


### PR DESCRIPTION
### Motivation
- Refresh the existing Thai audit notes to reflect the current repository findings: a grammar/typo in `api_gateway/README.md`, an environment-variable mismatch between runtime and start script, a documentation vs implementation discrepancy for required headers on `/api/v1/cognitive/emit`, and test-discovery failures when running tests from the repo root.

### Description
- Update `docs/CODEBASE_AUDIT_TASKS_TH.md` to replace stale findings with the current issues and provide one actionable proposal per category (typo, bug, documentation discrepancy, and test improvement).
- The document now calls out concrete recommendations such as using `GEMINI_API_KEY` (or providing a `GOOGLE_API_KEY` fallback), aligning README headers with implementation, and fixing test discovery (e.g. add `api_gateway/__init__.py` or configure `pytest.ini`).

### Testing
- Ran `pytest -q` from the repository root to capture current baseline behavior and reproduction steps for the test-improvement proposal, and the run failed during collection with `ModuleNotFoundError: No module named 'api_gateway'` and `ImportError: attempted relative import with no known parent package`.
- No other automated tests were modified or executed as part of this documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a2015e1483208f84294543220179)