### PR TITLE
Harden proxy resolution and make state-sync websocket broadcast resilient; improve websocket tests

### DIFF
--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -176,6 +176,18 @@ class StateSyncRoom:
             "user_state": self.user_states.get(user_id or "", {}),
         }
 
+    async def broadcast_json(self, message: dict[str, Any]) -> None:
+        if not self.clients:
+            return
+        disconnected_clients: list[WebSocket] = []
+        for client in self.clients:
+            try:
+                await client.send_json(message)
+            except RuntimeError:
+                disconnected_clients.append(client)
+        if disconnected_clients:
+            self.clients = [client for client in self.clients if client not in disconnected_clients]
+
 # --- DSL Validation ---
 
 class FirmaValidator:
@@ -271,7 +283,7 @@ def _is_blocked_proxy_target(hostname: str) -> bool:
                 or address.is_multicast
             ):
                 return True
-    except socket.gaierror:
+    except (socket.gaierror, OSError, ValueError):
         return True
     return False
 
@@ -455,7 +467,7 @@ async def state_sync(websocket: WebSocket, room_id: str, user_id: str | None = Q
             async with room.lock:
                 snapshot = room.apply_delta(payload.get("delta", {}), user_id, payload.get("user_delta", {}))
                 message = {"type": "state_updated", **snapshot}
-                await asyncio.gather(*[client.send_json(message) for client in room.clients])
+                await room.broadcast_json(message)
     except WebSocketDisconnect:
         async with room.lock:
             if websocket in room.clients:

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -55,9 +55,10 @@ def test_websocket_stream_with_query_key(client: TestClient) -> None:
 
 
 def test_websocket_stream_with_header_key(client: TestClient) -> None:
-    # Note: TestClient doesn't directly support setting headers for websockets.
-    # This is a known limitation. We test the query param route as the primary path.
-    pass
+    with client.websocket_connect("/ws/cognitive-stream", headers={"x-api-key": "test-key"}) as websocket:
+        websocket.send_json({"type": "dsl_submission", "payload": "..."})
+        response = websocket.receive_json()
+        assert response["status"] == "accepted"
 
 
 def test_proxy_fetch_supports_cors_preflight(client: TestClient) -> None:

--- a/api_gateway/test_runtime_quality.py
+++ b/api_gateway/test_runtime_quality.py
@@ -212,5 +212,36 @@ class GatewayExtensionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(snapshot["user_state"]["theme"], "dark")
 
 
+    def test_proxy_guard_rejects_invalid_hostname(self) -> None:
+        from api_gateway.main import _is_blocked_proxy_target
+
+        self.assertTrue(_is_blocked_proxy_target("bad host name"))
+
+    async def test_state_sync_room_broadcast_prunes_disconnected_clients(self) -> None:
+        from api_gateway.main import StateSyncRoom
+
+        class FailingSocket:
+            async def send_json(self, _message: dict[str, object]) -> None:
+                raise RuntimeError("cannot send")
+
+        class GoodSocket:
+            def __init__(self) -> None:
+                self.messages: list[dict[str, object]] = []
+
+            async def send_json(self, message: dict[str, object]) -> None:
+                self.messages.append(message)
+
+        room = StateSyncRoom()
+        failing = FailingSocket()
+        good = GoodSocket()
+        room.clients = [failing, good]  # type: ignore[list-item]
+
+        message = {"type": "state_updated", "version": 1}
+        await room.broadcast_json(message)
+
+        self.assertEqual(room.clients, [good])
+        self.assertEqual(good.messages, [message])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent malformed or unresolved hostnames from bypassing the proxy guard by treating additional resolver and parsing errors as blocked.
- Avoid a single failing websocket client from causing a full broadcast failure during state synchronization.
- Replace a placeholder websocket header test with a real integration path and add regression tests to capture these edge cases.

### Description
- Tightened `_is_blocked_proxy_target` to catch `socket.gaierror`, `OSError`, and `ValueError` and fail closed when hostname resolution or IP parsing fails by returning `True` in those cases.
- Added `StateSyncRoom.broadcast_json` to send messages to connected `WebSocket` clients and prune clients that raise send errors instead of letting a single failure break the fan-out.
- Updated the `/ws/state-sync/{room_id}` handler to call `room.broadcast_json(message)` rather than directly gathering `send_json` calls on all clients.
- Replaced the placeholder `pass` in the websocket header auth test with an actual connection test using the `x-api-key` header and added two regression tests in `api_gateway/test_runtime_quality.py` for invalid proxy hostnames and pruned disconnected clients in `StateSyncRoom`.

### Testing
- Ran the full test suite with `pytest -q`, resulting in `30 passed`.
- Exercised websocket behavior via `api_gateway/test_api.py` to verify header and query-key websocket auth paths both return an accepted status.
- Executed new async unit tests in `api_gateway/test_runtime_quality.py` to validate proxy guard behavior and that `broadcast_json` prunes failing clients, both of which passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8719e4e4832080d12918c26db188)