### PR TITLE
Harden gateway auth/proxy behavior and consolidate duplicated roadmap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 - [Contributing](#contributing)
 - [License](#license)
 - [เอกสารภาษาไทย (Thai Documentation)](#เอกสารภาษาไทย-thai-documentation)
-- [Extension Ideas (Legacy)](#extension-ideas-legacy)
 
 ---
 
@@ -585,21 +584,6 @@ Gateway: `http://localhost:8000` (เอกสาร API ที่ `/docs`)
 - `docs/`: เอกสารสถาปัตยกรรม อินเทอร์เฟซ ความปลอดภัย และ roadmap
 
 ### แนวทางต่อยอด
-- เพิ่ม Plugin Renderer API
-- เพิ่ม Session Replay (timeline + bookmarks)
-- เพิ่ม policy-driven link analysis พร้อม risk score/audit export
-- เพิ่ม Hybrid Data Layer (Redis + TimescaleDB/ClickHouse)
-- เพิ่ม collaboration controls (role/permission/moderation)
-- เพิ่ม Voice Quality Dashboard (WER/latency แยกภาษา-ภูมิภาค)
-- เพิ่ม Offline-first Runtime Packs
+รายละเอียดแผนระยะถัดไปถูกรวมไว้เพียงจุดเดียวในส่วน **Research & Engineering Roadmap** ด้านภาษาอังกฤษ เพื่อลดข้อมูลซ้ำซ้อนและให้มีแหล่งอ้างอิงเดียวของระบบ.
 
 ---
-
-## Extension Ideas (Legacy)
-- Move mutable runtime state to Redis (metrics counters, telemetry cache, ws room membership) for multi-worker consistency.
-- Add signed outbound proxy policy (HMAC request intent + per-tenant allowlist) to harden enterprise SSRF controls.
-- Build contract-fuzz pipeline: property-based payload generators + mutation corpus for schema regression stress tests.
-- Add persisted TSDB backend (InfluxDB/TimescaleDB) with retention + downsampling policies.
-- Add proxy allowlist/denylist + content-type and size guardrails for stronger SSRF safety.
-- Add voice A/B routing and collect WER / latency metrics by language-region cohort.
-- Add CRDT merge (Yjs/Automerge) for conflict-free collaborative editing beyond simple delta updates.

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -385,13 +385,21 @@ async def proxy_fetch_url(url: str, x_api_key: str | None = Header(None, alias="
     parsed = urlparse(url)
     if parsed.scheme not in {"http", "https"} or not parsed.hostname:
         raise HTTPException(status_code=400, detail="Invalid URL structure")
+    if parsed.username or parsed.password:
+        raise HTTPException(status_code=400, detail="URL credentials are not allowed")
     if PROXY_ALLOWED_HOSTS and parsed.hostname.lower() not in PROXY_ALLOWED_HOSTS:
         raise HTTPException(status_code=403, detail="URL host is not allowlisted")
     if _is_blocked_proxy_target(parsed.hostname):
         raise HTTPException(status_code=403, detail="URL host resolves to a blocked IP range")
     try:
-        async with httpx.AsyncClient(timeout=6.0, headers={"User-Agent": "AetheriumProxy/1.0"}) as client:
+        async with httpx.AsyncClient(
+            timeout=6.0,
+            follow_redirects=False,
+            headers={"User-Agent": "AetheriumProxy/1.0"},
+        ) as client:
             response = await client.get(url)
+            if response.is_redirect:
+                raise HTTPException(status_code=403, detail="Redirect responses are not allowed")
             response.raise_for_status()
             text = response.text[:120_000]
         return {"content_length": len(text), "snippet": " ".join(text.split())[:1200]}
@@ -454,6 +462,10 @@ async def cognitive_stream(websocket: WebSocket) -> None:
 
 @app.websocket("/ws/state-sync/{room_id}")
 async def state_sync(websocket: WebSocket, room_id: str, user_id: str | None = Query(None)) -> None:
+    api_key = _extract_ws_api_key(websocket)
+    if not api_key:
+        await websocket.close(code=1008, reason="Missing API Key")
+        return
     room = await _room(room_id)
     await websocket.accept()
     async with room.lock:

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -81,3 +81,19 @@ def test_generate_rejects_unsupported_model_with_400(client: TestClient) -> None
     )
     assert response.status_code == 400
     assert "Unsupported model" in response.text
+
+
+def test_state_sync_websocket_requires_api_key(client: TestClient) -> None:
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/ws/state-sync/demo-room"):
+            pass
+
+
+def test_proxy_fetch_rejects_urls_with_credentials(client: TestClient) -> None:
+    response = client.get(
+        "/api/v1/proxy/fetch",
+        params={"url": "https://user:pass@example.com/path"},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert response.status_code == 400
+    assert "credentials" in response.text.lower()

--- a/docs/11_PLATFORM_WORK_PLAN.md
+++ b/docs/11_PLATFORM_WORK_PLAN.md
@@ -1,108 +1,156 @@
-# Platform Work Plan: README Suggestion Execution
+# Platform Work Plan: System-wide Consistency, Bug Fixing, and Documentation Consolidation
 
 ## Context
-- **Initiative:** Manifest Runtime Hardening + UX Presets
-- **Scope:** Frontend settings module, i18n quality gates, CI quality checks
-- **Drivers:** reliability, security hygiene, devex, predictable operations
-- **Current state:** runtime has configurable settings and multilingual bundles, but lacked preset profiles and locale QA automation
-- **Target state:** preset-driven runtime profiles and CI-enforced locale consistency including pseudolocale validation
-- **Constraints:** preserve existing APIs/UI behavior, low implementation risk, no infra migration in this step
-- **Dependencies:** frontend maintainers, API gateway test pipeline, GitHub Actions
+- **Initiative:** Aetherium Manifest Platform Integrity Program
+- **Scope:** `api_gateway`, frontend runtime/docs, contracts/testing, operational documentation
+- **Drivers:** reliability, security, maintainability, documentation correctness, developer experience
+- **Current state:** major test suites pass, but there are still consistency/security gaps (e.g., unauthenticated state-sync WebSocket and permissive proxy behavior) and duplicated roadmap content across bilingual README sections
+- **Target state:** high-priority security and consistency defects are fixed, docs are deduplicated with a single canonical roadmap source, and work is organized into measurable platform execution tracks
+- **Constraints:** keep backward compatibility for current API consumers, low-risk incremental changes, maintain green CI (`pytest`)
+- **Dependencies:** API gateway maintainers, frontend/documentation owners, CI pipeline maintainers
+
+---
 
 ## 1) Workstreams
 
 ### A. Architecture
-- Define preset domain model for display/quality/voice/mini-box toggles
-- Add deterministic preset application flow in runtime state update path
+- Define one canonical planning source for roadmap and platform direction.
+- Keep bilingual documentation as presentation layers, not duplicate planning systems.
+- Preserve existing runtime/API boundaries while applying targeted hardening.
 
 ### B. Protocol
-- Emit command-bus event `display:preset` on preset activation
-- Sync state patch with preset metadata for collaborative state channels
+- Enforce authentication consistency across REST and WebSocket paths.
+- Define proxy URL safety guardrails as explicit protocol behavior (no credentials, no redirect traversal).
 
 ### C. Reliability
-- Add locale QA scanner for missing and extra key drift
-- Enforce pseudolocale (`en-XA`) existence and divergence from base locale
+- Add regression coverage for newly fixed gateway hardening cases.
+- Keep existing quality and contract tests green.
 
 ### D. Benchmark
-- Add CI gate for locale QA alongside contract checker
-- Keep existing runtime benchmark gates unchanged
+- Continue existing latency/stress benchmark gates from current toolchain.
+- Validate no regressions introduced by security hardening in normal flows.
 
 ### E. Ops
-- Add pseudolocale bundle to service-worker cache list
-- Document operational checklist for translation additions
+- Clarify operational docs so contributors know where roadmap truth lives.
+- Keep API behavior clear for incident and troubleshooting playbooks.
 
 ### F. Migration
-- Migrate README roadmap by removing now-implemented proposals
-- Keep backlog focused on remaining future directions
+- Migrate duplicated README roadmap content to a single canonical section.
+- Update Thai section to reference canonical roadmap source instead of re-listing duplicated items.
 
-## 2) Backlog (Epic → Story → Task with measurable acceptance)
+---
 
-## Epic 1: Scenario Presets Runtime
-### Story 1.1: Add preset selector
-- Task: Add `Scenario Preset` dropdown in Display settings tab
-- **Acceptance:** UI renders 5 options (`custom`, `presentation`, `meditation`, `debug`, `low-power`)
+## 2) Backlog (Epic → Story → Task + measurable acceptance)
 
-### Story 1.2: Implement preset behavior
-- Task: Add preset map and apply handler
-- **Acceptance:** selecting preset updates display page, quality tier/FPS, voice mode, and mini-box visibility in one user action
+### Epic 1: Security and Protocol Integrity
 
-### Story 1.3: Integrate telemetry/sync
-- Task: emit command event and state sync patch on preset apply
-- **Acceptance:** applying a preset emits `display:preset` and sends sync patch payload with `scenarioPreset`
+#### Story 1.1: Protect collaborative state WebSocket
+- **Task 1.1.1:** Require API key validation in `/ws/state-sync/{room_id}` using header/query extraction.
+- **Acceptance:** unauthenticated connection attempts are closed with policy violation (1008) and do not join room state.
 
-## Epic 2: Locale QA CI Gate
-### Story 2.1: Missing key scanner
-- Task: build `tools/contracts/locale_qa.py`
-- **Acceptance:** script exits non-zero for missing/extra translation keys vs base locale
+#### Story 1.2: Harden proxy endpoint against credential/redirect abuse
+- **Task 1.2.1:** Reject proxy URLs containing embedded credentials.
+- **Task 1.2.2:** Disable redirect following and reject redirect responses.
+- **Acceptance:**
+  - URL with username/password returns HTTP 400.
+  - Redirect response path is rejected with HTTP 403.
+  - Existing valid direct fetch behavior remains unchanged.
 
-### Story 2.2: Pseudolocale coverage
-- Task: add `locales/en-XA.json` and validate transformed text
-- **Acceptance:** QA script exits non-zero if pseudolocale missing or has unchanged base strings
+### Epic 2: Test and Quality Guardrail Expansion
 
-### Story 2.3: CI integration
-- Task: add locale QA step in workflow
-- **Acceptance:** PR workflow executes locale QA before runtime-quality job completion
+#### Story 2.1: Add regression tests for hardening changes
+- **Task 2.1.1:** Add API test for state-sync WebSocket requiring API key.
+- **Task 2.1.2:** Add API test for proxy credential rejection.
+- **Acceptance:** all tests pass and explicitly cover both failure modes.
 
-## 3) Options and Tradeoffs
+### Epic 3: Documentation Unification and Deduplication
 
-1. **Option A (chosen): static in-app preset map + CI script gate**
-   - Pros: simple, deterministic, low runtime overhead, easy maintainability
-   - Cons: presets require code deploy to change
+#### Story 3.1: Remove duplicated roadmap content
+- **Task 3.1.1:** Remove redundant legacy extension section from README.
+- **Task 3.1.2:** Replace duplicated Thai roadmap bullets with canonical reference pointer.
+- **Acceptance:** roadmap/extension planning appears once; Thai section no longer duplicates strategic items.
 
-2. **Option B: server-provided preset policy via API**
-   - Pros: dynamic tuning without frontend redeploy
-   - Cons: adds API dependency, failure modes on fetch, higher complexity
+---
 
-3. **Option C: user-authored JSON preset packs**
-   - Pros: high flexibility for power users
-   - Cons: validation and security surface increase, weaker guardrails
+## 3) Options, Tradeoffs, and Recommendation
 
-**Chosen rationale:** Option A fits current scope and constraints while removing two README gaps with minimal operational risk.
+### Option A (Chosen): Targeted hardening + regression tests + README deduplication
+- **Pros:** minimal disruption, immediate risk reduction, fast delivery, clear auditability.
+- **Cons:** incremental approach; does not redesign entire auth/transport stack.
 
-## 4) Risks, Failure Modes, Mitigation
-- **Risk:** Preset overrides user expectation unexpectedly.
-  - Mitigation: keep `custom` mode and apply only on explicit selection.
-- **Risk:** Locale QA blocks PRs due to translation drift.
-  - Mitigation: clear error messages listing exact missing/extra keys.
-- **Risk:** Pseudolocale not cached offline.
-  - Mitigation: include in service worker core assets.
+### Option B: Full auth middleware refactor for all WS/HTTP paths
+- **Pros:** strong long-term standardization and reduced drift risk.
+- **Cons:** larger migration risk, broader testing matrix, longer delivery timeline.
 
-## 5) Rollout/Rollback (Owner + Timeline)
-- **Owner:** Frontend platform maintainer
-- **Rollout timeline:**
-  - Day 0: merge code + docs + CI gate
-  - Day 1: verify workflow pass and manual UI smoke test
-- **Rollback plan:**
-  - Revert preset dropdown + handler section in `index.html`
-  - Remove locale QA workflow step and pseudolocale file
-  - Re-run workflow to confirm baseline restored
+### Option C: Introduce centralized outbound request policy service
+- **Pros:** reusable policy across services with richer enforcement.
+- **Cons:** adds infra dependency and deployment complexity not justified for current scope.
+
+**Recommendation:** choose **Option A** now for immediate high-priority risk reduction while preserving delivery velocity and compatibility.
+
+---
+
+## 4) Risks, Failure Modes, and Mitigation Plan
+
+- **Risk:** Existing clients using unauthenticated state-sync break unexpectedly.
+  - **Failure mode:** WebSocket connection closes at handshake.
+  - **Mitigation:** document API key requirement clearly and provide migration note in gateway docs.
+
+- **Risk:** Proxy consumers relying on redirect traversal fail.
+  - **Failure mode:** previously indirect URLs no longer resolve.
+  - **Mitigation:** require callers to supply final allowed URL directly; log rejected redirects for diagnostics.
+
+- **Risk:** Documentation drift reappears after future edits.
+  - **Failure mode:** duplicated roadmap bullets return in bilingual sections.
+  - **Mitigation:** enforce “single canonical roadmap section” contribution rule in documentation review checklist.
+
+---
+
+## 5) Rollout / Rollback Plan (Owner + Timeline)
+
+### Owners
+- **Gateway hardening:** API Gateway owner
+- **Tests and CI checks:** Quality owner
+- **README consolidation:** Documentation owner
+
+### Timeline
+- **Day 0:** implement hardening changes and tests.
+- **Day 0:** run full local test suite and verify no regressions.
+- **Day 1:** merge and monitor usage issues from gateway clients.
+
+### Rollback
+- Revert WebSocket auth enforcement commit if compatibility incident occurs.
+- Revert proxy redirect/credential constraints only if critical business flow depends on them (temporary emergency rollback).
+- Keep tests aligned with whichever behavior is active after rollback.
+
+---
 
 ## 6) Production Definition of Done
-- **Tests:**
-  - locale QA script passes on all committed locale files
-  - existing contract checker passes
-- **SLO gates:** no regression to existing runtime-quality checks
-- **Benchmark gates:** existing latency/stress benchmarks remain green
-- **Observability:** preset application emits command event for telemetry stream
-- **Runbooks:** translation addition checklist: add key in `en` + all locales + `en-XA`
-- **Security checks:** no new remote code paths; preset logic is local deterministic mapping
+
+- **Tests**
+  - Unit/API regression tests pass (`pytest -q`).
+  - New tests cover state-sync auth and proxy credential rejection paths.
+
+- **SLO gates**
+  - No increase in gateway error rates for authenticated standard paths.
+
+- **Benchmarking gates**
+  - Existing benchmark scripts remain runnable and unchanged in intent.
+
+- **Observability**
+  - Rejected proxy and unauthorized WS attempts remain diagnosable via HTTP/WS error details.
+
+- **Runbooks**
+  - Docs specify canonical roadmap source and API key requirement for state-sync WS.
+
+- **Security checks**
+  - SSRF posture improved by disallowing URL credentials and redirect traversal.
+  - State synchronization channel now enforces authentication parity with other protected endpoints.
+
+---
+
+## Redundant Information Removed for Single Source of Truth
+
+- Removed duplicated roadmap list under Thai README section.
+- Removed `Extension Ideas (Legacy)` section that repeated roadmap concepts.
+- Kept one canonical strategic list in `Research & Engineering Roadmap`.


### PR DESCRIPTION
### Motivation
- Reduce SSRF and credential-leak risk in the outbound proxy and align WebSocket auth with other protected gateway channels.
- Remove duplicated roadmap content across English/Thai README to create a single canonical source of truth for platform planning.
- Add targeted regression coverage to prevent reintroduction of these protocol/security regressions.

### Description
- Reject URLs with embedded credentials in the proxy endpoint and disable redirect traversal by setting `follow_redirects=False` and rejecting redirect responses in `api_gateway/main.py`.
- Enforce API key requirement for the collaborative state-sync WebSocket (`/ws/state-sync/{room_id}`) using the existing header/query extraction helper in `api_gateway/main.py`.
- Add failing-mode regression tests covering unauthenticated state-sync and credential-bearing proxy URLs in `api_gateway/test_api.py`.
- Deduplicate documentation by removing the legacy extension section and collapsing duplicate Thai roadmap bullets in `README.md`, and replace `docs/11_PLATFORM_WORK_PLAN.md` with a consolidated platform work plan.

### Testing
- Ran the full test suite with `pytest -q`; all tests passed: `32 passed`.
- New regression tests for proxy credential rejection and state-sync auth were executed as part of the suite and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b05ec5fd4c8320ba1f9f43a0e5fe60)