### PR TITLE
Introduce Light Cognition Layer Program: update backlog SQL and work plan doc

### DIFF
--- a/data/platform_work_backlog.sql
+++ b/data/platform_work_backlog.sql
@@ -1,4 +1,4 @@
--- Aetherium Cognitive Lightfield Platform backlog schema + seed data.
+-- Light Cognition Layer Program backlog schema + canonical seed data.
 -- Canonical source aligns with docs/11_PLATFORM_WORK_PLAN.md.
 
 PRAGMA foreign_keys = ON;
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS initiatives (
   drivers TEXT NOT NULL,
   current_state TEXT NOT NULL,
   target_state TEXT NOT NULL,
-  constraints TEXT NOT NULL,
+  constraints_text TEXT NOT NULL,
   dependencies TEXT NOT NULL
 );
 
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS decision_options (
   summary TEXT NOT NULL,
   pros TEXT NOT NULL,
   cons TEXT NOT NULL,
-  chosen INTEGER NOT NULL CHECK (chosen IN (0,1))
+  chosen INTEGER NOT NULL CHECK (chosen IN (0, 1))
 );
 
 CREATE TABLE IF NOT EXISTS risks (
@@ -90,27 +90,35 @@ CREATE TABLE IF NOT EXISTS dod_gates (
 );
 
 INSERT INTO initiatives (
-  id, code, name, scope, drivers, current_state, target_state, constraints, dependencies
+  id,
+  code,
+  name,
+  scope,
+  drivers,
+  current_state,
+  target_state,
+  constraints_text,
+  dependencies
 ) VALUES (
   1,
-  'AG-2026-CLP',
-  'Aetherium Cognitive Lightfield Platform',
-  'Orchestration services, protocol contracts, reliability, benchmark, operations, migration',
+  'LC-2026-MORPHO',
+  'Light Cognition Layer Program',
+  'services/modules/protocol/reliability/benchmark/ops/migration',
   'reliability,latency,semantic-fidelity,security,devex',
-  'Reactive Generative UI maps user intent to visual response in color, shape, density, and flow',
-  'Lightfield-native cognition substrate with reflection, reasoning-surface, and native intelligence modes',
-  'P95<16.7ms Tier-1, P95<33ms Tier-2, no raw biometric persistence, 2-quarter rollout',
-  'Genesis,Manifest,AetherBus,SRE,Security,ML Platform'
+  'Intent outputs can map directly to visual_parameters with limited temporal generation semantics',
+  'Intent flows through SemanticField, MorphogenesisEngine, LightCompiler, and CognitiveFieldRuntime before rendering',
+  'P95<16.7ms Tier-1; P95<33ms Tier-2; memory +25% max; 14-week rollout; no raw biometric persistence',
+  'Genesis cognition team, Manifest runtime team, AetherBus maintainers, SRE, Security/Privacy, ML platform'
 )
 ON CONFLICT (id) DO UPDATE SET
-  code=excluded.code,
-  name=excluded.name,
-  scope=excluded.scope,
-  drivers=excluded.drivers,
-  current_state=excluded.current_state,
-  target_state=excluded.target_state,
-  constraints=excluded.constraints,
-  dependencies=excluded.dependencies;
+  code = excluded.code,
+  name = excluded.name,
+  scope = excluded.scope,
+  drivers = excluded.drivers,
+  current_state = excluded.current_state,
+  target_state = excluded.target_state,
+  constraints_text = excluded.constraints_text,
+  dependencies = excluded.dependencies;
 
 INSERT INTO workstreams (id, initiative_id, name, owner, status) VALUES
   (1, 1, 'Architecture', 'platform-architect', 'in_progress'),
@@ -120,101 +128,102 @@ INSERT INTO workstreams (id, initiative_id, name, owner, status) VALUES
   (5, 1, 'Ops', 'sre-security-joint', 'planned'),
   (6, 1, 'Migration', 'release-manager', 'planned')
 ON CONFLICT (id) DO UPDATE SET
-  owner=excluded.owner,
-  status=excluded.status;
+  owner = excluded.owner,
+  status = excluded.status;
 
 INSERT INTO epics (id, workstream_id, code, title, objective, status) VALUES
-  (101, 1, 'A1', 'Cognitive Lightfield Architecture', 'Deliver reflection, reasoning-surface, and native-state architecture', 'in_progress'),
-  (201, 2, 'P1', 'Protocol v3 Cognition-Native', 'Unify cognition envelope with compatibility adapters', 'in_progress'),
-  (301, 3, 'R1', 'Reliability and Safety', 'Guarantee semantic integrity and failure containment', 'planned'),
-  (401, 4, 'B1', 'Benchmark and Quality Gates', 'Enforce performance and semantic quality budgets', 'planned'),
-  (501, 5, 'O1', 'Operations and Governance', 'Operationalize observability, runbooks, and compliance controls', 'planned'),
-  (601, 6, 'M1', 'Migration and Release', 'Ship phased rollout and rollback-safe migration', 'planned')
+  (120, 1, 'A2', 'Light Cognition Layer Architecture', 'Implement cognition-native middle layer between intent and render outputs', 'in_progress'),
+  (220, 2, 'P2', 'Protocol Evolution for Field Cognition', 'Define versioned envelope for semantic fields, morphogenesis plans, and compiled light programs', 'in_progress'),
+  (320, 3, 'R2', 'Reliability and Failure Containment', 'Detect and contain semantic-to-form drift in runtime evolution', 'planned'),
+  (420, 4, 'B2', 'Benchmark and Quality Gates', 'Enforce latency, resource, and semantic-legibility gates', 'planned'),
+  (520, 5, 'O2', 'Operations and Security Readiness', 'Operationalize telemetry, runbooks, and privacy/security controls', 'planned'),
+  (620, 6, 'M2', 'Migration and Release Management', 'Ship phased rollout with deterministic rollback', 'planned')
 ON CONFLICT (id) DO UPDATE SET
-  title=excluded.title,
-  objective=excluded.objective,
-  status=excluded.status;
+  title = excluded.title,
+  objective = excluded.objective,
+  status = excluded.status;
 
 INSERT INTO stories (id, epic_id, code, title, acceptance_criteria, status) VALUES
-  (1001, 101, 'A1.1', 'Reflection layer hardening', '99.95% ingest-to-render success; mapping consistency >=0.95', 'in_progress'),
-  (1002, 101, 'A1.2', 'Reasoning-surface primitives', 'Schema pass 100%; classifier F1 >=0.90', 'planned'),
-  (1003, 101, 'A1.3', 'Native cognition state engine', 'Explainable transitions >=85%; language alignment >=0.92', 'planned'),
-  (2001, 201, 'P1.1', 'Unified cognition envelope', 'Backward compatibility success 100%', 'in_progress'),
-  (2002, 201, 'P1.2', 'Explainability and policy metadata', '95% sessions contain trace summary; 100% policy-hit metadata', 'planned'),
-  (3001, 301, 'R1.1', 'Semantic integrity guardrails', 'Drift detection >=98%; fallback P95 <75ms', 'planned'),
-  (3002, 301, 'R1.2', 'Failure-mode containment', 'Replay success 100% for Sev-1 incidents', 'planned'),
-  (4001, 401, 'B1.1', 'Stage-wise performance benchmark', 'Nightly benchmark completion 100%', 'planned'),
-  (4002, 401, 'B1.2', 'Semantic quality benchmark', 'RLS >=0.80; inter-rater alpha >=0.70', 'planned'),
-  (5001, 501, 'O1.1', 'Observability and runbooks', 'MTTD <=10m and MTTR <=30m', 'planned'),
-  (5002, 501, 'O1.2', 'Security and privacy enforcement', '0 critical privacy findings', 'planned'),
-  (6001, 601, 'M1.1', 'Progressive rollout ladder', 'Promotion gates pass at each canary stage', 'planned'),
-  (6002, 601, 'M1.2', 'Data and protocol migration', 'Zero data loss in rehearsal', 'planned')
+  (1201, 120, 'A2.1', 'Semantic field ingestion', 'SemanticField validation pass 100%; ingestion success >=99.95%', 'in_progress'),
+  (1202, 120, 'A2.2', 'Morphogenesis planning', 'Plan generation success >=99.9%; instability containment P95 <=75ms', 'planned'),
+  (1203, 120, 'A2.3', 'Light program compilation and runtime', 'Compiler contract pass 100%; runtime overhead <=3ms P95', 'planned'),
+  (2201, 220, 'P2.1', 'Unified cognition-native envelope', 'Backward compatibility pass 100%; required blocks enforced in CI', 'in_progress'),
+  (2202, 220, 'P2.2', 'Explainability and governance metadata', 'Trace summary in >=95% sessions; governance metadata coverage 100%', 'planned'),
+  (3201, 320, 'R2.1', 'Semantic drift detection', 'Drift recall >=98%; false positives <=3%', 'planned'),
+  (3202, 320, 'R2.2', 'Deterministic containment', 'Containment <=75ms P95; Sev-1 replay reproducibility 100%', 'planned'),
+  (4201, 420, 'B2.1', 'Performance benchmark suite', 'Nightly completion 100%; memory increase <=25%', 'planned'),
+  (4202, 420, 'B2.2', 'Semantic legibility benchmark', 'Composite score >=0.80; inter-rater agreement >=0.70', 'planned'),
+  (5201, 520, 'O2.1', 'Observability and runbooks', 'MTTD <=10m; MTTR <=30m; Sev-1 playbook validation 100%', 'planned'),
+  (5202, 520, 'O2.2', 'Security and privacy controls', '0 critical audit findings; required CI compliance pass 100%', 'planned'),
+  (6201, 620, 'M2.1', 'Progressive rollout', 'Promotion gated by SLO+benchmark+error budget; rollback <=15m', 'planned'),
+  (6202, 620, 'M2.2', 'Legacy cleanup', 'Zero migration data loss; compatibility pass rate unchanged after cleanup', 'planned')
 ON CONFLICT (id) DO UPDATE SET
-  title=excluded.title,
-  acceptance_criteria=excluded.acceptance_criteria,
-  status=excluded.status;
+  title = excluded.title,
+  acceptance_criteria = excluded.acceptance_criteria,
+  status = excluded.status;
 
 INSERT INTO tasks (id, story_id, code, title, measurable_outcome, owner, status) VALUES
-  (9001, 1001, 'A1.1.1', 'Standardize lightfield_input contract', 'Single ingestion contract used by 100% reflection transactions', 'platform-architecture', 'in_progress'),
-  (9002, 1001, 'A1.1.2', 'Add deterministic rendering profile packs', 'Profiles cover shape/color/density/flow with validated presets', 'runtime-team', 'planned'),
-  (9003, 1002, 'A1.2.1', 'Add uncertainty and interference primitives', 'New fields validated by contract tests without regressions', 'platform-architecture', 'planned'),
-  (9004, 1002, 'A1.2.2', 'Add collapse and convergence primitives', 'Reasoning-state classifier reaches F1 >=0.90', 'ml-reliability', 'planned'),
-  (9005, 1003, 'A1.3.1', 'Implement latent state graph engine', 'State transition logs generated for >=85% sampled sessions', 'genesis-cognition', 'planned'),
-  (9006, 2001, 'P1.1.1', 'Define protocol envelope for 3 cognition modes', 'v3 envelope accepted by schema lint and fixtures', 'aetherbus-contracts', 'in_progress'),
-  (9007, 2001, 'P1.1.2', 'Ship v2/v3 compatibility adapters', 'Adapters pass 100% consumer compatibility tests', 'aetherbus-contracts', 'planned'),
-  (9008, 3001, 'R1.1.1', 'Build semantic drift detector service', 'Detector catches >=98% seeded divergence scenarios', 'ml-reliability', 'planned'),
-  (9009, 3001, 'R1.1.2', 'Add deterministic fallback trigger path', 'Fallback activates in <75ms P95 after drift breach', 'runtime-team', 'planned'),
-  (9010, 4002, 'B1.2.1', 'Implement Reasoning Legibility Score harness', 'RLS generated for every benchmark run', 'benchmark-team', 'planned'),
-  (9011, 5001, 'O1.1.1', 'Deploy cognitive observability dashboards', 'Latency/drift/fallback/RLS metrics available in production dashboards', 'sre', 'planned'),
-  (9012, 6001, 'M1.1.1', 'Execute canary rollout 5-20-50-100', 'All stages satisfy SLO and error-budget gates', 'release-management', 'planned')
+  (9201, 1201, 'A2.1.1', 'Normalize LLM semantics into SemanticField contract', 'SemanticField emitted for 100% cognition-native requests', 'platform-architecture', 'in_progress'),
+  (9202, 1201, 'A2.1.2', 'Add SemanticField schema and validator checks', 'CI validator coverage includes all SemanticField required attributes', 'aetherbus-contracts', 'planned'),
+  (9203, 1202, 'A2.2.1', 'Build MorphogenesisEngine topology planner', 'Topology seed + attractor map generated for >=99.9% replay payloads', 'genesis-cognition', 'planned'),
+  (9204, 1202, 'A2.2.2', 'Implement policy-aware morph constraints', 'Unsafe trajectories blocked with policy metadata emitted 100%', 'ml-reliability', 'planned'),
+  (9205, 1203, 'A2.3.1', 'Compile light programs to shader/particle/force outputs', 'Compiled artifact includes shader_uniforms + particle_targets + force_fields in 100% valid requests', 'runtime-team', 'planned'),
+  (9206, 1203, 'A2.3.2', 'Run CognitiveFieldRuntime with deterministic fallback', 'Fallback engages <=75ms P95 when drift or SLO trigger breaches threshold', 'runtime-team', 'planned'),
+  (9207, 2201, 'P2.1.1', 'Add cognition-native envelope blocks', 'Schema includes semantic_field/morphogenesis_plan/light_program/runtime_state and passes fixtures', 'aetherbus-contracts', 'in_progress'),
+  (9208, 2201, 'P2.1.2', 'Ship visual_parameters compatibility adapter', 'Legacy consumers pass 100% compatibility tests through adapter', 'aetherbus-contracts', 'planned'),
+  (9209, 3201, 'R2.1.1', 'Implement semantic-to-form drift metrics', 'Drift metrics logged at each runtime window and queryable in telemetry backend', 'ml-reliability', 'planned'),
+  (9210, 3202, 'R2.2.1', 'Implement soft-clamp and deterministic anchor containment', 'Containment mode chosen and applied automatically across seeded failure scenarios', 'runtime-team', 'planned'),
+  (9211, 4201, 'B2.1.1', 'Publish compile/tick/resource benchmark scenarios', 'Nightly benchmark report includes compile latency and tick stability percentiles', 'benchmark-team', 'planned'),
+  (9212, 5201, 'O2.1.1', 'Deploy drift/compile/fallback/frame observability dashboards', 'Dashboards + alerts are live with on-call routing for all critical metrics', 'sre', 'planned'),
+  (9213, 6201, 'M2.1.1', 'Execute progressive canary rollout 5/20/50/100', 'All phases satisfy promotion gates with recorded gate artifacts', 'release-management', 'planned')
 ON CONFLICT (id) DO UPDATE SET
-  title=excluded.title,
-  measurable_outcome=excluded.measurable_outcome,
-  owner=excluded.owner,
-  status=excluded.status;
+  title = excluded.title,
+  measurable_outcome = excluded.measurable_outcome,
+  owner = excluded.owner,
+  status = excluded.status;
 
 INSERT INTO decision_options (id, initiative_id, option_code, summary, pros, cons, chosen) VALUES
-  (1, 1, 'A', 'Layered maturity rollout: Reflection -> Reasoning Surface -> Native Intelligence', 'lowest migration risk, clear rollback, incremental validation', 'temporary complexity from multi-mode coexistence', 1),
-  (2, 1, 'B', 'Big-bang native-intelligence rewrite', 'fastest theoretical arrival at target architecture', 'high delivery risk and weak rollback control', 0),
-  (3, 1, 'C', 'Reflection-only optimization', 'predictable operations and near-term latency gains', 'fails strategic objective for reasoning visibility', 0)
+  (1, 1, 'A', 'Incremental middle-layer insertion', 'lowest migration risk, clear rollback, progressive observability', 'temporary dual-path complexity', 1),
+  (2, 1, 'B', 'Big-bang full replacement', 'fast architecture purity', 'high reliability and schedule risk, hard rollback', 0),
+  (3, 1, 'C', 'Direct mapping with minor heuristics', 'low near-term cost', 'does not deliver true generative temporal cognition', 0)
 ON CONFLICT (id) DO UPDATE SET
-  option_code=excluded.option_code,
-  summary=excluded.summary,
-  pros=excluded.pros,
-  cons=excluded.cons,
-  chosen=excluded.chosen;
+  option_code = excluded.option_code,
+  summary = excluded.summary,
+  pros = excluded.pros,
+  cons = excluded.cons,
+  chosen = excluded.chosen;
 
 INSERT INTO risks (id, initiative_id, risk_title, failure_mode, mitigation_plan, severity) VALUES
-  (1, 1, 'Semantic misrepresentation risk', 'Visual reasoning appears convincing while semantically incorrect', 'Semantic drift detector plus deterministic anchor and explainability audits', 'critical'),
-  (2, 1, 'Latency regression in native mode', 'Native cognition mode breaches render/update SLO', 'Stage-gated budgets, adaptive quality scaling, and hard promotion gates', 'high'),
-  (3, 1, 'Protocol fragmentation', 'Clients diverge in support for cognition-native fields', 'Versioned envelope with adapters and required schema lint checks', 'high'),
-  (4, 1, 'Privacy leakage from cognitive traces', 'Sensitive traces retained beyond policy window', 'TTL enforcement, policy scans, and auditable access controls', 'critical')
+  (1, 1, 'Semantic persuasion mismatch', 'Rendered field appears convincing while diverging from source semantics', 'Drift metrics, deterministic anchors, explainability audits', 'critical'),
+  (2, 1, 'Latency and cost regression', 'Runtime evolution stage breaches latency/resource envelopes', 'Benchmark gates, adaptive quality scaling, strict rollout gates', 'high'),
+  (3, 1, 'Protocol fragmentation', 'Consumers parse inconsistent envelope subsets across versions', 'Versioned contracts with mandatory CI lint and adapters', 'high'),
+  (4, 1, 'Privacy over-retention', 'Cognitive traces stored beyond policy TTL or accessed without control', 'TTL enforcement, deny-by-default storage, auditable access logs', 'critical')
 ON CONFLICT (id) DO UPDATE SET
-  risk_title=excluded.risk_title,
-  failure_mode=excluded.failure_mode,
-  mitigation_plan=excluded.mitigation_plan,
-  severity=excluded.severity;
+  risk_title = excluded.risk_title,
+  failure_mode = excluded.failure_mode,
+  mitigation_plan = excluded.mitigation_plan,
+  severity = excluded.severity;
 
 INSERT INTO rollout_phases (id, initiative_id, phase_name, timeline_weeks, owner, entry_gate, rollback_trigger) VALUES
-  (1, 1, 'Stage 0: Protocol v3 foundation', '1-3', 'platform-architect', 'Schema validators and feature flags pass in CI', 'Protocol compatibility failures >1%'),
-  (2, 1, 'Stage 1: Reflection hardening + reasoning primitives', '4-8', 'runtime-lead', 'Shadow mode metrics and compatibility gates green', 'SLO or schema regression in canary'),
-  (3, 1, 'Stage 2: Native state engine + drift controls', '9-14', 'ml-reliability-lead', 'Drift detector and replay gates pass', 'Drift false-negative incidents or latency breach'),
-  (4, 1, 'Stage 3: Canary to GA + redundancy cleanup', '15-20', 'release-manager', 'Canary gates pass at each traffic tier', 'Error-budget burn or RLS degradation below threshold')
+  (1, 1, 'Phase 0: Contracts and flags', '1-2', 'platform-architect', 'Schema validators and feature flags pass in CI', 'Protocol contract failure or compatibility drop >1%'),
+  (2, 1, 'Phase 1: SemanticField and Morphogenesis shadow mode', '3-6', 'runtime-lead', 'Shadow mode telemetry stable and compatibility green', 'SLO breach or drift false-negative incidents'),
+  (3, 1, 'Phase 2: Compiler and runtime canary 5%->20%', '7-10', 'ml-reliability-lead', 'Benchmark and drift gates pass for canary cohorts', 'Error budget burn or sustained latency regression'),
+  (4, 1, 'Phase 3: Canary 50%->100% and legacy cleanup', '11-14', 'release-manager', 'Promotion gates pass at each tier and replay verification complete', 'Semantic legibility drop below gate or compliance failure')
 ON CONFLICT (id) DO UPDATE SET
-  phase_name=excluded.phase_name,
-  timeline_weeks=excluded.timeline_weeks,
-  owner=excluded.owner,
-  entry_gate=excluded.entry_gate,
-  rollback_trigger=excluded.rollback_trigger;
+  phase_name = excluded.phase_name,
+  timeline_weeks = excluded.timeline_weeks,
+  owner = excluded.owner,
+  entry_gate = excluded.entry_gate,
+  rollback_trigger = excluded.rollback_trigger;
 
 INSERT INTO dod_gates (id, initiative_id, gate_category, gate_rule, measurable_target) VALUES
-  (1, 1, 'tests', 'Contract, replay, semantic alignment, migration rehearsal suites', '100% required suite pass'),
-  (2, 1, 'slo', 'Render/update latency gate across all modes', 'P95 <16.7ms Tier-1 and <33ms Tier-2'),
-  (3, 1, 'benchmark', 'Performance and Reasoning Legibility Score gate', 'RLS >=0.80 and native-mode memory increase <=25%'),
-  (4, 1, 'observability', 'Latency/drift/fallback/RLS dashboard and alert gate', 'MTTD <=10 minutes and MTTR <=30 minutes'),
-  (5, 1, 'runbooks', 'Drift/protocol/privacy/rollback runbook gate', '100% Sev-1 scenario coverage'),
-  (6, 1, 'security', 'Privacy and cognitive-trace policy compliance gate', '0 critical audit findings')
+  (1, 1, 'tests', 'Contract/replay/drift/migration rehearsal suites', '100% required suite pass'),
+  (2, 1, 'slo', 'Render and update latency across rollout phases', 'P95 <16.7ms Tier-1 and <33ms Tier-2'),
+  (3, 1, 'benchmark', 'Compile/tick/resource + semantic legibility gate', 'Memory increase <=25% and legibility score >=0.80'),
+  (4, 1, 'observability', 'Stage-level dashboard + alerting gate', 'MTTD <=10 minutes and MTTR <=30 minutes'),
+  (5, 1, 'runbooks', 'Drift/compiler/protocol/privacy/rollback runbook gate', '100% Sev-1 scenario coverage'),
+  (6, 1, 'security', 'Privacy retention and auditability gate', '0 critical findings and 100% CI compliance pass')
 ON CONFLICT (id) DO UPDATE SET
-  gate_category=excluded.gate_category,
-  gate_rule=excluded.gate_rule,
-  measurable_target=excluded.measurable_target;
+  gate_category = excluded.gate_category,
+  gate_rule = excluded.gate_rule,
+  measurable_target = excluded.measurable_target;

--- a/docs/11_PLATFORM_WORK_PLAN.md
+++ b/docs/11_PLATFORM_WORK_PLAN.md
@@ -1,177 +1,192 @@
-# Platform Work Plan: Aetherium Cognitive Lightfield Platform (2026)
+# Platform Work Plan: Light Cognition Layer Program (Aetherium Manifest)
 
 ## Context
-- **Initiative:** Aetherium Cognitive Lightfield Platform ("Light as Reflection → Reasoning Surface → Native Intelligence")
-- **Scope:** orchestration services, protocol contracts, reliability controls, benchmark framework, operations, and migration workflow
-- **Drivers:** reliability, latency, semantic fidelity, security/privacy, and developer experience
-- **Current state:** Reactive Generative UI is operational; user intent is mapped into color, shape, density, and flow as a visual response layer
-- **Target state:** Lightfield becomes a native cognitive substrate where uncertainty, synthesis, and decision states are first-class machine states before language output
+- **Initiative:** Light Cognition Layer Program (`LC-2026-MORPHO`)
+- **Scope:** services (`api_gateway`, runtime orchestration), modules (semantic-field + morphogenesis + light compiler), protocol contracts, reliability controls, benchmark framework, operations, migration
+- **Drivers:** reliability, latency stability, semantic fidelity, security/privacy, and developer experience
+- **Current state:** Intent output can map too directly into `visual_parameters`; visual behavior is deterministic but limited by mapping-table logic
+- **Target state:** Intent is transformed through a cognition-native middle layer (`SemanticField -> MorphogenesisEngine -> LightCompiler -> CognitiveFieldRuntime`) that produces time-evolving render programs
 - **Constraints:**
-  - **SLO:** P95 render pipeline < 16.7 ms (Tier-1), < 33 ms (Tier-2)
-  - **Budget:** prioritize existing runtime stack reuse before new infrastructure expansion
-  - **Timeline:** 3 maturity stages over 2 quarters
-  - **Compliance:** no persistent storage for raw biometric streams; policy-auditable reasoning traces
-- **Dependencies:** Genesis cognition team, Manifest runtime team, AetherBus maintainers, SRE, Security/Privacy, ML platform
+  - **SLO:** P95 render/update pipeline < 16.7 ms (Tier-1), < 33 ms (Tier-2)
+  - **Budget:** reuse current runtime and schema tooling first; cap native mode memory increase at +25% from baseline
+  - **Timeline:** 14 weeks across 4 release phases
+  - **Compliance:** no raw biometric persistence; reasoning traces policy-auditable with TTL enforcement
+- **Dependencies:** Genesis cognition team, Manifest runtime team, AetherBus contracts maintainers, SRE, Security/Privacy, ML platform
+
+---
+
+## Canonical Runtime Path (single source of truth)
+
+```text
+Intent
+  -> SemanticField
+  -> MorphogenesisEngine
+  -> LightCompiler
+  -> CognitiveFieldRuntime
+  -> Shader Uniforms / Particle Targets / Force Fields
+```
+
+Legacy `visual_parameters` flow remains only as compatibility fallback and rollback target.
 
 ---
 
 ## 1) Workstreams
 
-1. **Architecture** — model the 3-stage cognition ladder and convert it into runtime components.
-2. **Protocol** — evolve embodiment contracts to encode reasoning-surface states and native cognition fields.
-3. **Reliability** — enforce semantic honesty, failure containment, and deterministic replay.
-4. **Benchmark** — validate performance and semantic quality at each maturity stage.
-5. **Ops** — production readiness through observability, runbooks, incident drills, and governance.
-6. **Migration** — phased rollout from reflection-only mode to native-intelligence mode with safe rollback.
+1. **Architecture** — define and implement the Light Cognition Layer runtime boundary.
+2. **Protocol** — evolve envelope contracts to encode semantic field + morphology + compiled light program.
+3. **Reliability** — detect and contain semantic-to-form drift in time-based evolution.
+4. **Benchmark** — gate performance and semantic legibility before promotions.
+5. **Ops** — operationalize observability, runbooks, and security controls for the new layer.
+6. **Migration** — ship phased rollout with hard rollback controls.
 
 ---
 
-## 2) Backlog (Epic → Story → Task + Measurable Acceptance Criteria)
+## 2) Backlog (Epic -> Story -> Task + Measurable Acceptance Criteria)
 
-## Epic A1: Cognitive Lightfield Architecture
+## Epic A2: Light Cognition Layer Architecture
 
-### Story A1.1: Reflection layer hardening
-- **Task A1.1.1:** Standardize intent/emotion/semantics ingestion into a single `lightfield_input` contract.
-- **Task A1.1.2:** Add deterministic rendering profile packs for shape/color/density/flow.
+### Story A2.1: Semantic field ingestion
+- **Task A2.1.1:** Normalize LLM semantic outputs into `SemanticField` (`intent_vector`, `confidence_gradient`, `ambiguity_index`, `emotional_polarity`).
+- **Task A2.1.2:** Add deterministic schema and runtime validators for `SemanticField`.
 - **Acceptance criteria:**
-  - 99.95% successful ingest-to-render transactions over a 24-hour soak test.
-  - Mean semantic mapping consistency score >= 0.95 on replay corpus.
+  - `SemanticField` contract validation pass = 100% in CI.
+  - Semantic ingestion success >= 99.95% in 24h soak test.
 
-### Story A1.2: Reasoning-surface primitives
-- **Task A1.2.1:** Add uncertainty primitives (`oscillation`, `branching_attractor_count`, `phase_interference`).
-- **Task A1.2.2:** Add decision-collapse primitive (`chaos_to_order_ratio`) and synthesis merge primitive (`mass_convergence_index`).
+### Story A2.2: Morphogenesis planning
+- **Task A2.2.1:** Build `MorphogenesisEngine` to convert semantic fields into topology seeds, attractor maps, and temporal operators.
+- **Task A2.2.2:** Implement policy-aware constraints to prevent unsafe or unstable morph trajectories.
 - **Acceptance criteria:**
-  - 100% schema validation pass for new fields.
-  - Reasoning-state classifier F1 score >= 0.90 on annotated test dataset.
+  - Morphogenesis plan generation success >= 99.9% across replay corpus.
+  - Instability containment trigger P95 <= 75 ms.
 
-### Story A1.3: Native cognition state engine
-- **Task A1.3.1:** Introduce latent lightfield state graph (`latent_state_id`, `state_energy`, `semantic_topology`).
-- **Task A1.3.2:** Emit language as a secondary projection from latent state.
+### Story A2.3: Light program compilation and runtime
+- **Task A2.3.1:** Implement `LightCompiler` output (`shader_uniforms`, `particle_targets`, `force_fields`, `runtime_tick_policy`).
+- **Task A2.3.2:** Implement `CognitiveFieldRuntime` for time-based evolution and deterministic fallback.
 - **Acceptance criteria:**
-  - At least 85% of sampled sessions produce explainable latent-state transitions.
-  - Language output remains semantically aligned >= 0.92 with latent-state summaries.
+  - Compiler contract pass = 100% against schema and fixture tests.
+  - Runtime overhead vs legacy path <= 3 ms at P95.
 
-## Epic P1: Protocol v3 (Cognition-Native)
+## Epic P2: Protocol Evolution for Field Cognition
 
-### Story P1.1: Unified cognition envelope
-- **Task P1.1.1:** Define protocol envelope for `reflection_state`, `reasoning_surface_state`, and `native_state`.
-- **Task P1.1.2:** Version contract with strict backward compatibility adapters for v1/v2 consumers.
+### Story P2.1: Unified cognition-native envelope
+- **Task P2.1.1:** Add protocol section blocks: `semantic_field`, `morphogenesis_plan`, `light_program`, `runtime_state`.
+- **Task P2.1.2:** Provide compatibility adapter for consumers that still read `visual_parameters`.
 - **Acceptance criteria:**
-  - Backward compatibility success = 100% across existing consumer test fixtures.
-  - Contract lint and schema evolution checks pass in CI for every commit.
+  - Backward compatibility pass = 100% for existing fixtures.
+  - Required field blocks enforced by schema lint in CI.
 
-### Story P1.2: Explainability and policy metadata
-- **Task P1.2.1:** Add `reason_trace_summary` and `policy_guardrail_hits` metadata.
-- **Task P1.2.2:** Expose machine-readable reasoning markers to UI inspection APIs.
+### Story P2.2: Explainability and governance metadata
+- **Task P2.2.1:** Emit `reason_trace_summary`, `policy_guardrail_hits`, `drift_status`.
+- **Task P2.2.2:** Expose inspection endpoint for field-stage transitions.
 - **Acceptance criteria:**
-  - 95%+ sessions include non-empty reasoning trace summary.
-  - Policy guardrail metadata is present for 100% blocked/adjusted actions.
+  - Non-empty trace summary present in >= 95% sessions.
+  - Governance metadata present for 100% blocked/adjusted actions.
 
-## Epic R1: Reliability and Safety
+## Epic R2: Reliability and Failure Containment
 
-### Story R1.1: Semantic integrity guardrails
-- **Task R1.1.1:** Implement runtime semantic drift detector between latent state and rendered state.
-- **Task R1.1.2:** Force deterministic fallback on drift threshold breach.
+### Story R2.1: Semantic drift detection
+- **Task R2.1.1:** Implement drift metrics (`semantic_coherence_score`, `topology_divergence_index`, `temporal_instability_ratio`).
+- **Task R2.1.2:** Add drift detector comparing source semantic manifold vs runtime field telemetry.
 - **Acceptance criteria:**
-  - Drift detector catches >= 98% seeded divergence scenarios.
-  - Fallback activation time < 75 ms at P95.
+  - Drift detection recall >= 98% on seeded divergence set.
+  - False-positive rate <= 3% on baseline scenarios.
 
-### Story R1.2: Failure-mode containment
-- **Task R1.2.1:** Add isolated execution lanes for generative reasoning modules.
-- **Task R1.2.2:** Add deterministic replay packages for incident reconstruction.
+### Story R2.2: Deterministic containment
+- **Task R2.2.1:** Add containment modes: soft clamp, deterministic anchor replay, hard fallback.
+- **Task R2.2.2:** Package replay bundle for all Sev-1 failure classes.
 - **Acceptance criteria:**
-  - 100% Sev-1 incidents reproduce in replay harness.
-  - Blast radius constrained to single tenant/session in chaos drills.
+  - Containment activation <= 75 ms at P95.
+  - Sev-1 replay reproducibility = 100%.
 
-## Epic B1: Benchmark and Quality Gates
+## Epic B2: Benchmark and Quality Gates
 
-### Story B1.1: Stage-wise performance benchmark
-- **Task B1.1.1:** Publish benchmark suites for Reflection, Reasoning Surface, Native Intelligence modes.
-- **Task B1.1.2:** Track GPU/CPU/memory cost envelope per mode.
+### Story B2.1: Performance benchmark suite
+- **Task B2.1.1:** Add benchmark scenarios for compile latency, tick stability, and resource envelope.
+- **Task B2.1.2:** Gate promotion on Tier-1/Tier-2 latency thresholds.
 - **Acceptance criteria:**
-  - Benchmark suite executes in CI nightly with 100% completion.
-  - Native mode stays within +25% memory budget over reflection baseline.
+  - Nightly benchmark run completion = 100%.
+  - Native mode memory increase <= 25% vs baseline.
 
-### Story B1.2: Semantic quality benchmark
-- **Task B1.2.1:** Create human+model evaluation harness for "visible reasoning quality".
-- **Task B1.2.2:** Define and gate on Reasoning Legibility Score (RLS).
+### Story B2.2: Semantic legibility benchmark
+- **Task B2.2.1:** Measure intent-to-field faithfulness and temporal continuity.
+- **Task B2.2.2:** Gate canary promotion with composite semantic legibility score.
 - **Acceptance criteria:**
-  - RLS >= 0.80 before canary promotion.
-  - Inter-rater agreement (Krippendorff alpha) >= 0.70.
+  - Composite score >= 0.80 before promotion.
+  - Inter-rater agreement >= 0.70 for human-evaluated subset.
 
-## Epic O1: Operations and Governance
+## Epic O2: Operations and Security Readiness
 
-### Story O1.1: Observability and runbooks
-- **Task O1.1.1:** Deploy dashboards for latency, drift, fallback rate, RLS, and policy-hit metrics.
-- **Task O1.1.2:** Author runbooks for drift storms, protocol mismatch, and model rollback.
+### Story O2.1: Observability and runbooks
+- **Task O2.1.1:** Deploy dashboards for drift, compile errors, fallback frequency, frame-time variance, policy hits.
+- **Task O2.1.2:** Validate runbooks for drift storm, compiler degradation, protocol mismatch, emergency rollback.
 - **Acceptance criteria:**
-  - MTTD <= 10 minutes and MTTR <= 30 minutes in incident simulations.
-  - 100% Sev-1 playbooks validated quarterly.
+  - MTTD <= 10 minutes; MTTR <= 30 minutes in simulations.
+  - 100% Sev-1 playbook validation quarterly.
 
-### Story O1.2: Security and privacy enforcement
-- **Task O1.2.1:** Enforce deny-by-default storage policies for raw biometric signals.
-- **Task O1.2.2:** Add continuous compliance checks for reasoning-trace retention policy.
+### Story O2.2: Security and privacy controls
+- **Task O2.2.1:** Enforce no raw biometric persistence and TTL for reasoning traces.
+- **Task O2.2.2:** Add continuous compliance checks in protected branch CI.
 - **Acceptance criteria:**
-  - 0 critical findings in privacy audits.
-  - 100% compliance checks passing in protected branch CI.
+  - 0 critical findings in security/privacy audits.
+  - Compliance checks pass 100% in required CI.
 
-## Epic M1: Migration and Release
+## Epic M2: Migration and Release Management
 
-### Story M1.1: Progressive rollout ladder
-- **Task M1.1.1:** Implement flags: `mode_reflection`, `mode_reasoning_surface`, `mode_native_intelligence`.
-- **Task M1.1.2:** Execute canary progression 5% → 20% → 50% → 100% with hard promotion gates.
+### Story M2.1: Progressive rollout
+- **Task M2.1.1:** Add flags: `semantic_field_enabled`, `morphogenesis_enabled`, `light_compiler_enabled`, `cognitive_runtime_enabled`.
+- **Task M2.1.2:** Execute canary progression: 5% -> 20% -> 50% -> 100%.
 - **Acceptance criteria:**
-  - Every promotion stage passes SLO + RLS + error-budget gates.
-  - Rollback to previous stable mode in <= 15 minutes.
+  - Promotion only when SLO + benchmark + error budget gates are green.
+  - Rollback to prior stable mode <= 15 minutes.
 
-### Story M1.2: Data and protocol migration
-- **Task M1.2.1:** Build dual-write adapters for protocol v2 and v3.
-- **Task M1.2.2:** Remove redundant legacy mapping paths after GA validation.
+### Story M2.2: Legacy cleanup
+- **Task M2.2.1:** Keep dual-write/dual-read until GA stability window is complete.
+- **Task M2.2.2:** Remove redundant direct mapping after compatibility and replay verification.
 - **Acceptance criteria:**
-  - Zero data loss in migration rehearsal runs.
-  - Legacy path removal does not reduce compatibility test pass rate.
+  - Migration rehearsal shows zero contract/data loss.
+  - Legacy path removal does not reduce compatibility pass rate.
 
 ---
 
 ## 3) Options, Tradeoffs, and Recommendation
 
-### Option A: Layered Maturity (Reflection → Reasoning Surface → Native) **[Chosen]**
-- **Pros:** lowest migration risk, clear observability at each stage, compatible with existing contracts.
-- **Cons:** requires temporary coexistence of multiple execution modes.
+### Option A: Incremental middle-layer insertion **[Chosen]**
+- **Pros:** lowest migration risk, clear rollback surface, progressive observability and tuning.
+- **Cons:** temporary dual-path complexity and extra adapter maintenance.
 
-### Option B: Big-Bang Native Intelligence Rewrite
-- **Pros:** fastest path to full cognitive-native architecture.
-- **Cons:** highest delivery and reliability risk, weak rollback surface, expensive retraining and validation.
+### Option B: Full replacement (big-bang)
+- **Pros:** fastest architecture purity.
+- **Cons:** highest reliability and schedule risk; rollback is harder.
 
-### Option C: Reflection-Only Optimization
-- **Pros:** highly predictable operations and near-term latency wins.
-- **Cons:** cannot expose reasoning visibility or native cognition interaction goals.
+### Option C: Keep direct mapping + minor heuristics
+- **Pros:** lower near-term cost and minimal code churn.
+- **Cons:** fails to deliver true time-based generative cognition behavior.
 
-**Recommendation:** Select **Option A** because it maximizes production safety while still delivering the strategic shift to cognition-native interaction.
-
----
-
-## 4) Risks, Failure Modes, and Mitigation Plan
-
-- **Risk:** Reasoning visuals are persuasive but semantically incorrect.
-  - **Failure mode:** users trust wrong internal state representation.
-  - **Mitigation:** semantic drift detector + mandatory deterministic anchor + explainability audits.
-
-- **Risk:** Native cognition mode breaches latency envelope.
-  - **Failure mode:** interaction lag and degraded experience.
-  - **Mitigation:** staged performance budgets, adaptive quality scaling, and strict rollout gates.
-
-- **Risk:** Protocol fragmentation across clients.
-  - **Failure mode:** incompatible consumers or missing reasoning fields.
-  - **Mitigation:** versioned envelope, compatibility adapters, schema lint in CI.
-
-- **Risk:** Privacy/control leakage from richer cognitive traces.
-  - **Failure mode:** over-retention or sensitive trace misuse.
-  - **Mitigation:** retention TTL, policy scanning, security approvals, and audit logs.
+**Recommendation:** choose **Option A** because it best balances delivery risk, operational safety, and strategic architecture goals.
 
 ---
 
-## 5) Rollout / Rollback Plan (Owner + Timeline)
+## 4) Risks, Failure Modes, Mitigation
+
+- **Risk:** semantic persuasion mismatch.
+  - **Failure mode:** rendered field looks plausible but misrepresents intent semantics.
+  - **Mitigation:** drift metrics + deterministic anchors + explainability audits.
+
+- **Risk:** latency/cost regression in runtime evolution.
+  - **Failure mode:** frame drops and SLO violations under load.
+  - **Mitigation:** benchmark gates, adaptive quality scaling, hard rollout gates.
+
+- **Risk:** protocol fragmentation.
+  - **Failure mode:** clients consume different envelope subsets.
+  - **Mitigation:** strict versioned contracts, CI lint, compatibility adapters.
+
+- **Risk:** privacy over-retention.
+  - **Failure mode:** sensitive cognitive traces stored beyond policy.
+  - **Mitigation:** TTL enforcement, deny-by-default storage policy, auditable access logs.
+
+---
+
+## 5) Rollout/Rollback Plan (owner + timeline)
 
 ## Owners
 - Architecture: Platform Architect
@@ -182,53 +197,53 @@
 - Migration: Release Manager
 
 ## Timeline
-- **Stage 0 (Weeks 1–3):** Protocol v3 foundation, schema validators, feature flags.
-- **Stage 1 (Weeks 4–8):** Reflection hardening + Reasoning Surface primitives in shadow mode.
-- **Stage 2 (Weeks 9–14):** Native cognition state engine, semantic drift controls, benchmark hardening.
-- **Stage 3 (Weeks 15–20):** Canary to GA and deprecation of redundant legacy mapping paths.
+- **Phase 0 (Weeks 1-2):** contracts, schema validators, and feature flags.
+- **Phase 1 (Weeks 3-6):** SemanticField + MorphogenesisEngine in shadow mode.
+- **Phase 2 (Weeks 7-10):** LightCompiler + CognitiveFieldRuntime canary (5% -> 20%).
+- **Phase 3 (Weeks 11-14):** canary expansion (50% -> 100%), GA, and redundant legacy cleanup.
 
 ## Rollback
-- Immediate mode rollback via feature flags to last stable stage.
-- Protocol fallback through compatibility adapters (v3 → v2).
-- Freeze native-state emission and revert to reasoning-surface mode on SLO breach.
-- Restore known-good release artifact through automated deployment rollback.
+- Immediate runtime rollback via feature flags to last stable mode.
+- Protocol adapter fallback from cognition-native blocks to legacy `visual_parameters`.
+- Freeze compile/runtime stage on error-budget burn or SLO breach.
+- Restore known-good release artifact via deployment rollback automation.
 
 ---
 
-## 6) Production Definition of Done
+## 6) Definition of Done (production)
 
-- **Tests:** contract tests, deterministic replay tests, semantic alignment tests, migration rehearsals.
-- **SLO gates:** render pipeline latency and update latency pass at each rollout stage.
-- **Benchmark gates:** performance budgets + Reasoning Legibility Score gates satisfied.
-- **Observability:** dashboards, traces, and alerts for all key cognitive/operational metrics.
-- **Runbooks:** validated runbooks for drift, protocol failure, privacy incidents, and rollback.
-- **Security checks:** storage policy enforcement, audit logging, compliance scan pass.
-
----
-
-## Architecture / Protocol Update Outline
-
-1. Add cognition mode abstraction (`reflection`, `reasoning_surface`, `native`) to orchestrator boundary.
-2. Introduce protocol v3 envelope with explicit state sections and compatibility adapter.
-3. Split renderer pipeline into deterministic anchor path + reasoning expression path.
-4. Add semantic integrity service for drift detection and policy enforcement.
-5. Expose explainability APIs for UI/runtime inspection and governance tooling.
+- **Tests:** contract tests, deterministic replay tests, drift tests, migration rehearsals.
+- **SLO gates:** render/update pipeline SLO passes at each rollout phase.
+- **Benchmarking gates:** performance budget and semantic legibility gates pass before promotion.
+- **Observability:** dashboards, traces, and alerts for all stage-level metrics.
+- **Runbooks:** validated runbooks for drift storm, compiler incidents, protocol mismatch, rollback.
+- **Security checks:** privacy policy enforcement, retention TTL checks, audit log verification.
 
 ---
 
-## Reliability & Ops Readiness Checklist
+## Architecture and Protocol Update Outline
 
-- [ ] Contract test suite green for protocol v2/v3 compatibility.
-- [ ] Replay harness reproduces all critical failure classes.
-- [ ] SLO dashboards with actionable alerts deployed.
-- [ ] Security/privacy scans integrated into required CI checks.
-- [ ] Rollout/rollback runbooks validated in game-day exercise.
-- [ ] On-call owner roster and escalation matrix published.
+1. Add cognition middle-layer boundary between intent semantics and rendering output.
+2. Version envelope schema to include semantic-field and morphogenesis artifacts.
+3. Keep legacy direct mapping only as compatibility path during migration.
+4. Add stage telemetry for explainability and runtime governance.
+5. Enforce schema, drift, and policy gates in CI/CD promotion flow.
 
 ---
 
-## Redundancy Removal (Single Canonical Source)
+## Reliability and Ops Readiness Checklist
 
-- Consolidated all platform execution planning into this file and the paired SQL backlog dataset.
-- Removed repeated narrative descriptions by keeping one canonical Epic→Story→Task chain with measurable criteria.
-- Defined one recommendation and one rollout ladder to avoid conflicting strategy variants.
+- [ ] Contract suite green for cognition-native and legacy compatibility paths.
+- [ ] Drift detector and containment tested against seeded failure corpus.
+- [ ] Benchmarks meet latency/resource/semantic thresholds in nightly CI.
+- [ ] Dashboards and alerts deployed with on-call routing.
+- [ ] Runbooks validated through game-day drills.
+- [ ] Security/privacy checks enforced in required branch protections.
+
+---
+
+## Redundancy Removal and Canonical Data Strategy
+
+- Keep this document as the single canonical planning source for the initiative.
+- Keep one normalized backlog database seed in `data/platform_work_backlog.sql` aligned to this plan.
+- Remove duplicate narrative by expressing delivery only through workstreams, epics, and measurable gates.


### PR DESCRIPTION
### Motivation
- Rename and reframe the initiative from the previous "Aetherium Cognitive Lightfield Platform" to the `Light Cognition Layer Program (LC-2026-MORPHO)` and make the canonical backlog and documentation consistent.
- Clarify and normalize backlog schema fields and identifiers for clearer tooling and CI integration.
- Replace legacy narrative/IDs with a single canonical runtime path and updated workstream/epic/story/task taxonomy to match the new architecture and rollout plan.

### Description
- Update `data/platform_work_backlog.sql` to rename the initiative, change codes/IDs for epics/stories/tasks, and replace narrative content with the new `SemanticField -> MorphogenesisEngine -> LightCompiler -> CognitiveFieldRuntime` flow. 
- Rename the `initiatives.constraints` column to `constraints_text` and adjust all `INSERT ... ON CONFLICT` upsert targets and SQL formatting for consistency; tighten some CHECK formatting (e.g. `chosen` constraint spacing). 
- Refresh backlog content: new epics (A2/P2/R2/B2/O2/M2), stories, tasks, acceptance criteria, decision options, risks, rollout phases, and DoD gates to reflect the incremental middle-layer insertion strategy and rollout phases/timelines. 
- Update `docs/11_PLATFORM_WORK_PLAN.md` to match the SQL seed: new initiative name, canonical runtime path, detailed phases, updated timelines (14 weeks), refined constraints (memory +25% cap, no raw biometric persistence), and canonicalized rollout/rollback/runbook/gate language.

### Testing
- Executed the SQL script against a local SQLite instance (`sqlite3 :memory:`) to validate table creation, `INSERT` statements, and `ON CONFLICT` upserts; schema creation and upserts completed without errors. 
- Ran a markdown lint pass on the updated `docs/11_PLATFORM_WORK_PLAN.md` (`markdownlint`) to ensure formatting consistency; lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b068af21208320b9e31198262d795a)