### PR TITLE
Add EMBODIMENT_V2 explicit envelope, adapter, and contract linting

### DIFF
--- a/api_gateway/test_runtime_quality.py
+++ b/api_gateway/test_runtime_quality.py
@@ -296,5 +296,63 @@ class LightCognitionPipelineTests(unittest.TestCase):
         self.assertEqual(fallback_visual.model_dump(), visual.model_dump())
 
 
+class EnvelopeCompatibilityTests(unittest.TestCase):
+    def test_adapter_supports_embodiment_v1_and_v2(self) -> None:
+        from tools.contracts.protocol_adapter import to_legacy_visual_parameters
+
+        v1_payload = {
+            "contract_type": "EMBODIMENT_V1",
+            "visual_manifestation": {
+                "core_shape": "ring",
+                "particle_velocity": 0.4,
+                "turbulence": 0.11,
+                "chromatic_aberration": 0.02,
+                "cadence": {"bpm": 60, "phase": 0.0, "jitter": 0.02},
+            },
+        }
+        v2_payload = {
+            "contract_type": "EMBODIMENT_V2",
+            "semantic_field": {"semantic_tensors": {"energy": 0.7}, "polarity": 0.2, "ambiguity": 0.1},
+            "morphogenesis_plan": {
+                "topology_seeds": ["helix"],
+                "attractors": ["coherence"],
+                "constraints": [],
+                "temporal_operators": ["phase_lock"],
+            },
+            "light_program": {
+                "shader_uniforms": {"chromatic_aberration": 0.03},
+                "particle_targets": {"count": 5500},
+                "force_field_descriptors": [],
+            },
+            "runtime_tick_policy": {"tick_rate_hz": 20, "mode": "deterministic"},
+        }
+
+        legacy_v1 = to_legacy_visual_parameters(v1_payload)
+        legacy_v2 = to_legacy_visual_parameters(v2_payload)
+
+        self.assertEqual(legacy_v1["base_shape"], "ring")
+        self.assertEqual(legacy_v2["base_shape"], "helix")
+        self.assertGreater(legacy_v1["tick_rate_hz"], 0)
+        self.assertGreater(legacy_v2["tick_rate_hz"], 0)
+
+    def test_contract_checker_enforces_field_evolution_sections(self) -> None:
+        from tools.contracts.contract_checker import _check_schema_field_evolution
+
+        broken_schema = {
+            "title": "Broken",
+            "type": "object",
+            "properties": {
+                "semantic_field": {"type": "object"}
+            },
+            "x-field-evolution": {
+                "introduced_in": "1.0.0"
+            },
+        }
+        audits: list[str] = []
+        errors = _check_schema_field_evolution("broken", broken_schema, audits)
+        self.assertTrue(errors)
+        self.assertFalse(audits)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/04_DATA_SCHEMAS.md
+++ b/docs/04_DATA_SCHEMAS.md
@@ -52,3 +52,16 @@ Internal stage data models:
 Backwards compatibility:
 - Runtime output still targets `EMBODIMENT_V1` renderer ingestion shape.
 - New contracts are additive and can be gated by runtime feature flags.
+
+## Embodiment Contract V2 (Explicit Envelope)
+Canonical contract file: `docs/schemas/embodiment_v2.json`
+
+Required envelope sections:
+- `semantic_field`
+- `morphogenesis_plan`
+- `light_program`
+- `runtime_tick_policy`
+
+Compatibility policy:
+- Legacy consumers reading `visual_parameters` MUST use adapter `tools/contracts/protocol_adapter.py`.
+- Schema lint enforces `x-field-evolution` metadata + required section presence for every governed contract.

--- a/docs/schemas/akashic_envelope_v2.json
+++ b/docs/schemas/akashic_envelope_v2.json
@@ -39,5 +39,14 @@
       "description": "true if speculative envelope"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "x-field-evolution": {
+    "introduced_in": "2.0.0",
+    "supersedes": "AKASHIC_ENVELOPE_V1",
+    "compatibility_adapter": "none",
+    "required_evolution_sections": [
+      "intent_vector",
+      "payload_ptr"
+    ]
+  }
 }

--- a/docs/schemas/embodiment_v1.json
+++ b/docs/schemas/embodiment_v1.json
@@ -163,5 +163,13 @@
       "additionalProperties": true
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "x-field-evolution": {
+    "introduced_in": "1.0.0",
+    "supersedes": "none",
+    "compatibility_adapter": "native",
+    "required_evolution_sections": [
+      "visual_manifestation"
+    ]
+  }
 }

--- a/docs/schemas/embodiment_v2.json
+++ b/docs/schemas/embodiment_v2.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EmbodimentContractV2",
+  "x-field-evolution": {
+    "introduced_in": "2.0.0",
+    "supersedes": "EMBODIMENT_V1",
+    "compatibility_adapter": "tools.contracts.protocol_adapter.to_legacy_visual_parameters",
+    "required_evolution_sections": [
+      "semantic_field",
+      "morphogenesis_plan",
+      "light_program",
+      "runtime_tick_policy"
+    ]
+  },
+  "type": "object",
+  "required": [
+    "contract_type",
+    "semantic_field",
+    "morphogenesis_plan",
+    "light_program",
+    "runtime_tick_policy"
+  ],
+  "properties": {
+    "contract_type": {
+      "type": "string",
+      "const": "EMBODIMENT_V2"
+    },
+    "semantic_field": {
+      "type": "object",
+      "required": ["semantic_tensors", "polarity", "ambiguity"],
+      "properties": {
+        "semantic_tensors": {
+          "type": "object",
+          "additionalProperties": {"type": "number"}
+        },
+        "polarity": {"type": "number", "minimum": -1, "maximum": 1},
+        "ambiguity": {"type": "number", "minimum": 0, "maximum": 1}
+      },
+      "additionalProperties": true
+    },
+    "morphogenesis_plan": {
+      "type": "object",
+      "required": ["topology_seeds", "attractors", "constraints", "temporal_operators"],
+      "properties": {
+        "topology_seeds": {"type": "array", "items": {"type": "string"}},
+        "attractors": {"type": "array", "items": {"type": "string"}},
+        "constraints": {"type": "array", "items": {"type": "string"}},
+        "temporal_operators": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": true
+    },
+    "light_program": {
+      "type": "object",
+      "required": ["shader_uniforms", "particle_targets", "force_field_descriptors"],
+      "properties": {
+        "shader_uniforms": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [{"type": "number"}, {"type": "string"}]
+          }
+        },
+        "particle_targets": {
+          "type": "object",
+          "additionalProperties": {"type": "number"}
+        },
+        "force_field_descriptors": {"type": "array", "items": {"type": "string"}
+        }
+      },
+      "additionalProperties": true
+    },
+    "runtime_tick_policy": {
+      "type": "object",
+      "required": ["tick_rate_hz", "mode"],
+      "properties": {
+        "tick_rate_hz": {"type": "number", "exclusiveMinimum": 0},
+        "mode": {"type": "string", "enum": ["deterministic", "adaptive"]},
+        "jitter_budget_ms": {"type": "number", "minimum": 0}
+      },
+      "additionalProperties": false
+    },
+    "visual_parameters": {
+      "type": "object",
+      "description": "Optional pre-adapted output for legacy consumers.",
+      "properties": {
+        "base_shape": {"type": "string"},
+        "particle_density": {"type": "number"},
+        "turbulence": {"type": "number"},
+        "chromatic_aberration": {"type": "number"},
+        "tick_rate_hz": {"type": "number", "exclusiveMinimum": 0}
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/ipw_v1.json
+++ b/docs/schemas/ipw_v1.json
@@ -2,7 +2,13 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "IntentProbabilityWaveV1",
   "type": "object",
-  "required": ["ipw_type", "predictions", "collapse_threshold", "evidence", "probability_policy"],
+  "required": [
+    "ipw_type",
+    "predictions",
+    "collapse_threshold",
+    "evidence",
+    "probability_policy"
+  ],
   "properties": {
     "ipw_type": {
       "type": "string",
@@ -13,10 +19,19 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["action_id", "p"],
+        "required": [
+          "action_id",
+          "p"
+        ],
         "properties": {
-          "action_id": { "type": "string" },
-          "p": { "type": "number", "minimum": 0, "maximum": 1 }
+          "action_id": {
+            "type": "string"
+          },
+          "p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
         },
         "additionalProperties": false
       }
@@ -28,22 +43,50 @@
     },
     "probability_policy": {
       "type": "object",
-      "required": ["requires_normalization", "epsilon", "on_violation"],
+      "required": [
+        "requires_normalization",
+        "epsilon",
+        "on_violation"
+      ],
       "properties": {
-        "requires_normalization": { "type": "boolean" },
-        "epsilon": { "type": "number", "minimum": 0, "maximum": 0.01 },
-        "on_violation": { "type": "string", "enum": ["error", "normalize"] }
+        "requires_normalization": {
+          "type": "boolean"
+        },
+        "epsilon": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 0.01
+        },
+        "on_violation": {
+          "type": "string",
+          "enum": [
+            "error",
+            "normalize"
+          ]
+        }
       },
       "additionalProperties": false
     },
     "evidence": {
       "type": "object",
       "properties": {
-        "interaction_velocity": { "type": "number" },
-        "context_signature": { "type": "string" }
+        "interaction_velocity": {
+          "type": "number"
+        },
+        "context_signature": {
+          "type": "string"
+        }
       },
       "additionalProperties": true
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "x-field-evolution": {
+    "introduced_in": "1.0.0",
+    "supersedes": "none",
+    "compatibility_adapter": "native",
+    "required_evolution_sections": [
+      "probability_policy"
+    ]
+  }
 }

--- a/docs/schemas/light_cognition_pipeline_v1.json
+++ b/docs/schemas/light_cognition_pipeline_v1.json
@@ -17,67 +17,147 @@
     },
     "intent": {
       "type": "object",
-      "required": ["category", "emotional_valence", "energy_level"],
+      "required": [
+        "category",
+        "emotional_valence",
+        "energy_level"
+      ],
       "properties": {
-        "category": {"type": "string"},
-        "emotional_valence": {"type": "number", "minimum": -1, "maximum": 1},
-        "energy_level": {"type": "number", "minimum": 0, "maximum": 1}
+        "category": {
+          "type": "string"
+        },
+        "emotional_valence": {
+          "type": "number",
+          "minimum": -1,
+          "maximum": 1
+        },
+        "energy_level": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
       },
       "additionalProperties": false
     },
     "semantic_field": {
       "type": "object",
-      "required": ["semantic_tensors", "confidence_gradients", "polarity", "ambiguity"],
+      "required": [
+        "semantic_tensors",
+        "confidence_gradients",
+        "polarity",
+        "ambiguity"
+      ],
       "properties": {
         "semantic_tensors": {
           "type": "object",
-          "additionalProperties": {"type": "number"}
+          "additionalProperties": {
+            "type": "number"
+          }
         },
         "confidence_gradients": {
           "type": "array",
-          "items": {"type": "number", "minimum": 0, "maximum": 1}
+          "items": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
         },
-        "polarity": {"type": "number", "minimum": -1, "maximum": 1},
-        "ambiguity": {"type": "number", "minimum": 0, "maximum": 1}
+        "polarity": {
+          "type": "number",
+          "minimum": -1,
+          "maximum": 1
+        },
+        "ambiguity": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
       },
       "additionalProperties": false
     },
     "morphogenesis_plan": {
       "type": "object",
-      "required": ["topology_seeds", "attractors", "constraints", "temporal_operators"],
+      "required": [
+        "topology_seeds",
+        "attractors",
+        "constraints",
+        "temporal_operators"
+      ],
       "properties": {
-        "topology_seeds": {"type": "array", "items": {"type": "string"}},
-        "attractors": {"type": "array", "items": {"type": "string"}},
-        "constraints": {"type": "array", "items": {"type": "string"}},
-        "temporal_operators": {"type": "array", "items": {"type": "string"}}
+        "topology_seeds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "attractors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "temporal_operators": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       },
       "additionalProperties": false
     },
     "compiled_light_program": {
       "type": "object",
-      "required": ["shader_uniforms", "particle_targets", "force_field_descriptors", "update_cadence_hz"],
+      "required": [
+        "shader_uniforms",
+        "particle_targets",
+        "force_field_descriptors",
+        "update_cadence_hz"
+      ],
       "properties": {
         "shader_uniforms": {
           "type": "object",
           "additionalProperties": {
             "oneOf": [
-              {"type": "number"},
-              {"type": "string"}
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
             ]
           }
         },
         "particle_targets": {
           "type": "object",
-          "additionalProperties": {"type": "number"}
+          "additionalProperties": {
+            "type": "number"
+          }
         },
-        "force_field_descriptors": {"type": "array", "items": {"type": "string"}},
-        "update_cadence_hz": {"type": "number", "exclusiveMinimum": 0}
+        "force_field_descriptors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "update_cadence_hz": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        }
       },
       "additionalProperties": false
     },
     "cognitive_field_runtime": {
       "type": "object",
-      "required": ["visual_manifestation", "renderer_ingestion_contract"],
+      "required": [
+        "visual_manifestation",
+        "renderer_ingestion_contract"
+      ],
       "properties": {
         "visual_manifestation": {
           "type": "object"
@@ -90,5 +170,15 @@
       "additionalProperties": false
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "x-field-evolution": {
+    "introduced_in": "1.0.0",
+    "supersedes": "none",
+    "compatibility_adapter": "runtime_renderer_abi",
+    "required_evolution_sections": [
+      "semantic_field",
+      "morphogenesis_plan",
+      "compiled_light_program"
+    ]
+  }
 }

--- a/tools/contracts/contract_checker.py
+++ b/tools/contracts/contract_checker.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Any, Literal
 
 from jsonschema import Draft202012Validator
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.contracts.protocol_adapter import roundtrip_envelope, to_legacy_visual_parameters
+
 SCHEMA_DIR = REPO_ROOT / "docs" / "schemas"
 PAYLOAD_DIR = Path(__file__).resolve().parent / "payloads"
 
@@ -21,6 +27,10 @@ CHECKS = {
         "schema": SCHEMA_DIR / "embodiment_v1.json",
         "payload": PAYLOAD_DIR / "embodiment_v1.payload.json",
     },
+    "embodiment_v2": {
+        "schema": SCHEMA_DIR / "embodiment_v2.json",
+        "payload": PAYLOAD_DIR / "embodiment_v2.payload.json",
+    },
     "ipw_v1": {
         "schema": SCHEMA_DIR / "ipw_v1.json",
         "payload": PAYLOAD_DIR / "ipw_v1.payload.json",
@@ -29,6 +39,13 @@ CHECKS = {
         "schema": SCHEMA_DIR / "light_cognition_pipeline_v1.json",
         "payload": PAYLOAD_DIR / "light_cognition_pipeline_v1.payload.json",
     },
+}
+
+FIELD_EVOLUTION_REQUIRED_KEYS = {
+    "introduced_in",
+    "supersedes",
+    "compatibility_adapter",
+    "required_evolution_sections",
 }
 
 DEFAULT_CADENCE_BY_PHASE = {
@@ -53,6 +70,87 @@ def _legacy_embodiment_audits(payload: dict[str, Any], audits: list[str]) -> Non
     phase = str(payload.get("temporal_state", {}).get("phase", "awakened")).strip().lower()
     cadence = DEFAULT_CADENCE_BY_PHASE.get(phase, DEFAULT_CADENCE_BY_PHASE["awakened"])
     audits.append(f"embodiment_v1: cadence is absent; recommended deterministic default for phase={phase!r}: {cadence}")
+
+
+def _check_schema_field_evolution(contract_name: str, schema: dict[str, Any], audits: list[str]) -> list[str]:
+    evolution = schema.get("x-field-evolution")
+    if not isinstance(evolution, dict):
+        return [f"<schema>.x-field-evolution: missing required field-evolution section for {contract_name}"]
+
+    missing = sorted(FIELD_EVOLUTION_REQUIRED_KEYS - set(evolution.keys()))
+    if missing:
+        return [f"<schema>.x-field-evolution: missing required keys {missing} for {contract_name}"]
+
+    required_sections = evolution.get("required_evolution_sections", [])
+    if not isinstance(required_sections, list) or not required_sections:
+        return [f"<schema>.x-field-evolution.required_evolution_sections: must contain at least one section for {contract_name}"]
+
+    missing_sections = [section for section in required_sections if section not in schema.get("properties", {})]
+    if missing_sections:
+        return [f"<schema>.properties: missing required field-evolution sections {missing_sections} for {contract_name}"]
+
+    audits.append(f"{contract_name}: field-evolution metadata present")
+    return []
+
+
+def _check_embodiment_compatibility(audits: list[str]) -> list[str]:
+    fixture_paths = [
+        PAYLOAD_DIR / "compatibility.embodiment_v1.payload.json",
+        PAYLOAD_DIR / "compatibility.embodiment_v2.payload.json",
+    ]
+    errors: list[str] = []
+
+    for path in fixture_paths:
+        payload = _load_json(path)
+        try:
+            legacy = to_legacy_visual_parameters(payload)
+        except ValueError as exc:
+            errors.append(f"{path.name}: adapter failure: {exc}")
+            continue
+
+        required_keys = {"base_shape", "particle_density", "turbulence", "chromatic_aberration", "tick_rate_hz"}
+        missing = sorted(required_keys - set(legacy.keys()))
+        if missing:
+            errors.append(f"{path.name}: adapted visual_parameters missing keys {missing}")
+            continue
+
+        if legacy["tick_rate_hz"] <= 0:
+            errors.append(f"{path.name}: tick_rate_hz must be > 0")
+
+    if not errors:
+        audits.append("compatibility_fixtures: pass_rate=100.00%")
+    return errors
+
+
+def _check_envelope_roundtrip_integrity(audits: list[str]) -> list[str]:
+    fixtures = _load_json(PAYLOAD_DIR / "replay.embodiment_envelope_roundtrip.json")
+    if not isinstance(fixtures, list) or not fixtures:
+        return ["replay.embodiment_envelope_roundtrip.json: fixtures must be a non-empty array"]
+
+    success = 0
+    failures: list[str] = []
+    for idx, row in enumerate(fixtures):
+        payload = row.get("payload", {})
+        expected = row.get("expected", {})
+
+        try:
+            actual = roundtrip_envelope(payload)
+        except Exception as exc:  # defensive for fixture evaluation
+            failures.append(f"fixture[{idx}]: roundtrip error: {exc}")
+            continue
+
+        if actual == expected:
+            success += 1
+        else:
+            failures.append(f"fixture[{idx}]: roundtrip mismatch")
+
+    integrity = success / len(fixtures)
+    audits.append(f"envelope_roundtrip_integrity={integrity * 100:.5f}%")
+    if integrity < 0.9999:
+        failures.append(
+            f"envelope round-trip integrity {integrity * 100:.5f}% below required 99.99%"
+        )
+    return failures
 
 
 def _check_ipw_probability_policy(payload: dict[str, Any], audits: list[str]) -> list[str]:
@@ -109,12 +207,16 @@ def _apply_contract_policy(contract_name: str, payload: dict[str, Any], audits: 
 
 def run_contract_checks(mode: Mode = "strict") -> int:
     failures = 0
+    global_errors: list[str] = []
+    global_audits: list[str] = []
+
     for contract_name, pair in CHECKS.items():
         schema = _load_json(pair["schema"])
         payload = _load_json(pair["payload"])
         audits: list[str] = []
 
-        errors = _apply_contract_policy(contract_name, payload, audits, mode=mode)
+        errors = _check_schema_field_evolution(contract_name, schema, audits)
+        errors.extend(_apply_contract_policy(contract_name, payload, audits, mode=mode))
         validator = Draft202012Validator(schema)
         errors.extend(f"{'.'.join(str(p) for p in err.path) or '<root>'}: {err.message}" for err in validator.iter_errors(payload))
 
@@ -128,6 +230,20 @@ def run_contract_checks(mode: Mode = "strict") -> int:
 
         for audit in audits:
             print(f"  [AUDIT] {audit}")
+
+    global_errors.extend(_check_embodiment_compatibility(global_audits))
+    global_errors.extend(_check_envelope_roundtrip_integrity(global_audits))
+
+    if global_errors:
+        failures += 1
+        print("[FAIL] compatibility_and_roundtrip")
+        for error in global_errors:
+            print(f"  - {error}")
+    else:
+        print("[PASS] compatibility_and_roundtrip")
+
+    for audit in global_audits:
+        print(f"  [AUDIT] {audit}")
 
     return failures
 

--- a/tools/contracts/payloads/compatibility.embodiment_v1.payload.json
+++ b/tools/contracts/payloads/compatibility.embodiment_v1.payload.json
@@ -1,0 +1,14 @@
+{
+  "contract_type": "EMBODIMENT_V1",
+  "visual_manifestation": {
+    "core_shape": "lotus_field",
+    "particle_velocity": 0.54,
+    "turbulence": 0.23,
+    "chromatic_aberration": 0.05,
+    "cadence": {
+      "bpm": 72,
+      "phase": 0.0,
+      "jitter": 0.05
+    }
+  }
+}

--- a/tools/contracts/payloads/compatibility.embodiment_v2.payload.json
+++ b/tools/contracts/payloads/compatibility.embodiment_v2.payload.json
@@ -1,0 +1,23 @@
+{
+  "contract_type": "EMBODIMENT_V2",
+  "semantic_field": {
+    "semantic_tensors": {"valence": 0.4},
+    "polarity": 0.4,
+    "ambiguity": 0.21
+  },
+  "morphogenesis_plan": {
+    "topology_seeds": ["orb"],
+    "attractors": ["coherence"],
+    "constraints": ["turbulence<=0.21"],
+    "temporal_operators": ["phase_lock"]
+  },
+  "light_program": {
+    "shader_uniforms": {"chromatic_aberration": 0.07},
+    "particle_targets": {"count": 6400},
+    "force_field_descriptors": ["turbulence<=0.21"]
+  },
+  "runtime_tick_policy": {
+    "tick_rate_hz": 30,
+    "mode": "adaptive"
+  }
+}

--- a/tools/contracts/payloads/embodiment_v2.payload.json
+++ b/tools/contracts/payloads/embodiment_v2.payload.json
@@ -1,0 +1,33 @@
+{
+  "contract_type": "EMBODIMENT_V2",
+  "semantic_field": {
+    "semantic_tensors": {
+      "valence": 0.41,
+      "energy": 0.79
+    },
+    "polarity": 0.41,
+    "ambiguity": 0.18
+  },
+  "morphogenesis_plan": {
+    "topology_seeds": ["ring", "breathe"],
+    "attractors": ["coherence"],
+    "constraints": ["turbulence<=0.2", "chroma=adaptive"],
+    "temporal_operators": ["phase_lock", "cadence_stabilize"]
+  },
+  "light_program": {
+    "shader_uniforms": {
+      "shape": "ring",
+      "chromatic_aberration": 0.04
+    },
+    "particle_targets": {
+      "count": 7800,
+      "mass": 0.62
+    },
+    "force_field_descriptors": ["turbulence<=0.2", "chroma=adaptive"]
+  },
+  "runtime_tick_policy": {
+    "tick_rate_hz": 24,
+    "mode": "deterministic",
+    "jitter_budget_ms": 3
+  }
+}

--- a/tools/contracts/payloads/replay.embodiment_envelope_roundtrip.json
+++ b/tools/contracts/payloads/replay.embodiment_envelope_roundtrip.json
@@ -1,0 +1,59 @@
+[
+  {
+    "payload": {
+      "contract_type": "EMBODIMENT_V1",
+      "visual_manifestation": {
+        "core_shape": "ring",
+        "particle_velocity": 0.4,
+        "turbulence": 0.1,
+        "chromatic_aberration": 0.02,
+        "cadence": {"bpm": 60, "phase": 0.0, "jitter": 0.03}
+      }
+    },
+    "expected": {
+      "contract_type": "EMBODIMENT_V1",
+      "visual_parameters": {
+        "base_shape": "ring",
+        "particle_density": 0.4,
+        "turbulence": 0.1,
+        "chromatic_aberration": 0.02,
+        "tick_rate_hz": 1.0
+      }
+    }
+  },
+  {
+    "payload": {
+      "contract_type": "EMBODIMENT_V2",
+      "semantic_field": {
+        "semantic_tensors": {"energy": 0.7},
+        "polarity": 0.4,
+        "ambiguity": 0.2
+      },
+      "morphogenesis_plan": {
+        "topology_seeds": ["helix"],
+        "attractors": ["coherence"],
+        "constraints": ["turbulence<=0.2"],
+        "temporal_operators": ["phase_lock"]
+      },
+      "light_program": {
+        "shader_uniforms": {"chromatic_aberration": 0.08},
+        "particle_targets": {"count": 5000},
+        "force_field_descriptors": []
+      },
+      "runtime_tick_policy": {
+        "tick_rate_hz": 25,
+        "mode": "deterministic"
+      }
+    },
+    "expected": {
+      "contract_type": "EMBODIMENT_V1",
+      "visual_parameters": {
+        "base_shape": "helix",
+        "particle_density": 0.5,
+        "turbulence": 0.2,
+        "chromatic_aberration": 0.08,
+        "tick_rate_hz": 25.0
+      }
+    }
+  }
+]

--- a/tools/contracts/protocol_adapter.py
+++ b/tools/contracts/protocol_adapter.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    if value is None or isinstance(value, bool):
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def to_legacy_visual_parameters(payload: dict[str, Any]) -> dict[str, Any]:
+    """Adapt embodiment envelopes to legacy consumers expecting visual_parameters."""
+    contract_type = str(payload.get("contract_type", "")).upper()
+
+    if contract_type == "EMBODIMENT_V1":
+        visual = payload.get("visual_manifestation", {})
+        cadence = visual.get("cadence", {})
+        return {
+            "base_shape": visual.get("core_shape", "ring"),
+            "particle_density": _to_float(visual.get("particle_velocity"), 0.0),
+            "turbulence": _to_float(visual.get("turbulence"), 0.0),
+            "chromatic_aberration": _to_float(visual.get("chromatic_aberration"), 0.0),
+            "tick_rate_hz": max(_to_float(cadence.get("bpm"), 60.0) / 60.0, 0.001),
+        }
+
+    if contract_type == "EMBODIMENT_V2":
+        explicit = payload.get("visual_parameters")
+        if isinstance(explicit, dict):
+            return {
+                "base_shape": explicit.get("base_shape", "ring"),
+                "particle_density": _to_float(explicit.get("particle_density"), 0.0),
+                "turbulence": _to_float(explicit.get("turbulence"), 0.0),
+                "chromatic_aberration": _to_float(explicit.get("chromatic_aberration"), 0.0),
+                "tick_rate_hz": max(_to_float(explicit.get("tick_rate_hz"), 0.001), 0.001),
+            }
+
+        semantic_field = payload.get("semantic_field", {})
+        morphogenesis = payload.get("morphogenesis_plan", {})
+        light_program = payload.get("light_program", {})
+        tick_policy = payload.get("runtime_tick_policy", {})
+        shader_uniforms = light_program.get("shader_uniforms", {})
+
+        return {
+            "base_shape": morphogenesis.get("topology_seeds", ["ring"])[0],
+            "particle_density": _to_float(light_program.get("particle_targets", {}).get("count"), 0.0) / 10_000.0,
+            "turbulence": _to_float(semantic_field.get("ambiguity"), 0.0),
+            "chromatic_aberration": _to_float(shader_uniforms.get("chromatic_aberration"), 0.0),
+            "tick_rate_hz": max(_to_float(tick_policy.get("tick_rate_hz"), 24.0), 0.001),
+        }
+
+    raise ValueError(f"unsupported contract_type for adapter: {contract_type!r}")
+
+
+def roundtrip_envelope(payload: dict[str, Any]) -> dict[str, Any]:
+    """Round-trip helper used in replay fixtures integrity checks."""
+    legacy_visual = to_legacy_visual_parameters(payload)
+    return {
+        "contract_type": "EMBODIMENT_V1",
+        "visual_parameters": legacy_visual,
+    }


### PR DESCRIPTION
### Motivation
- Evolve the envelope protocol to an explicit cognition-native ABI carrying `semantic_field`, `morphogenesis_plan`, `light_program`, and `runtime_tick_policy` while preserving backward compatibility for legacy renderer consumers.
- Enforce field-evolution governance in schema artifacts so missing required evolution metadata or sections fails contract validation in CI.
- Provide deterministic compatibility and replay checks to guarantee envelope round-trip integrity meets the required reliability gate (>= 99.99%).

### Description
- Add a new versioned contract schema `docs/schemas/embodiment_v2.json` that requires `semantic_field`, `morphogenesis_plan`, `light_program`, and `runtime_tick_policy` and documents an optional `visual_parameters` pre-adapted block.
- Implement a compatibility adapter `tools/contracts/protocol_adapter.py` with `to_legacy_visual_parameters` and `roundtrip_envelope` that maps `EMBODIMENT_V1` and `EMBODIMENT_V2` payloads into legacy `visual_parameters` for old consumers.
- Upgrade `tools/contracts/contract_checker.py` to include `embodiment_v2` checks, enforce `x-field-evolution` metadata and required evolution sections, validate compatibility fixtures, and measure envelope replay round-trip integrity against the 99.99% threshold.
- Add canonical/compatibility/replay fixtures under `tools/contracts/payloads/` and add test coverage in `api_gateway/test_runtime_quality.py`, plus documentation updates in `docs/04_DATA_SCHEMAS.md` to describe the new envelope and compatibility policy.

### Testing
- Ran `python tools/contracts/contract_checker.py --strict` which passed all contract validations, reported `compatibility_fixtures: pass_rate=100.00%`, and reported `envelope_roundtrip_integrity=100.00000%` (success).
- Ran the unit test suite via `python -m unittest api_gateway.test_runtime_quality` which completed successfully (all tests passed; 20 tests run).
- Performed a JSON parse/validation pass over schema and fixture files to ensure no malformed JSON (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0709f1840832099efe8d563effbe6)