### PR TITLE
Add runtime + semantic benchmark suites and promotion gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,9 @@ cd api_gateway && pytest -q
 
 # contract checks
 python3 tools/contracts/contract_checker.py
+
+# release benchmark gates (performance + semantics)
+python3 tools/benchmarks/runtime_semantic_benchmark.py --input tools/benchmarks/runtime_semantic_samples.sample.json
 ```
 
 ---

--- a/api_gateway/test_runtime_quality.py
+++ b/api_gateway/test_runtime_quality.py
@@ -7,7 +7,8 @@ from jsonschema import Draft202012Validator
 from api_gateway.deterministic_replay import replay_incident_package, replay_lockstep
 from tools.benchmarks.creative_stress_scenarios import run_scenarios
 from tools.benchmarks.intent_light_knowledge_graph import build_graph
-from tools.benchmarks.latency_perception_benchmark import run_benchmark
+from tools.benchmarks.latency_perception_benchmark import run_benchmark as run_latency_benchmark
+from tools.benchmarks.runtime_semantic_benchmark import run_benchmark as run_release_benchmark
 from tools.contracts.contract_checker import _apply_contract_policy
 
 
@@ -28,17 +29,69 @@ class LatencyPerceptionBenchmarkTests(unittest.TestCase):
             {"raw_rtt_ms": 50, "render_pipeline_ms": 34, "cognitive_settle_ms": 40, "prediction_mismatch": 0.1},
             {"raw_rtt_ms": 55, "render_pipeline_ms": 36, "cognitive_settle_ms": 43, "prediction_mismatch": 0.0},
         ]
-        result = run_benchmark(samples)
+        result = run_latency_benchmark(samples)
         self.assertIn("raw_rtt_ms", result)
         self.assertIn("perceived_latency_ms", result)
         self.assertNotEqual(result["raw_rtt_ms"]["mean"], result["perceived_latency_ms"]["mean"])
 
     def test_perception_benchmark_empty_samples_returns_safe_defaults(self) -> None:
-        result = run_benchmark([])
+        result = run_latency_benchmark([])
         self.assertEqual(result["sample_count"], 0)
         self.assertIsNone(result["raw_rtt_ms"]["mean"])
         self.assertIsNone(result["perceived_latency_ms"]["p95"])
         self.assertFalse(result["gunui_target_met"])
+
+
+class RuntimeSemanticBenchmarkTests(unittest.TestCase):
+    def test_release_gates_pass_when_all_acceptance_criteria_are_met(self) -> None:
+        payload = {
+            "compile_latency_ms": [62.1, 66.4, 71.0, 73.3, 68.8],
+            "tick_delta_ms": [0.8, 1.1, 1.0, 1.4, 1.2],
+            "render_pipeline_ms": [31.2, 33.4, 35.1, 37.0, 38.2],
+            "resource_samples": [
+                {"gpu_utilization": 0.61, "cpu_utilization": 0.52, "memory_mb": 1240},
+                {"gpu_utilization": 0.67, "cpu_utilization": 0.58, "memory_mb": 1310},
+                {"gpu_utilization": 0.71, "cpu_utilization": 0.62, "memory_mb": 1375},
+            ],
+            "intent_faithfulness_scores": [0.84, 0.86, 0.82, 0.88, 0.85],
+            "temporal_continuity_scores": [0.81, 0.83, 0.84, 0.8, 0.82],
+            "legibility_scores": [
+                {"human": 0.88, "model": 0.83},
+                {"human": 0.86, "model": 0.82},
+                {"human": 0.89, "model": 0.85},
+            ],
+        }
+        result = run_release_benchmark(payload)
+
+        self.assertEqual(result["nightly_completion_rate"], 1.0)
+        self.assertTrue(result["render_pipeline"]["pass"])
+        self.assertGreaterEqual(result["semantic_composite_score"], 0.8)
+        self.assertTrue(result["promotion_gates"]["canary"])
+        self.assertTrue(result["promotion_gates"]["ga"])
+
+    def test_ga_gate_blocks_when_semantic_composite_is_below_target(self) -> None:
+        payload = {
+            "compile_latency_ms": [60.0, 65.0, 70.0],
+            "tick_delta_ms": [1.0, 1.1, 1.2],
+            "render_pipeline_ms": [30.0, 35.0, 38.0],
+            "resource_samples": [
+                {"gpu_utilization": 0.6, "cpu_utilization": 0.5, "memory_mb": 1200},
+                {"gpu_utilization": 0.7, "cpu_utilization": 0.6, "memory_mb": 1300},
+            ],
+            "intent_faithfulness_scores": [0.79, 0.77, 0.78],
+            "temporal_continuity_scores": [0.78, 0.79, 0.77],
+            "legibility_scores": [
+                {"human": 0.79, "model": 0.78},
+                {"human": 0.8, "model": 0.77},
+            ],
+        }
+        result = run_release_benchmark(payload)
+
+        self.assertEqual(result["nightly_completion_rate"], 1.0)
+        self.assertTrue(result["render_pipeline"]["pass"])
+        self.assertLess(result["semantic_composite_score"], 0.8)
+        self.assertFalse(result["promotion_gates"]["canary"])
+        self.assertFalse(result["promotion_gates"]["ga"])
 
 
 class CreativeStressScenarioTests(unittest.TestCase):

--- a/tools/benchmarks/runtime_semantic_benchmark.py
+++ b/tools/benchmarks/runtime_semantic_benchmark.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SLO = {
+    "compile_latency_p95_ms": 85.0,
+    "tick_stability_p95_delta_ms": 1.6,
+    "gpu_p95_utilization": 0.85,
+    "cpu_p95_utilization": 0.8,
+    "memory_p95_mb": 2048.0,
+    "render_pipeline_p95_ms": 45.0,
+    "semantic_composite_min": 0.8,
+}
+
+PERFORMANCE_SUITES = [
+    "compile_latency",
+    "runtime_tick_stability",
+    "resource_envelope",
+]
+
+SEMANTIC_SUITES = [
+    "intent_to_field_faithfulness",
+    "temporal_continuity_quality",
+    "human_model_legibility",
+]
+
+
+def _percentile(values: list[float], percentile: float = 0.95) -> float | None:
+    if not values:
+        return None
+    sorted_values = sorted(values)
+    idx = max(0, int(len(sorted_values) * percentile) - 1)
+    return round(sorted_values[idx], 4)
+
+
+def _mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return round(statistics.fmean(values), 4)
+
+
+def run_benchmark(payload: dict[str, Any]) -> dict[str, Any]:
+    slo = {**DEFAULT_SLO, **payload.get("slo_targets", {})}
+
+    compile_latency_samples = payload.get("compile_latency_ms", [])
+    tick_delta_samples = payload.get("tick_delta_ms", [])
+    render_pipeline_samples = payload.get("render_pipeline_ms", [])
+    resource_samples = payload.get("resource_samples", [])
+
+    faithfulness_scores = payload.get("intent_faithfulness_scores", [])
+    temporal_scores = payload.get("temporal_continuity_scores", [])
+    legibility_scores = payload.get("legibility_scores", [])
+
+    compile_p95 = _percentile(compile_latency_samples)
+    tick_p95 = _percentile(tick_delta_samples)
+    render_p95 = _percentile(render_pipeline_samples)
+
+    gpu_samples = [float(row.get("gpu_utilization", 0.0)) for row in resource_samples]
+    cpu_samples = [float(row.get("cpu_utilization", 0.0)) for row in resource_samples]
+    memory_samples = [float(row.get("memory_mb", 0.0)) for row in resource_samples]
+
+    legibility_human = [float(row.get("human", 0.0)) for row in legibility_scores]
+    legibility_model = [float(row.get("model", 0.0)) for row in legibility_scores]
+    legibility_pairs = [
+        round((human * 0.6) + (model * 0.4), 4)
+        for human, model in zip(legibility_human, legibility_model)
+    ]
+
+    suite_results = {
+        "compile_latency": {
+            "mean_ms": _mean(compile_latency_samples),
+            "p95_ms": compile_p95,
+            "slo_target_p95_ms": slo["compile_latency_p95_ms"],
+            "pass": compile_p95 is not None and compile_p95 <= slo["compile_latency_p95_ms"],
+        },
+        "runtime_tick_stability": {
+            "mean_delta_ms": _mean(tick_delta_samples),
+            "p95_delta_ms": tick_p95,
+            "slo_target_p95_delta_ms": slo["tick_stability_p95_delta_ms"],
+            "pass": tick_p95 is not None and tick_p95 <= slo["tick_stability_p95_delta_ms"],
+        },
+        "resource_envelope": {
+            "gpu_p95": _percentile(gpu_samples),
+            "cpu_p95": _percentile(cpu_samples),
+            "memory_p95_mb": _percentile(memory_samples),
+            "targets": {
+                "gpu_p95_utilization": slo["gpu_p95_utilization"],
+                "cpu_p95_utilization": slo["cpu_p95_utilization"],
+                "memory_p95_mb": slo["memory_p95_mb"],
+            },
+            "pass": (
+                _percentile(gpu_samples) is not None
+                and _percentile(gpu_samples) <= slo["gpu_p95_utilization"]
+                and _percentile(cpu_samples) is not None
+                and _percentile(cpu_samples) <= slo["cpu_p95_utilization"]
+                and _percentile(memory_samples) is not None
+                and _percentile(memory_samples) <= slo["memory_p95_mb"]
+            ),
+        },
+        "intent_to_field_faithfulness": {
+            "mean_score": _mean(faithfulness_scores),
+            "pass": _mean(faithfulness_scores) is not None and _mean(faithfulness_scores) >= slo["semantic_composite_min"],
+        },
+        "temporal_continuity_quality": {
+            "mean_score": _mean(temporal_scores),
+            "pass": _mean(temporal_scores) is not None and _mean(temporal_scores) >= slo["semantic_composite_min"],
+        },
+        "human_model_legibility": {
+            "human_mean": _mean(legibility_human),
+            "model_mean": _mean(legibility_model),
+            "composite_mean": _mean(legibility_pairs),
+            "pass": _mean(legibility_pairs) is not None and _mean(legibility_pairs) >= slo["semantic_composite_min"],
+        },
+    }
+
+    expected_suites = PERFORMANCE_SUITES + SEMANTIC_SUITES
+    completed_suites = [name for name in expected_suites if suite_results[name]["pass"] or suite_results[name]["pass"] is False]
+    completion_rate = round(len(completed_suites) / len(expected_suites), 4) if expected_suites else 0.0
+
+    semantic_composite = _mean(
+        [
+            score
+            for score in [
+                suite_results["intent_to_field_faithfulness"]["mean_score"],
+                suite_results["temporal_continuity_quality"]["mean_score"],
+                suite_results["human_model_legibility"]["composite_mean"],
+            ]
+            if score is not None
+        ]
+    )
+
+    all_suites_green = all(suite_results[name]["pass"] for name in expected_suites)
+    render_gate = render_p95 is not None and render_p95 <= slo["render_pipeline_p95_ms"]
+    semantic_gate = semantic_composite is not None and semantic_composite >= slo["semantic_composite_min"]
+
+    return {
+        "performance_suites": {name: suite_results[name] for name in PERFORMANCE_SUITES},
+        "semantic_quality_suites": {name: suite_results[name] for name in SEMANTIC_SUITES},
+        "nightly_completion_rate": completion_rate,
+        "render_pipeline": {
+            "p95_ms": render_p95,
+            "slo_target_p95_ms": slo["render_pipeline_p95_ms"],
+            "pass": render_gate,
+        },
+        "semantic_composite_score": semantic_composite,
+        "promotion_gates": {
+            "canary": completion_rate == 1.0 and render_gate and semantic_gate,
+            "ga": completion_rate == 1.0 and render_gate and semantic_gate and all_suites_green,
+            "criteria": {
+                "nightly_completion_rate": 1.0,
+                "render_pipeline_p95_slo": slo["render_pipeline_p95_ms"],
+                "semantic_composite_min": slo["semantic_composite_min"],
+            },
+        },
+    }
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(description="Runtime performance + semantic quality benchmark")
+    parser.add_argument("--input", type=Path, required=True)
+    args = parser.parse_args()
+
+    with args.input.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    result = run_benchmark(payload)
+    print(json.dumps(result, indent=2))
+    return 0 if result["promotion_gates"]["canary"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tools/benchmarks/runtime_semantic_samples.sample.json
+++ b/tools/benchmarks/runtime_semantic_samples.sample.json
@@ -1,0 +1,20 @@
+{
+  "compile_latency_ms": [62.1, 66.4, 71.0, 73.3, 68.8, 64.9, 69.5, 72.2, 70.8, 67.4],
+  "tick_delta_ms": [0.8, 1.1, 1.0, 1.4, 1.2, 1.0, 0.9, 1.3, 1.2, 1.1],
+  "render_pipeline_ms": [31.2, 33.4, 35.1, 37.0, 38.2, 36.8, 34.9, 39.1, 40.0, 37.3],
+  "resource_samples": [
+    {"gpu_utilization": 0.61, "cpu_utilization": 0.52, "memory_mb": 1240},
+    {"gpu_utilization": 0.67, "cpu_utilization": 0.58, "memory_mb": 1310},
+    {"gpu_utilization": 0.71, "cpu_utilization": 0.62, "memory_mb": 1375},
+    {"gpu_utilization": 0.74, "cpu_utilization": 0.66, "memory_mb": 1420},
+    {"gpu_utilization": 0.69, "cpu_utilization": 0.61, "memory_mb": 1360}
+  ],
+  "intent_faithfulness_scores": [0.84, 0.86, 0.82, 0.88, 0.85],
+  "temporal_continuity_scores": [0.81, 0.83, 0.84, 0.8, 0.82],
+  "legibility_scores": [
+    {"human": 0.88, "model": 0.83},
+    {"human": 0.86, "model": 0.82},
+    {"human": 0.89, "model": 0.85},
+    {"human": 0.87, "model": 0.84}
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide automated performance and semantic-quality benchmarks to enforce release gates (canary/GA) for the runtime and field visualization pipeline.
- Ensure the nightly benchmark completion rate is 100%, the P95 render pipeline stays within SLO, and the legibility/faithfulness composite meets the 0.80 threshold before promotion.

### Description
- Add `tools/benchmarks/runtime_semantic_benchmark.py` implementing performance suites (`compile_latency`, `runtime_tick_stability`, `resource_envelope`) and semantic suites (`intent_to_field_faithfulness`, `temporal_continuity_quality`, `human_model_legibility`) and computing promotion gates (`canary` and `ga`).
- Add sample fixture `tools/benchmarks/runtime_semantic_samples.sample.json` that exercises all suites and targets SLOs.
- Extend `api_gateway/test_runtime_quality.py` to import the new benchmark runner and add unit tests covering positive and negative gate behavior via `run_benchmark`.
- Update `README.md` validation section with the new benchmark CLI command and provide default SLOs and criteria used by the runner.

### Testing
- Ran the runtime+semantic benchmark CLI with the sample: `python3 tools/benchmarks/runtime_semantic_benchmark.py --input tools/benchmarks/runtime_semantic_samples.sample.json`, which produced a JSON result where `promotion_gates.canary` and `promotion_gates.ga` evaluated to true (benchmark passed).
- Ran the test suite: `python3 -m pytest -q api_gateway/test_runtime_quality.py`, which completed successfully with `25 passed` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0777766608320a751742669f54cd8)