### PR TITLE
Add LCL middle-brain pipeline with runtime governor and compiler expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,9 @@ Future directions:
 - **Signed Proxy Requests** ✅  
   Implemented HMAC request signing + timestamp skew checks + nonce replay protection for `/api/v1/proxy/fetch` (configurable via environment flags).
 
+- **LCL Middle-Brain Pipeline** ✅  
+  Added a structured control path (`Intent Interpreter` → `Formation Retriever` → `Morphology Compiler` → `Runtime Governor`) with shape/scene/motion compilers and runtime safety clamping.
+
 - **Proxy Key Rotation and Tenant Scope**  
   Add key identifiers (`kid`) with dual-key rotation windows and optional tenant-scoped signing secrets.
 

--- a/am_control_handler.js
+++ b/am_control_handler.js
@@ -1,182 +1,215 @@
 /**
- * Control Handler v3.0
- * Replace hard-coded FSM triggers with dynamic light control
+ * Control Handler v3.1
+ * Middle-brain orchestration between user request and light runtime.
+ *
+ * Pipeline:
+ * User Request -> Intent Interpreter -> Formation Retriever -> Morphology Compiler -> Runtime Governor -> Kernel
  */
 
-class ControlHandlerV3 {
-    constructor(kernel, shapeCo compiler, evaluator) {
-        this.Kernel = kernel;
-        this.ShapeCompiler = shapeCompiler;
-        this.Evaluator = evaluator;
-        this.currentControl = null;
-    }
+class RuntimeGovernor {
+  constructor(options = {}) {
+    this.defaults = {
+      maxTargets: 14000,
+      maxParticleEnergy: 1.4,
+      maxLuminance: 1.0,
+      maxTurbulence: 0.85,
+      ...options,
+    };
+  }
 
-    /**
-     * Main entry: handle user light request (เป็นฟังก์ชันที่เรียกเมื่อผู้ใช้พูด)
-     */
-    async handleUserLightRequest(userText) {
-        try {
-            // ขั้นที่ 1: Intent Interpretation
-            const intendPacket = await this.IntentInterpreter.parse_user_request(userText);
-            console.log("[Intent]", intendPacket);
+  sanitize(packet = {}, runtimeControl = {}) {
+    const constraints = packet.constraints || {};
+    const safety = packet.safety || {};
 
-            // ขั้นที่ 2: Formation Retrieval + Morphology Compilation
-            const runtimeControl = this.FormationRetriever
-                .compile_morphology_to_runtime_control(intendPacket);
-            console.log("[Runtime Control]", runtimeControl);
+    const limitTargets = Number.isFinite(constraints.max_targets)
+      ? constraints.max_targets
+      : (Number.isFinite(constraints.max_particles) ? constraints.max_particles : this.defaults.maxTargets);
 
-            // ขั้นที่ 3: Apply Control
-            this.applyRuntimeControl(intendPacket, runtimeControl);
+    const maxTargets = clamp(limitTargets, 100, this.defaults.maxTargets);
+    const maxParticleEnergy = clamp(
+      Number.isFinite(safety.max_particle_energy) ? safety.max_particle_energy : this.defaults.maxParticleEnergy,
+      0.2,
+      this.defaults.maxParticleEnergy,
+    );
 
-            // ขั้นที่ 4: Start Evaluation Loop (closed-loop)
-            this.startEvaluationLoop(intendPacket);
+    const fieldRecipe = runtimeControl.field_recipe || {};
+    fieldRecipe.coherence_target = clamp(fieldRecipe.coherence_target ?? packet.motion?.coherence_target ?? 0.6, 0, 1);
+    fieldRecipe.turbulence = clamp(fieldRecipe.turbulence ?? packet.field?.turbulence ?? 0.2, 0, this.defaults.maxTurbulence);
+    fieldRecipe.flow_magnitude = clamp(fieldRecipe.flow_magnitude ?? 0.4, 0, 1);
+    fieldRecipe.vorticity = clamp(fieldRecipe.vorticity ?? 0, -1, 1);
 
-        } catch (error) {
-            console.error("[ControlHandler Error]", error);
-        }
-    }
+    const visualRecipe = runtimeControl.visual_recipe || {};
+    visualRecipe.glow_strength = clamp(visualRecipe.glow_strength ?? packet.optics?.glow ?? 0.6, 0, 1);
+    visualRecipe.luminance = clamp(visualRecipe.luminance ?? packet.optics?.luminance ?? 0.8, 0, this.defaults.maxLuminance);
 
-    /**
-     * Apply LCL control packet to Kernel
-     */
-    applyRuntimeControl(intendPacket, runtimeControl) {
-        const morphology = intendPacket.morphology;
-        const motion = intendPacket.motion;
-        const optics = intendPacket.optics;
-        const fieldRecipe = runtimeControl.field_recipe;
+    runtimeControl.constraints = {
+      ...runtimeControl.constraints,
+      max_targets: maxTargets,
+      max_particle_energy: maxParticleEnergy,
+    };
+    runtimeControl.field_recipe = fieldRecipe;
+    runtimeControl.visual_recipe = visualRecipe;
 
-        // ตั้ง render mode
-        const renderMode = runtimeControl.render_mode;
-
-        // สร้าง target field ตามรูปทรง
-        if (renderMode === "particle_sdf_proxy") {
-            this.Kernel.targetField = this.ShapeCompiler.compileShapeField(intendPacket);
-        } else if (renderMode === "particle_shatter") {
-            // ใช้สมการ fracture
-            this.Kernel.targetField = this.ShapeCompiler._generateFracture(0, 12000, intendPacket);
-        }
-
-        // ตั้ง physics parameters
-        this.Kernel.coherence = fieldRecipe.coherence_target;
-        this.Kernel.turbulence = fieldRecipe.turbulence;
-        this.Kernel.flowMag = fieldRecipe.flow_magnitude || 0.5;
-        this.Kernel.vorticity = fieldRecipe.vorticity || 0.0;
-
-        // ตั้ง timing
-        const timing = runtimeControl.timing_envelope;
-        this.Kernel.attackMs = timing.attack_ms;
-        this.Kernel.holdMs = timing.hold_ms;
-        this.Kernel.releaseMs = timing.release_ms;
-
-        // ตั้ง visual
-        const visual = runtimeControl.visual_recipe;
-        this.Kernel.primaryColor = visual.primary_color;
-        this.Kernel.secondaryColor = visual.secondary_color;
-        this.Kernel.glowStrength = visual.glow_strength;
-        this.Kernel.luminance = visual.luminance;
-
-        // Trigger FSM transition (smooth)
-        this.Kernel.transitionTo("MANIFEST", {
-            morphology,
-            motion,
-            optics
-        });
-
-        this.currentControl = intendPacket;
-    }
-
-    /**
-     * Closed-loop evaluation: ทุก N เฟรม ตรวจสอบและปรับแต่ง
-     */
-    startEvaluationLoop(intendPacket) {
-        let frameCounter = 0;
-        const evaluationInterval = 30;  // ตรวจทุก 30 เฟรม
-
-        const evalLoop = () => {
-            frameCounter++;
-
-            if (frameCounter % evaluationInterval === 0) {
-                // Capture framebuffer
-                const framebuffer = this.Kernel.captureFramebuffer();
-
-                // Evaluate
-                const metrics = this.Evaluator.evaluate_light_manifestation(
-                    framebuffer,
-                    intendPacket.intent.user_request,
-                    intendPacket
-                );
-
-                console.log("[Evaluation]", metrics);
-
-                // Suggest adjustments
-                const adjustments = this.Evaluator.suggest_runtime_adjustments(metrics);
-
-                if (Object.keys(adjustments).length > 0) {
-                    console.log("[Adjustments]", adjustments);
-                    this.applyAdjustments(adjustments);
-                }
-            }
-
-            // Continue loop
-            if (this.Kernel.isManifesting) {
-                requestAnimationFrame(evalLoop);
-            }
-        };
-
-        requestAnimationFrame(evalLoop);
-    }
-
-    /**
-     * Apply runtime adjustments from evaluator
-     */
-    applyAdjustments(adjustments) {
-        if (adjustments.coherence !== undefined) {
-            this.Kernel.coherence = Math.max(0, Math.min(1, 
-                this.Kernel.coherence + adjustments.coherence
-            ));
-        }
-
-        if (adjustments.glow_strength !== undefined) {
-            this.Kernel.glowStrength = Math.max(0, Math.min(1,
-                this.Kernel.glowStrength + adjustments.glow_strength
-            ));
-        }
-
-        if (adjustments.luminance !== undefined) {
-            this.Kernel.luminance = Math.max(0, Math.min(1,
-                this.Kernel.luminance + adjustments.luminance
-            ));
-        }
-
-        if (adjustments.turbulence !== undefined) {
-            this.Kernel.turbulence = Math.max(0, Math.min(0.8,
-                this.Kernel.turbulence + adjustments.turbulence
-            ));
-        }
-
-        if (adjustments.flow_magnitude !== undefined) {
-            this.Kernel.flowMag = Math.max(0, Math.min(1,
-                this.Kernel.flowMag + adjustments.flow_magnitude
-            ));
-        }
-
-        if (adjustments.noise_level !== undefined) {
-            this.Kernel.noiseLevel = Math.max(0, Math.min(1,
-                this.Kernel.noiseLevel + adjustments.noise_level
-            ));
-        }
-    }
+    return runtimeControl;
+  }
 }
 
-// Integration with existing code
-// ในไฟล์ index.html เพิ่ม:
-/*
-const controlHandler = new ControlHandlerV3(Kernel, ShapeCompiler, Evaluator);
+class ControlHandlerV3 {
+  constructor({ kernel, shapeCompiler, evaluator, intentInterpreter, formationRetriever, runtimeGovernor } = {}) {
+    this.kernel = kernel;
+    this.shapeCompiler = shapeCompiler;
+    this.evaluator = evaluator;
+    this.intentInterpreter = intentInterpreter;
+    this.formationRetriever = formationRetriever;
+    this.runtimeGovernor = runtimeGovernor || new RuntimeGovernor();
 
-// เมื่อผู้ใช้พูด (จาก speech API หรือ text input)
-userInput.addEventListener("submit", async (e) => {
-    e.preventDefault();
-    const userText = userInput.value;
-    await controlHandler.handleUserLightRequest(userText);
-});
-*/
+    this.currentControl = null;
+    this.loopActive = false;
+  }
+
+  /**
+   * Main entry: process user request and drive runtime through LCL packet.
+   */
+  async handleUserLightRequest(userText) {
+    if (!this.intentInterpreter || !this.formationRetriever || !this.kernel || !this.shapeCompiler) {
+      throw new Error("ControlHandlerV3 missing required dependencies");
+    }
+
+    const intentPacket = await this.intentInterpreter.parse_user_request(userText);
+    const runtimeControl = this.formationRetriever.compile_morphology_to_runtime_control(intentPacket);
+    const safeRuntimeControl = this.runtimeGovernor.sanitize(intentPacket, runtimeControl);
+
+    this.applyRuntimeControl(intentPacket, safeRuntimeControl);
+
+    if (intentPacket.reference?.evaluation_mode !== "off" && this.evaluator) {
+      this.startEvaluationLoop(intentPacket);
+    }
+
+    return { intentPacket, runtimeControl: safeRuntimeControl };
+  }
+
+  applyRuntimeControl(intentPacket, runtimeControl) {
+    const renderMode = runtimeControl.render_mode || "shape_field";
+    const maxTargets = runtimeControl.constraints?.max_targets || 12000;
+
+    this.kernel.targetType = intentPacket.morphology?.family || renderMode;
+    this.kernel.targetField = this.compileTargetField(renderMode, intentPacket, maxTargets);
+
+    const fieldRecipe = runtimeControl.field_recipe || {};
+    this.kernel.coherence = fieldRecipe.coherence_target;
+    this.kernel.turbulence = fieldRecipe.turbulence;
+    this.kernel.flowMag = fieldRecipe.flow_magnitude;
+    this.kernel.vorticity = fieldRecipe.vorticity;
+
+    const timing = runtimeControl.timing_envelope || {};
+    this.kernel.attackMs = timing.attack_ms ?? 900;
+    this.kernel.holdMs = timing.hold_ms ?? 1800;
+    this.kernel.releaseMs = timing.release_ms ?? 1200;
+
+    const visual = runtimeControl.visual_recipe || {};
+    this.kernel.primaryColor = visual.primary_color || "#FFFFFF";
+    this.kernel.secondaryColor = visual.secondary_color || "#888888";
+    this.kernel.glowStrength = visual.glow_strength ?? 0.6;
+    this.kernel.luminance = visual.luminance ?? 0.8;
+
+    this.applyMotionBias(intentPacket.motion_bias || runtimeControl.motion_bias || {});
+
+    if (typeof this.kernel.transitionTo === "function") {
+      this.kernel.transitionTo("MANIFEST", {
+        intent: intentPacket.intent,
+        morphology: intentPacket.morphology,
+        motion: intentPacket.motion,
+        optics: intentPacket.optics,
+      });
+    }
+
+    this.currentControl = intentPacket;
+  }
+
+  compileTargetField(renderMode, control, maxTargets) {
+    switch (renderMode) {
+      case "shape_field":
+      case "particle_sdf_proxy":
+        return this.shapeCompiler.compileShapeField(control, maxTargets);
+      case "scene_field":
+      case "radiance_proxy":
+      case "particle_volumetric":
+        return this.shapeCompiler.compileSceneField(control, maxTargets);
+      case "motion_field":
+      case "particle_shatter":
+        return this.shapeCompiler.compileMotionField(control, maxTargets);
+      default:
+        return this.shapeCompiler.compileShapeField(control, maxTargets);
+    }
+  }
+
+  applyMotionBias(motionBias) {
+    if (!motionBias || !this.kernel) return;
+
+    this.kernel.rhythmHz = clamp(motionBias.rhythm_hz ?? this.kernel.rhythmHz ?? 0.2, 0.05, 4);
+    this.kernel.attackBias = clamp(motionBias.attack ?? this.kernel.attackBias ?? 0.5, 0, 1);
+    this.kernel.settlingBias = clamp(motionBias.settling ?? this.kernel.settlingBias ?? 0.5, 0, 1);
+    this.kernel.driftBias = clamp(motionBias.drift ?? this.kernel.driftBias ?? 0.1, 0, 1);
+    this.kernel.collapseTendency = clamp(motionBias.collapse_tendency ?? this.kernel.collapseTendency ?? 0.05, 0, 1);
+  }
+
+  startEvaluationLoop(intentPacket) {
+    if (this.loopActive) return;
+
+    const evaluationInterval = 30;
+    let frameCounter = 0;
+    this.loopActive = true;
+
+    const evalLoop = () => {
+      if (!this.kernel?.isManifesting) {
+        this.loopActive = false;
+        return;
+      }
+
+      frameCounter += 1;
+      if (frameCounter % evaluationInterval === 0 && typeof this.kernel.captureFramebuffer === "function") {
+        const framebuffer = this.kernel.captureFramebuffer();
+        const metrics = this.evaluator.evaluate_light_manifestation(
+          framebuffer,
+          intentPacket.intent?.user_request || "",
+          intentPacket,
+        );
+        const adjustments = this.evaluator.suggest_runtime_adjustments(metrics);
+        this.applyAdjustments(adjustments);
+      }
+
+      requestAnimationFrame(evalLoop);
+    };
+
+    requestAnimationFrame(evalLoop);
+  }
+
+  applyAdjustments(adjustments = {}) {
+    if (adjustments.coherence !== undefined) {
+      this.kernel.coherence = clamp(this.kernel.coherence + adjustments.coherence, 0, 1);
+    }
+    if (adjustments.glow_strength !== undefined) {
+      this.kernel.glowStrength = clamp(this.kernel.glowStrength + adjustments.glow_strength, 0, 1);
+    }
+    if (adjustments.luminance !== undefined) {
+      this.kernel.luminance = clamp(this.kernel.luminance + adjustments.luminance, 0, 1);
+    }
+    if (adjustments.turbulence !== undefined) {
+      this.kernel.turbulence = clamp(this.kernel.turbulence + adjustments.turbulence, 0, 0.85);
+    }
+    if (adjustments.flow_magnitude !== undefined) {
+      this.kernel.flowMag = clamp(this.kernel.flowMag + adjustments.flow_magnitude, 0, 1);
+    }
+    if (adjustments.noise_level !== undefined) {
+      this.kernel.noiseLevel = clamp((this.kernel.noiseLevel || 0) + adjustments.noise_level, 0, 1);
+    }
+  }
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, Number.isFinite(value) ? value : min));
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { ControlHandlerV3, RuntimeGovernor };
+}

--- a/am_formation_retriever.py
+++ b/am_formation_retriever.py
@@ -183,13 +183,7 @@ class FormationRetrievalSystem:
         """
         
         # เก็บ archetype ฐาน
-        archetype_id = intent_packet["reference"]["motion_archetype_id"]
-        archetype = self.retrieve_archetype(
-            f"{intent_packet['motion']['archetype']}".replace("_", "/").
-            replace("spiral_convergence", "spiral_convergence").
-            replace("radial_bloom", "emergence/nebula_birth")
-            # simplified mapping
-        )
+        archetype = self._resolve_archetype(intent_packet)
         
         # ดัดแปลง base config ตามมอร์ฟโลยีและออปติกส์
         runtime_control = {
@@ -207,7 +201,8 @@ class FormationRetrievalSystem:
                 intent_packet["optics"],
                 intent_packet["morphology"]
             ),
-            "constraints": intent_packet["constraints"],
+            "constraints": intent_packet.get("constraints", {}),
+            "motion_bias": intent_packet.get("motion_bias", {}),
             "render_mode": self._select_render_mode(
                 intent_packet["intent"]["mode"],
                 intent_packet["morphology"]
@@ -216,6 +211,24 @@ class FormationRetrievalSystem:
         
         return runtime_control
     
+    def _resolve_archetype(self, intent_packet: Dict[str, Any]) -> FormationArchetype:
+        """Map motion archetype labels to canonical Book of Formation IDs."""
+
+        requested = intent_packet.get("reference", {}).get("motion_archetype_id")
+        if requested and requested in self.book_of_formation:
+            return self.book_of_formation[requested]
+
+        motion = intent_packet.get("motion", {}).get("archetype", "stabilization")
+        mapping = {
+            "emergence": "emergence/nebula_birth",
+            "stabilization": "stabilization/sphere_equilibrium",
+            "dissolution": "dissolution/light_fade",
+            "reasoning": "reasoning/spiral_convergence",
+            "error": "error/fracture_shell",
+        }
+        canonical = mapping.get(motion, "stabilization/sphere_equilibrium")
+        return self.book_of_formation.get(canonical, self.book_of_formation["stabilization/sphere_equilibrium"])
+
     def _adapt_field_parameters(self, 
                                base_config: Dict,
                                morphology: Dict,
@@ -273,14 +286,15 @@ class FormationRetrievalSystem:
         
         family = morphology.get("family", "")
         
-        if "spiral" in family or "convergence" in family:
-            return "particle_sdf_proxy"
-        elif "fracture" in family:
-            return "particle_shatter"
-        elif "nebula" in family or "cloud" in family:
-            return "particle_volumetric"
-        else:
-            return "particle_sdf_proxy"  # default
+        if intent_mode in {"scene", "world"}:
+            return "scene_field"
+        if intent_mode in {"motion", "feedback"}:
+            return "motion_field"
+        if "fracture" in family:
+            return "motion_field"
+        if "nebula" in family or "cloud" in family:
+            return "scene_field"
+        return "shape_field"
 
 
 # Example usage

--- a/am_intent_interpreter.py
+++ b/am_intent_interpreter.py
@@ -113,19 +113,32 @@ class IntentInterpreter:
                 "user_request": user_text,
                 "primary_goal": intent_type.value,
                 "abstraction_level": analysis.get("abstraction_level", "symbolic"),
-                "mode": "auto"  # ปล่อยให้ runtime ตัดสิน
+                "mode": "shape"  # routed by controller render strategy
             },
             "morphology": morphology,
             "motion": motion,
             "optics": optics,
-            "field_parameters": {
+            "field": {
                 "coherence": 0.65,
                 "turbulence": 0.15,
                 "flow_magnitude": 0.5,
                 "noise_level": 0.2,
                 "vorticity": 0.0
             },
+            "motion_bias": {
+                "archetype": motion.get("archetype", "stabilization"),
+                "rhythm_hz": motion.get("tempo_hz", 0.2),
+                "attack": 0.7 if motion.get("tempo_hz", 0.2) < 0.4 else 0.5,
+                "settling": 0.82,
+                "drift": 0.11,
+                "collapse_tendency": 0.03 if intent_type != IntentType.MANIFEST_ERROR else 0.22
+            },
+            "safety": {
+                "max_targets": 14000,
+                "max_particle_energy": 1.4
+            },
             "constraints": {
+                "max_targets": 12000,
                 "max_particles": 12000,
                 "max_energy": 1.4,
                 "max_brightness": 0.95,

--- a/am_shape_compiler.js
+++ b/am_shape_compiler.js
@@ -1,220 +1,228 @@
 /**
  * Shape Compiler
- * แปลง shape grammar → field of particles
- * Direct equation-based generation
+ * Equation-driven field compilers for morphology / scene / motion targets.
  */
 
 class ShapeCompiler {
-    constructor(canvasWidth, canvasHeight) {
-        this.W = canvasWidth;
-        this.H = canvasHeight;
-        this.CX = canvasWidth / 2;
-        this.CY = canvasHeight / 2;
+  constructor(canvasWidth, canvasHeight) {
+    this.W = canvasWidth;
+    this.H = canvasHeight;
+    this.CX = canvasWidth / 2;
+    this.CY = canvasHeight / 2;
+  }
+
+  compileShapeField(control, maxTargets) {
+    const pts = [];
+    const n = Math.max(200, maxTargets || control.constraints?.max_targets || control.constraints?.max_particles || 12000);
+    const shape = control.morphology?.family || "sphere";
+
+    for (let i = 0; i < n; i += 1) {
+      let pos;
+      switch (shape) {
+        case "sphere":
+          pos = this._generateSphere(i, n, control);
+          break;
+        case "spiral_vortex":
+        case "spiral_convergence":
+          pos = this._generateSpiral(i, n, control);
+          break;
+        case "flower_shell":
+          pos = this._generateFlower(i, n, control);
+          break;
+        case "wave_ribbon":
+          pos = this._generateWaveRibbon(i, n, control);
+          break;
+        case "nebula_cloud":
+          pos = this._generateNebula(i, n, control);
+          break;
+        case "fracture_shell":
+          pos = this._generateFracture(i, n, control);
+          break;
+        case "torus":
+          pos = this._generateTorus(i, n, control);
+          break;
+        default:
+          pos = this._generateSphere(i, n, control);
+      }
+
+      if (pos?.x !== undefined && pos?.y !== undefined) {
+        pts.push({
+          x: pos.x,
+          y: pos.y,
+          color: pos.color || control.optics?.primary_colors?.[0] || "#FFFFFF",
+          energy: pos.energy || 1,
+        });
+      }
     }
 
-    /**
-     * Main entry point: compile shape family + parameters → particle field
-     */
-    compileShapeField(control) {
-        const pts = [];
-        const n = control.constraints?.max_particles || 12000;
-        const shape = control.morphology?.family || "sphere";
+    return pts;
+  }
 
-        for (let i = 0; i < n; i++) {
-            let pos = {};
+  compileSceneField(control, maxTargets) {
+    const local = {
+      ...control,
+      morphology: {
+        ...(control.morphology || {}),
+        family: control.morphology?.family || "nebula_cloud",
+      },
+    };
+    const pts = this.compileShapeField(local, maxTargets);
+    const horizon = this.CY + this.H * 0.16;
 
-            // เลือกสมการตามรูปทรง
-            switch (shape) {
-                case "sphere":
-                    pos = this._generateSphere(i, n, control);
-                    break;
-                case "spiral_vortex":
-                    pos = this._generateSpiral(i, n, control);
-                    break;
-                case "flower_shell":
-                    pos = this._generateFlower(i, n, control);
-                    break;
-                case "wave_ribbon":
-                    pos = this._generateWaveRibbon(i, n, control);
-                    break;
-                case "nebula_cloud":
-                    pos = this._generateNebula(i, n, control);
-                    break;
-                case "fracture_shell":
-                    pos = this._generateFracture(i, n, control);
-                    break;
-                case "torus":
-                    pos = this._generateTorus(i, n, control);
-                    break;
-                default:
-                    pos = this._generateSphere(i, n, control);
-            }
+    return pts.map((point, index) => {
+      const band = index % 3;
+      const yOffset = band === 0 ? -40 : (band === 1 ? 0 : 40);
+      return {
+        ...point,
+        x: point.x,
+        y: point.y * 0.6 + horizon * 0.4 + yOffset,
+        energy: Math.max(0.2, point.energy * 0.8),
+      };
+    });
+  }
 
-            if (pos.x !== undefined && pos.y !== undefined) {
-                pts.push({
-                    x: pos.x,
-                    y: pos.y,
-                    color: pos.color || control.optics?.primary_colors?.[0] || "#FFFFFF",
-                    energy: pos.energy || 1.0
-                });
-            }
-        }
+  compileMotionField(control, maxTargets) {
+    const n = Math.max(200, maxTargets || 8000);
+    const pts = [];
+    const flowMode = control.motion?.flow_mode || control.motion_bias?.archetype || "drift";
 
-        return pts;
+    for (let i = 0; i < n; i += 1) {
+      const t = i / n;
+      const baseAngle = t * Math.PI * 2;
+      let x = this.CX;
+      let y = this.CY;
+
+      if (flowMode.includes("spiral")) {
+        const r = 20 + t * Math.min(this.W, this.H) * 0.24;
+        x += Math.cos(baseAngle * 8) * r;
+        y += Math.sin(baseAngle * 8) * r * 0.7;
+      } else if (flowMode.includes("radial")) {
+        const r = Math.random() * Math.min(this.W, this.H) * 0.3;
+        x += Math.cos(baseAngle) * r;
+        y += Math.sin(baseAngle) * r;
+      } else {
+        x += (Math.random() - 0.5) * this.W * 0.75;
+        y += Math.sin(baseAngle * 12) * 40 + (Math.random() - 0.5) * 18;
+      }
+
+      pts.push({
+        x,
+        y,
+        color: this._gradientColor(t, control.optics || {}),
+        energy: 0.4 + Math.random() * 0.6,
+      });
     }
 
-    // ============== SHAPE GENERATORS ==============
+    return pts;
+  }
 
-    _generateSphere(i, n, control) {
-        const u = (Math.random() * Math.PI * 2);
-        const v = (Math.random() * Math.PI);
-        const r = Math.min(this.W, this.H) * 0.18;
+  _generateSphere(i, n, control) {
+    const u = Math.random() * Math.PI * 2;
+    const v = Math.random() * Math.PI;
+    const r = Math.min(this.W, this.H) * 0.18;
+    return {
+      x: this.CX + Math.cos(u) * Math.sin(v) * r,
+      y: this.CY + Math.cos(v) * r,
+      color: control.optics?.primary_colors?.[0],
+      energy: 1,
+    };
+  }
 
-        const x = this.CX + Math.cos(u) * Math.sin(v) * r;
-        const y = this.CY + Math.cos(v) * r;
+  _generateSpiral(i, n, control) {
+    const t = (i / n) * 10 * Math.PI;
+    const r = 12 + i * 0.03;
+    const twist = control.morphology?.complexity || 0.6;
+    return {
+      x: this.CX + Math.cos(t) * r,
+      y: this.CY + Math.sin(t) * r * 0.55 * (0.8 + twist * 0.4),
+      color: this._lerpColor(control.optics?.primary_colors?.[0], control.optics?.secondary_colors?.[0], i / n),
+      energy: 1 - (i / n) * 0.3,
+    };
+  }
 
-        return {
-            x, y,
-            color: control.optics?.primary_colors?.[0],
-            energy: 1.0
-        };
+  _generateFlower(i, n, control) {
+    const petalCount = control.morphology?.symmetry || 5;
+    const petalPhase = ((i % (n / petalCount)) / (n / petalCount)) * Math.PI * 2;
+    const r = 50 + 30 * Math.cos(petalPhase);
+    const angle = (Math.floor(i / (n / petalCount)) / petalCount) * Math.PI * 2 + petalPhase;
+    return {
+      x: this.CX + Math.cos(angle) * r,
+      y: this.CY + Math.sin(angle) * r,
+      color: control.optics?.primary_colors?.[0],
+      energy: Math.abs(Math.sin(petalPhase)),
+    };
+  }
+
+  _generateWaveRibbon(i, n, control) {
+    const progress = i / n;
+    const waveFreq = control.morphology?.complexity || 0.5;
+    return {
+      x: this.CX - this.W * 0.4 + progress * this.W * 0.8,
+      y: this.CY + Math.sin(progress * Math.PI * waveFreq * 4) * 40,
+      color: this._gradientColor(progress, control.optics || {}),
+      energy: Math.sin(progress * Math.PI),
+    };
+  }
+
+  _generateNebula() {
+    const angle = Math.random() * Math.PI * 2;
+    const radius = (Math.random() ** 0.5) * 150;
+    return {
+      x: this.CX + Math.cos(angle) * radius,
+      y: this.CY + Math.sin(angle) * radius,
+      energy: Math.random() * 0.8 + 0.2,
+    };
+  }
+
+  _generateFracture(i, n, control) {
+    const angle = Math.random() * Math.PI * 2;
+    const speed = Math.random() * 0.5 + 0.5;
+    const radius = Math.random() * 80;
+    return {
+      x: this.CX + Math.cos(angle) * radius * speed,
+      y: this.CY + Math.sin(angle) * radius * speed,
+      color: control.optics?.primary_colors?.[0],
+      energy: 1 - (i / n) * 0.5,
+    };
+  }
+
+  _generateTorus() {
+    const major = 80;
+    const minor = 30;
+    const u = Math.random() * Math.PI * 2;
+    const v = Math.random() * Math.PI * 2;
+    return {
+      x: this.CX + (major + minor * Math.cos(v)) * Math.cos(u),
+      y: this.CY + (major + minor * Math.cos(v)) * Math.sin(u),
+      energy: Math.abs(Math.sin(v)),
+    };
+  }
+
+  _lerpColor(hex1, hex2, t) {
+    const c1 = this._hexToRgb(hex1 || "#FFFFFF");
+    const c2 = this._hexToRgb(hex2 || hex1 || "#FFFFFF");
+    return `rgb(${Math.round(c1.r + (c2.r - c1.r) * t)},${Math.round(c1.g + (c2.g - c1.g) * t)},${Math.round(c1.b + (c2.b - c1.b) * t)})`;
+  }
+
+  _gradientColor(progress, optics) {
+    if (!optics?.primary_colors?.length) return "#FFFFFF";
+    return this._lerpColor(optics.primary_colors[0], optics.secondary_colors?.[0] || optics.primary_colors[0], progress);
+  }
+
+  _hexToRgb(hex) {
+    if (hex.startsWith("rgb")) {
+      const [r, g, b] = hex.match(/\d+/g).map(Number);
+      return { r, g, b };
     }
-
-    _generateSpiral(i, n, control) {
-        const t = (i / n) * 10 * Math.PI;
-        const r = 12 + i * 0.03;
-        const twist = control.morphology?.complexity || 0.6;
-
-        const x = this.CX + Math.cos(t) * r;
-        const y = this.CY + Math.sin(t) * r * 0.55 * (0.8 + twist * 0.4);
-
-        return {
-            x, y,
-            color: this._lerpColor(
-                control.optics?.primary_colors?.[0],
-                control.optics?.secondary_colors?.[0],
-                i / n
-            ),
-            energy: 1.0 - (i / n) * 0.3
-        };
-    }
-
-    _generateFlower(i, n, control) {
-        const petal_count = control.morphology?.symmetry || 5;
-        const t = (i / n) * Math.PI * 2;
-        const petal_phase = (i % (n / petal_count)) / (n / petal_count) * Math.PI * 2;
-
-        const r = 50 + 30 * Math.cos(petal_phase);
-        const angle = (Math.floor(i / (n / petal_count)) / petal_count) * Math.PI * 2 + petal_phase;
-
-        const x = this.CX + Math.cos(angle) * r;
-        const y = this.CY + Math.sin(angle) * r;
-
-        return {
-            x, y,
-            color: control.optics?.primary_colors?.[0],
-            energy: Math.sin(petal_phase)
-        };
-    }
-
-    _generateWaveRibbon(i, n, control) {
-        const progress = (i / n);
-        const wave_freq = control.morphology?.complexity || 0.5;
-
-        const x = this.CX - this.W * 0.4 + progress * this.W * 0.8;
-        const wave_y = Math.sin(progress * Math.PI * wave_freq * 4) * 40;
-        const y = this.CY + wave_y;
-
-        return {
-            x, y,
-            color: this._gradientColor(progress, control.optics),
-            energy: Math.sin(progress * Math.PI)
-        };
-    }
-
-    _generateNebula(i, n, control) {
-        // Perlin noise-like distribution (simplified)
-        const angle = Math.random() * Math.PI * 2;
-        const radius = Math.random() ** 0.5 * 150;  // concentrated toward center
-
-        const x = this.CX + Math.cos(angle) * radius;
-        const y = this.CY + Math.sin(angle) * radius;
-
-        return {
-            x, y,
-            color: control.optics?.secondary_colors?.[0],
-            energy: Math.random() * 0.8 + 0.2
-        };
-    }
-
-    _generateFracture(i, n, control) {
-        const burst_angle = Math.random() * Math.PI * 2;
-        const burst_speed = Math.random() * 0.5 + 0.5;
-        const fragment_radius = Math.random() * 80;
-
-        const x = this.CX + Math.cos(burst_angle) * fragment_radius * burst_speed;
-        const y = this.CY + Math.sin(burst_angle) * fragment_radius * burst_speed;
-
-        return {
-            x, y,
-            color: control.optics?.primary_colors?.[0],
-            energy: 1.0 - (i / n) * 0.5
-        };
-    }
-
-    _generateTorus(i, n, control) {
-        const major_radius = 80;
-        const minor_radius = 30;
-        const u = Math.random() * Math.PI * 2;
-        const v = Math.random() * Math.PI * 2;
-
-        const x = this.CX + (major_radius + minor_radius * Math.cos(v)) * Math.cos(u);
-        const y = this.CY + (major_radius + minor_radius * Math.cos(v)) * Math.sin(u);
-
-        return {
-            x, y,
-            color: control.optics?.primary_colors?.[0],
-            energy: Math.sin(v)
-        };
-    }
-
-    // ============== HELPER METHODS ==============
-
-    _lerpColor(hex1, hex2, t) {
-        const c1 = this._hexToRgb(hex1);
-        const c2 = this._hexToRgb(hex2);
-
-        const r = Math.round(c1.r + (c2.r - c1.r) * t);
-        const g = Math.round(c1.g + (c2.g - c1.g) * t);
-        const b = Math.round(c1.b + (c2.b - c1.b) * t);
-
-        return `rgb(${r},${g},${b})`;
-    }
-
-    _gradientColor(progress, optics) {
-        if (!optics?.primary_colors?.length) return "#FFFFFF";
-        return this._lerpColor(
-            optics.primary_colors[0],
-            optics.secondary_colors?.[0] || optics.primary_colors[0],
-            progress
-        );
-    }
-
-    _hexToRgb(hex) {
-        if (hex.startsWith("rgb")) {
-            const match = hex.match(/\d+/g);
-            return { r: parseInt(match[0]), g: parseInt(match[1]), b: parseInt(match[2]) };
-        }
-        hex = hex.replace("#", "");
-        return {
-            r: parseInt(hex.substring(0, 2), 16),
-            g: parseInt(hex.substring(2, 4), 16),
-            b: parseInt(hex.substring(4, 6), 16)
-        };
-    }
+    const normalized = hex.replace("#", "");
+    return {
+      r: parseInt(normalized.substring(0, 2), 16),
+      g: parseInt(normalized.substring(2, 4), 16),
+      b: parseInt(normalized.substring(4, 6), 16),
+    };
+  }
 }
 
-// Export
-if (typeof module !== 'undefined' && module.exports) {
-    module.exports = ShapeCompiler;
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = ShapeCompiler;
 }

--- a/lcl_schema.json
+++ b/lcl_schema.json
@@ -1,67 +1,89 @@
- url=https://github.com/Aetherium-Syndicate-Inspectra/Aetherium-Manifest/blob/main/
 {
-  "version": "3.0",
-  "title": "Light Control Language (LCL) Schema",
-  "description": "Structured control signals between Intent Interpreter and Runtime",
-  
-  "control_packet": {
-    "id": "unique_control_id",
-    "timestamp": "ISO8601",
-    
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Light Control Language (LCL)",
+  "type": "object",
+  "required": ["intent", "morphology", "motion", "optics", "constraints"],
+  "properties": {
+    "version": { "type": "string", "default": "3.1" },
     "intent": {
-      "user_request": "string",
-      "primary_goal": "enum: [create_form, respond_to_emotion, visualize_concept, manifest_error, dissolve]",
-      "abstraction_level": "enum: [concrete, symbolic, abstract]",
-      "mode": "enum: [symbol, world, shape, scene, motion, feedback]"
+      "type": "object",
+      "required": ["user_request", "primary_goal"],
+      "properties": {
+        "user_request": { "type": "string" },
+        "primary_goal": { "type": "string" },
+        "abstraction_level": { "enum": ["concrete", "symbolic", "abstract"] },
+        "mode": { "enum": ["symbol", "world", "shape", "scene", "motion", "feedback", "auto"] }
+      }
     },
-    
     "morphology": {
-      "family": "string",
-      "symmetry": "int 1-12",
-      "complexity": "float 0-1",
-      "edge_softness": "float 0-1",
-      "density": "float 0-1"
+      "type": "object",
+      "required": ["family"],
+      "properties": {
+        "family": { "type": "string" },
+        "symmetry": { "type": "integer", "minimum": 1, "maximum": 12 },
+        "edge_softness": { "type": "number", "minimum": 0, "maximum": 1 },
+        "density": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
     },
-    
     "motion": {
-      "archetype": "enum: [emergence, stabilization, dissolution, reasoning, error, breath, spiral, wave]",
-      "tempo_hz": "float 0.1-2.0",
-      "coherence_target": "float 0-1",
-      "flow_mode": "enum: [radial_bloom, spiral_convergence, wave_propagation, drift, fracture]",
-      "attack_ms": "int 200-2000",
-      "settle_ms": "int 500-5000",
-      "release_ms": "int 500-3000"
+      "type": "object",
+      "required": ["archetype", "flow_mode"],
+      "properties": {
+        "archetype": { "type": "string" },
+        "tempo_hz": { "type": "number", "minimum": 0.1, "maximum": 4 },
+        "coherence_target": { "type": "number", "minimum": 0, "maximum": 1 },
+        "flow_mode": { "type": "string" },
+        "attack_ms": { "type": "integer", "minimum": 50 },
+        "settle_ms": { "type": "integer", "minimum": 50 },
+        "release_ms": { "type": "integer", "minimum": 50 }
+      }
     },
-    
+    "motion_bias": {
+      "type": "object",
+      "properties": {
+        "archetype": { "type": "string" },
+        "rhythm_hz": { "type": "number", "minimum": 0.05, "maximum": 4 },
+        "attack": { "type": "number", "minimum": 0, "maximum": 1 },
+        "settling": { "type": "number", "minimum": 0, "maximum": 1 },
+        "drift": { "type": "number", "minimum": 0, "maximum": 1 },
+        "collapse_tendency": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
     "optics": {
-      "palette_mode": "enum: [thermodynamic, emotional, spectral, monochrome]",
-      "primary_colors": ["#HEX", "#HEX"],
-      "secondary_colors": ["#HEX", "#HEX"],
-      "glow_strength": "float 0-1",
-      "luminance": "float 0-1",
-      "contrast": "float 0-1"
+      "type": "object",
+      "properties": {
+        "palette_mode": { "type": "string" },
+        "primary_colors": { "type": "array", "items": { "type": "string" } },
+        "secondary_colors": { "type": "array", "items": { "type": "string" } },
+        "glow_strength": { "type": "number", "minimum": 0, "maximum": 1 },
+        "luminance": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
     },
-    
-    "field_parameters": {
-      "coherence": "float 0-1",
-      "turbulence": "float 0-1",
-      "flow_magnitude": "float 0-1",
-      "noise_level": "float 0-1",
-      "vorticity": "float 0-1"
+    "field": {
+      "type": "object",
+      "properties": {
+        "coherence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "turbulence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "flow_magnitude": { "type": "number", "minimum": 0, "maximum": 1 },
+        "noise_level": { "type": "number", "minimum": 0, "maximum": 1 },
+        "vorticity": { "type": "number", "minimum": -1, "maximum": 1 }
+      }
     },
-    
     "constraints": {
-      "max_particles": "int",
-      "max_energy": "float",
-      "max_brightness": "float",
-      "duration_ms": "int or null",
-      "safety_level": "enum: [strict, normal, expressive]"
+      "type": "object",
+      "properties": {
+        "max_targets": { "type": "integer", "minimum": 100 },
+        "max_particles": { "type": "integer", "minimum": 100 },
+        "max_energy": { "type": "number", "minimum": 0.1 },
+        "max_brightness": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
     },
-    
-    "reference": {
-      "book_of_formation_id": "string or null",
-      "motion_archetype_id": "string",
-      "evaluation_mode": "enum: [off, periodic, continuous]"
+    "safety": {
+      "type": "object",
+      "properties": {
+        "max_targets": { "type": "integer", "minimum": 100 },
+        "max_particle_energy": { "type": "number", "minimum": 0.1 }
+      }
     }
   }
 }

--- a/tests/lcl_pipeline.test.js
+++ b/tests/lcl_pipeline.test.js
@@ -1,0 +1,44 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const ShapeCompiler = require('../am_shape_compiler.js');
+const { ControlHandlerV3, RuntimeGovernor } = require('../am_control_handler.js');
+
+test('ShapeCompiler exposes shape/scene/motion field compilers', () => {
+  const compiler = new ShapeCompiler(1000, 700);
+  const control = {
+    morphology: { family: 'spiral_vortex' },
+    optics: { primary_colors: ['#ffffff'], secondary_colors: ['#0000ff'] },
+    motion: { flow_mode: 'spiral_convergence' },
+    constraints: { max_targets: 1200 },
+  };
+
+  assert.equal(compiler.compileShapeField(control, 500).length, 500);
+  assert.equal(compiler.compileSceneField(control, 300).length, 300);
+  assert.equal(compiler.compileMotionField(control, 200).length, 200);
+});
+
+test('RuntimeGovernor clamps risky values', () => {
+  const governor = new RuntimeGovernor({ maxTargets: 14000 });
+  const runtime = governor.sanitize(
+    { safety: { max_particle_energy: 3 }, constraints: { max_targets: 99999 } },
+    { field_recipe: { coherence_target: 2, turbulence: 9, flow_magnitude: -1 }, visual_recipe: { luminance: 9 } }
+  );
+
+  assert.equal(runtime.constraints.max_targets, 14000);
+  assert.equal(runtime.constraints.max_particle_energy, 1.4);
+  assert.equal(runtime.field_recipe.coherence_target, 1);
+  assert.equal(runtime.field_recipe.turbulence, 0.85);
+  assert.equal(runtime.field_recipe.flow_magnitude, 0);
+  assert.equal(runtime.visual_recipe.luminance, 1);
+});
+
+test('ControlHandler compiles field according to render mode', () => {
+  const compiler = new ShapeCompiler(800, 600);
+  const handler = new ControlHandlerV3({ kernel: {}, shapeCompiler: compiler, intentInterpreter: {}, formationRetriever: {} });
+
+  const control = { morphology: { family: 'sphere' }, optics: {} };
+  assert.equal(handler.compileTargetField('shape_field', control, 250).length, 250);
+  assert.equal(handler.compileTargetField('scene_field', control, 210).length, 210);
+  assert.equal(handler.compileTargetField('motion_field', control, 190).length, 200);
+});


### PR DESCRIPTION
### Motivation
- Provide a deterministic middle-brain so natural-language intent becomes a structured Light Control Language (LCL) packet instead of ad-hoc prompts, enabling safe, repeatable runtime control of light manifestations.
- Enable AI-driven shape/formation-driven rendering (shape/scene/motion) and closed-loop feedback so the system can iterate toward a perceptual goal instead of one-shot commands.
- Add safety/clamping to avoid runaway runtime parameters (particles, energy, turbulence, luminance) before they reach the kernel.
- Standardize the contract between interpretation and runtime via a JSON Schema for the LCL packet.

### Description
- Implemented `ControlHandlerV3` and `RuntimeGovernor` in `am_control_handler.js` to orchestrate the pipeline `Intent Interpreter → Formation Retriever → Morphology Compiler → Runtime Governor → Kernel` and sanitize runtime control packets before application.
- Expanded shape compiler into three compiler families in `am_shape_compiler.js`: `compileShapeField`, `compileSceneField`, and `compileMotionField`, and preserved existing generators (sphere, spiral, flower, fracture, torus, nebula, etc.).
- Updated formation retrieval in `am_formation_retriever.py` to resolve canonical Book of Formation archetypes via `_resolve_archetype` and to route render modes to `shape_field`, `scene_field`, or `motion_field`.
- Extended the intent packet produced by `am_intent_interpreter.py` to include `field`, `motion_bias`, and `safety` blocks and adjusted `mode` routing to align with controller strategy.
- Replaced invalid `lcl_schema.json` content with a valid JSON Schema describing the central LCL contract (`intent`, `morphology`, `motion`, `optics`, `field`, `motion_bias`, `constraints`, `safety`).
- Marked the new pipeline as implemented in `README.md` and added unit tests in `tests/lcl_pipeline.test.js` validating compiler outputs, governor clamping, and render-mode routing.

### Testing
- Performed syntax/type checks: `node --check am_control_handler.js` and `node --check am_shape_compiler.js`, both passed.
- Python modules byte-compiled with `python -m py_compile am_intent_interpreter.py am_formation_retriever.py am_biovisionnet_evaluator.py` and succeeded.
- Ran the unit suite with `node --test tests/lcl_pipeline.test.js` and all tests passed (compiler outputs, runtime governor clamping, render-mode routing).
- Validated JSON schema with `python -m json.tool lcl_schema.json`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0bc985d388320a933b98019b2aad4)