### PR TITLE
Add schema-vs-runtime contract drift guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,8 +503,11 @@ Future directions:
 - **Contract Fuzz Testing** ✅  
   Added deterministic schema mutation fuzzing (`tools/contracts/contract_fuzz.py`) with a regression corpus (`tools/contracts/payloads/fuzz_regressions.json`) and CI-ready pass/fail thresholds.
 
-- **Contract Differential Drift Guard**  
-  Add schema-vs-runtime differential checks to detect acceptance drift between gateway validators and canonical JSON schemas.
+- **Contract Differential Drift Guard** ✅  
+  Added schema-vs-runtime differential checks (`tools/contracts/runtime_drift_guard.py`) with deterministic fixtures to detect acceptance drift between gateway validators and canonical JSON schemas.
+
+- **Contract Drift Telemetry Export**  
+  Export drift-guard structural match and policy-violation rates into telemetry for dashboarding and alerting.
 
 - **Voice Model Experimentation**  
   A/B routing and quality tracking by language-region (WER, latency, accuracy).

--- a/docs/schemas/cognitive_emit_request_v1.json
+++ b/docs/schemas/cognitive_emit_request_v1.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aetherium.dev/schemas/cognitive_emit_request_v1.json",
+  "title": "CognitiveEmitRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["session_id", "model_response", "model_metadata"],
+  "properties": {
+    "session_id": {"type": "string", "minLength": 1},
+    "model_response": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_id", "reasoning_trace", "intent_vector", "visual_manifestation"],
+      "properties": {
+        "trace_id": {"type": "string", "minLength": 1},
+        "reasoning_trace": {"type": "string", "minLength": 1},
+        "intent_vector": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["category", "emotional_valence", "energy_level"],
+          "properties": {
+            "category": {"type": "string", "minLength": 1},
+            "emotional_valence": {"type": "number", "minimum": -1.0, "maximum": 1.0},
+            "energy_level": {"type": "number", "minimum": 0.0, "maximum": 1.0}
+          }
+        },
+        "visual_manifestation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "base_shape",
+            "transition_type",
+            "color_palette",
+            "particle_physics",
+            "chromatic_mode"
+          ],
+          "properties": {
+            "base_shape": {"type": "string", "minLength": 1},
+            "transition_type": {"type": "string", "minLength": 1},
+            "color_palette": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["primary"],
+              "properties": {
+                "primary": {"type": "string", "minLength": 1},
+                "secondary": {"type": ["string", "null"]}
+              }
+            },
+            "particle_physics": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["turbulence", "flow_direction", "luminance_mass"],
+              "properties": {
+                "turbulence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                "flow_direction": {"type": "string", "minLength": 1},
+                "luminance_mass": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                "particle_count": {"type": "integer", "minimum": 0, "default": 0}
+              }
+            },
+            "chromatic_mode": {"type": "string", "minLength": 1},
+            "emergency_override": {"type": "boolean", "default": false},
+            "device_tier": {"type": "integer", "minimum": 1, "maximum": 4, "default": 1}
+          }
+        }
+      }
+    },
+    "model_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["model_name", "temperature", "max_tokens"],
+      "properties": {
+        "model_name": {"type": "string", "minLength": 1},
+        "temperature": {"type": "number", "minimum": 0.0, "maximum": 2.0},
+        "max_tokens": {"type": "integer", "exclusiveMinimum": 0}
+      }
+    }
+  },
+  "x-field-evolution": {
+    "introduced_in": "cognitive_emit_request_v1",
+    "supersedes": "none",
+    "compatibility_adapter": "runtime:api_gateway.main.CognitiveEmitRequest",
+    "required_evolution_sections": ["model_response", "model_metadata"]
+  }
+}

--- a/tools/contracts/contract_checker.py
+++ b/tools/contracts/contract_checker.py
@@ -13,7 +13,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from tools.contracts.protocol_adapter import roundtrip_envelope, to_legacy_visual_parameters
+from tools.contracts.protocol_adapter import roundtrip_envelope, to_legacy_visual_parameters  # noqa: E402
+from tools.contracts.runtime_drift_guard import run_guard as run_runtime_drift_guard  # noqa: E402
 
 SCHEMA_DIR = REPO_ROOT / "docs" / "schemas"
 PAYLOAD_DIR = Path(__file__).resolve().parent / "payloads"
@@ -233,6 +234,10 @@ def run_contract_checks(mode: Mode = "strict") -> int:
 
     global_errors.extend(_check_embodiment_compatibility(global_audits))
     global_errors.extend(_check_envelope_roundtrip_integrity(global_audits))
+    if run_runtime_drift_guard() != 0:
+        global_errors.append("runtime drift guard detected structural mismatch")
+    else:
+        global_audits.append("runtime_drift_guard: structural_match_rate=100.00%")
 
     if global_errors:
         failures += 1

--- a/tools/contracts/payloads/runtime_drift_cases.json
+++ b/tools/contracts/payloads/runtime_drift_cases.json
@@ -1,0 +1,139 @@
+[
+  {
+    "name": "valid_baseline",
+    "payload": {
+      "session_id": "user_883920_session_001",
+      "model_response": {
+        "trace_id": "gen_883920_ax",
+        "reasoning_trace": "user expresses stress and requests support",
+        "intent_vector": {
+          "category": "analysis_request_with_empathy",
+          "emotional_valence": -0.7,
+          "energy_level": 0.8
+        },
+        "visual_manifestation": {
+          "base_shape": "spiral_vortex",
+          "transition_type": "morph_fluid",
+          "color_palette": {
+            "primary": "#800080",
+            "secondary": "#00FFFF"
+          },
+          "particle_physics": {
+            "turbulence": 0.4,
+            "flow_direction": "centripetal",
+            "luminance_mass": 0.9,
+            "particle_count": 12000
+          },
+          "chromatic_mode": "BIT_24_RGB",
+          "device_tier": 3
+        }
+      },
+      "model_metadata": {
+        "model_name": "gpt-4o",
+        "temperature": 0.3,
+        "max_tokens": 1500
+      }
+    }
+  },
+  {
+    "name": "invalid_missing_session_id",
+    "payload": {
+      "model_response": {
+        "trace_id": "gen_missing_sid",
+        "reasoning_trace": "missing session",
+        "intent_vector": {
+          "category": "analysis_request_with_empathy",
+          "emotional_valence": 0.1,
+          "energy_level": 0.5
+        },
+        "visual_manifestation": {
+          "base_shape": "ring",
+          "transition_type": "pulse",
+          "color_palette": {
+            "primary": "#00FFFF"
+          },
+          "particle_physics": {
+            "turbulence": 0.2,
+            "flow_direction": "centripetal",
+            "luminance_mass": 0.8,
+            "particle_count": 1000
+          },
+          "chromatic_mode": "BIT_24_RGB"
+        }
+      },
+      "model_metadata": {
+        "model_name": "gpt-4o",
+        "temperature": 0.2,
+        "max_tokens": 256
+      }
+    }
+  },
+  {
+    "name": "invalid_energy_level_out_of_range",
+    "payload": {
+      "session_id": "session_energy_invalid",
+      "model_response": {
+        "trace_id": "gen_energy_invalid",
+        "reasoning_trace": "invalid energy",
+        "intent_vector": {
+          "category": "analysis_request_with_empathy",
+          "emotional_valence": 0.1,
+          "energy_level": 1.4
+        },
+        "visual_manifestation": {
+          "base_shape": "ring",
+          "transition_type": "pulse",
+          "color_palette": {
+            "primary": "#00FFFF"
+          },
+          "particle_physics": {
+            "turbulence": 0.2,
+            "flow_direction": "centripetal",
+            "luminance_mass": 0.8,
+            "particle_count": 1000
+          },
+          "chromatic_mode": "BIT_24_RGB"
+        }
+      },
+      "model_metadata": {
+        "model_name": "gpt-4o",
+        "temperature": 0.2,
+        "max_tokens": 256
+      }
+    }
+  },
+  {
+    "name": "policy_violation_crimson_without_emergency_override",
+    "payload": {
+      "session_id": "session_policy_case",
+      "model_response": {
+        "trace_id": "gen_policy_case",
+        "reasoning_trace": "policy violation case",
+        "intent_vector": {
+          "category": "analysis_request_with_empathy",
+          "emotional_valence": -0.1,
+          "energy_level": 0.2
+        },
+        "visual_manifestation": {
+          "base_shape": "ring",
+          "transition_type": "pulse",
+          "color_palette": {
+            "primary": "#DC143C"
+          },
+          "particle_physics": {
+            "turbulence": 0.1,
+            "flow_direction": "centripetal",
+            "luminance_mass": 0.7,
+            "particle_count": 400
+          },
+          "chromatic_mode": "BIT_24_RGB"
+        }
+      },
+      "model_metadata": {
+        "model_name": "gpt-4o",
+        "temperature": 0.2,
+        "max_tokens": 256
+      }
+    }
+  }
+]

--- a/tools/contracts/runtime_drift_guard.py
+++ b/tools/contracts/runtime_drift_guard.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from api_gateway.main import CognitiveEmitRequest, FirmaValidator  # noqa: E402
+
+SCHEMA_PATH = REPO_ROOT / "docs" / "schemas" / "cognitive_emit_request_v1.json"
+DEFAULT_CASES_PATH = Path(__file__).resolve().parent / "payloads" / "runtime_drift_cases.json"
+
+
+@dataclass
+class DriftCaseResult:
+    name: str
+    schema_accepts: bool
+    runtime_structure_accepts: bool
+    runtime_policy_accepts: bool
+    violations: list[str]
+
+    @property
+    def has_structure_drift(self) -> bool:
+        return self.schema_accepts != self.runtime_structure_accepts
+
+
+def _load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def evaluate_cases(
+    schema: dict[str, Any],
+    cases: list[dict[str, Any]],
+) -> list[DriftCaseResult]:
+    validator = Draft202012Validator(schema)
+    results: list[DriftCaseResult] = []
+
+    for row in cases:
+        name = str(row.get("name", "unnamed_case"))
+        payload = row.get("payload", {})
+        schema_errors = list(validator.iter_errors(payload))
+        schema_accepts = not schema_errors
+
+        try:
+            parsed = CognitiveEmitRequest.model_validate(payload)
+            runtime_structure_accepts = True
+            runtime_policy_accepts, violations = FirmaValidator.validate_dsl_response(parsed)
+        except ValidationError:
+            runtime_structure_accepts = False
+            runtime_policy_accepts = False
+            violations = []
+
+        results.append(
+            DriftCaseResult(
+                name=name,
+                schema_accepts=schema_accepts,
+                runtime_structure_accepts=runtime_structure_accepts,
+                runtime_policy_accepts=runtime_policy_accepts,
+                violations=violations,
+            )
+        )
+
+    return results
+
+
+def run_guard(cases_path: Path = DEFAULT_CASES_PATH) -> int:
+    schema = _load_json(SCHEMA_PATH)
+    cases = _load_json(cases_path)
+    if not isinstance(cases, list) or not cases:
+        print(f"[FAIL] invalid cases file: {cases_path}")
+        return 1
+
+    results = evaluate_cases(schema, cases)
+    drift_failures = [result for result in results if result.has_structure_drift]
+
+    for result in results:
+        state = "DRIFT" if result.has_structure_drift else "OK"
+        print(
+            f"[{state}] {result.name} "
+            f"schema_accepts={result.schema_accepts} "
+            f"runtime_structure_accepts={result.runtime_structure_accepts} "
+            f"runtime_policy_accepts={result.runtime_policy_accepts}"
+        )
+        if result.violations:
+            print(f"  [POLICY] violations={result.violations}")
+
+    structural_match = (len(results) - len(drift_failures)) / len(results)
+    print(f"[AUDIT] structural_match_rate={structural_match * 100:.2f}%")
+
+    if drift_failures:
+        print("[FAIL] schema-vs-runtime drift detected")
+        return 1
+
+    print("[PASS] schema-vs-runtime drift guard")
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Detect structural drift between canonical schema and runtime validators")
+    parser.add_argument(
+        "--cases",
+        type=Path,
+        default=DEFAULT_CASES_PATH,
+        help="Path to JSON file with drift-guard test cases",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    raise SystemExit(run_guard(cases_path=args.cases))

--- a/tools/contracts/test_runtime_drift_guard.py
+++ b/tools/contracts/test_runtime_drift_guard.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+
+from tools.contracts.runtime_drift_guard import evaluate_cases
+
+
+def test_runtime_drift_guard_cases_match_runtime_and_schema_contracts() -> None:
+    with open("docs/schemas/cognitive_emit_request_v1.json", "r", encoding="utf-8") as handle:
+        schema = json.load(handle)
+    with open("tools/contracts/payloads/runtime_drift_cases.json", "r", encoding="utf-8") as handle:
+        cases = json.load(handle)
+
+    results = evaluate_cases(schema=schema, cases=cases)
+
+    assert len(results) == 4
+    assert all(not result.has_structure_drift for result in results)
+
+    policy_case = next(result for result in results if result.name == "policy_violation_crimson_without_emergency_override")
+    assert policy_case.runtime_policy_accepts is False
+    assert policy_case.violations


### PR DESCRIPTION
### Motivation
- Ensure parity between canonical JSON schemas and runtime Pydantic validators for the cognitive emit payload to prevent silent contract drift. 
- Make policy-only violations (e.g., reserved emergency color) visible to contract checks without breaking runtime behavior. 
- Implement the roadmap item for a Contract Differential Drift Guard so CI gates can detect structural mismatches early.

### Description
- Add a canonical schema `docs/schemas/cognitive_emit_request_v1.json` describing the cognitive emit request shape and field-evolution metadata.  
- Add `tools/contracts/runtime_drift_guard.py` which compares JSON Schema acceptance vs runtime `CognitiveEmitRequest` validation and reports policy violations and a structural match rate.  
- Add deterministic fixtures `tools/contracts/payloads/runtime_drift_cases.json` (baseline, missing required field, out-of-range value, policy-only violation) and unit test `tools/contracts/test_runtime_drift_guard.py`.  
- Integrate the drift guard into `tools/contracts/contract_checker.py` so contract checks include the schema-vs-runtime differential gate, and update `README.md` to mark this item complete and suggest telemetry follow-up.

### Testing
- Ran the drift guard directly: `python3 tools/contracts/runtime_drift_guard.py` and it passed with structural_match_rate=100% and policy violation reported for the Crimson case.  
- Ran the combined contract check: `python3 tools/contracts/contract_checker.py` and it passed, including the drift guard audit output.  
- Ran unit tests: `pytest -q api_gateway/test_api.py tools/contracts/test_runtime_drift_guard.py` which returned `15 passed`.  
- Ran linters/typecheck for the modified area: `ruff` on the changed contract files passed and `pyright` typecheck reported `0 errors` for the new guard and checker modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b589143164832092a1ed5f0b5e3fe6)