### PR TITLE
Restore TS runtime compatibility, add evaluators/control handler, and fix tests

### DIFF
--- a/am_control_handler.js
+++ b/am_control_handler.js
@@ -1,0 +1,53 @@
+class RuntimeGovernor {
+  constructor({ maxTargets = 14000, maxParticleEnergy = 1.4 } = {}) {
+    this.maxTargets = maxTargets;
+    this.maxParticleEnergy = maxParticleEnergy;
+  }
+
+  sanitize(control = {}, runtime = {}) {
+    return {
+      ...runtime,
+      constraints: {
+        max_targets: Math.min(control.constraints?.max_targets ?? this.maxTargets, this.maxTargets),
+        max_particle_energy: Math.min(control.safety?.max_particle_energy ?? this.maxParticleEnergy, this.maxParticleEnergy),
+      },
+      field_recipe: {
+        ...runtime.field_recipe,
+        coherence_target: clamp(runtime.field_recipe?.coherence_target ?? 0.5, 0, 1),
+        turbulence: clamp(runtime.field_recipe?.turbulence ?? 0.2, 0, 0.85),
+        flow_magnitude: clamp(runtime.field_recipe?.flow_magnitude ?? 0.4, 0, 1),
+      },
+      visual_recipe: {
+        ...runtime.visual_recipe,
+        luminance: clamp(runtime.visual_recipe?.luminance ?? 0.8, 0, 1),
+      },
+    };
+  }
+}
+
+class ControlHandlerV3 {
+  constructor({ kernel, shapeCompiler, intentInterpreter, formationRetriever }) {
+    this.kernel = kernel;
+    this.shapeCompiler = shapeCompiler;
+    this.intentInterpreter = intentInterpreter;
+    this.formationRetriever = formationRetriever;
+  }
+
+  compileTargetField(renderMode, control, maxTargets) {
+    switch (renderMode) {
+      case 'shape_field':
+        return this.shapeCompiler.compileShapeField(control, maxTargets);
+      case 'scene_field':
+        return this.shapeCompiler.compileSceneField(control, maxTargets);
+      case 'motion_field':
+      default:
+        return this.shapeCompiler.compileMotionField(control, Math.max(200, maxTargets ?? 200));
+    }
+  }
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+module.exports = { ControlHandlerV3, RuntimeGovernor };

--- a/formation-retriever.ts
+++ b/formation-retriever.ts
@@ -1,8 +1,8 @@
-import {
+import type {
   FormationReference,
   LightControlLanguage,
   MotionArchetype,
-} from './light-control-language';
+} from './light-control-language.ts';
 
 export interface FormationManifestEntry {
   id: string;
@@ -142,12 +142,9 @@ async function fetchAndParseJson<T>(url: string): Promise<T> {
   if (!res.ok) throw new Error(`Failed to fetch content from ${url}: ${res.statusText}`);
   const text = await res.text();
   
-  // CRITICAL: This assumes the fetched content is valid JSON.
-  // In production, you would replace this with a robust YAML parser library (e.g., js-yaml)
-  // if the source is guaranteed to be YAML.
   try {
     return JSON.parse(text) as T;
-  } catch (e) {
+  } catch {
     throw new Error(`Failed to parse content from ${url} as JSON.`);
   }
 }

--- a/kernel.test.ts
+++ b/kernel.test.ts
@@ -1,96 +1,129 @@
-// AETHERIUM KERNEL TEST SUITE (Placeholder)
-//
-// This file provides a basic structure for testing the AetheriumKernel.
-// In a real-world scenario, you would use a testing framework like Jest or Vitest.
-//
-// To run these tests, you would typically use a command like: `npx vitest run`
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { AetheriumKernel } from './kernel.ts';
 
-import { AetheriumKernel } from './kernel';
+class MockCanvasElement {
+  width = 800;
+  height = 600;
+  clientWidth = 800;
+  clientHeight = 600;
 
-// --- Mocking Dependencies ---
-// We need to mock browser-specific features and network requests.
+  getContext(kind: string) {
+    if (kind === 'webgl2') {
+      return {
+        BLEND: 1,
+        ONE: 1,
+        COLOR_BUFFER_BIT: 0x4000,
+        RGBA: 0x1908,
+        UNSIGNED_BYTE: 0x1401,
+        clear: () => {},
+        clearColor: () => {},
+        enable: () => {},
+        blendFunc: () => {},
+        viewport: () => {},
+        readPixels: () => {},
+      };
+    }
 
-// Mock Canvas & WebGL2 Context
-global.HTMLCanvasElement.prototype.getContext = () => {
-  return {
-    clear: () => {},
-    clearColor: () => {},
-    enable: () => {},
-    blendFunc: () => {},
-    viewport: () => {},
-    readPixels: () => {},
-    // Add other mocked GL functions as needed by the renderer
-  };
-};
+    if (kind === '2d') {
+      return {
+        clearRect: () => {},
+        fillText: () => {},
+        getImageData: () => ({ data: new Uint8ClampedArray(this.width * this.height * 4) }),
+        set font(_value: string) {},
+        set textAlign(_value: string) {},
+        set textBaseline(_value: string) {},
+        set fillStyle(_value: string) {},
+      };
+    }
 
-global.fetch = async (url) => {
-  console.log(`Mock fetch for: ${url}`);
-  if (url.toString().endsWith('/api/light/interpret')) {
-    return new Response(JSON.stringify({ 
-      lcl: { version: '4.0', intent: 'create_light_form', /* ... other LCL fields */ } 
+    return null;
+  }
+}
+
+globalThis.HTMLCanvasElement = MockCanvasElement as typeof HTMLCanvasElement;
+globalThis.window = { innerWidth: 800, innerHeight: 600 } as Window & typeof globalThis;
+globalThis.document = {
+  createElement: () => new MockCanvasElement(),
+} as Document;
+globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+  return 1;
+}) as typeof requestAnimationFrame;
+globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+globalThis.fetch = (async (url: string | URL) => {
+  const target = url.toString();
+  if (target.endsWith('/api/light/interpret')) {
+    return new Response(JSON.stringify({
+      lcl: {
+        version: '4.0',
+        intent: 'create_light_form',
+        morphology: { family: 'sphere', symmetry: 1, density: 0.5, scale: 0.3, edge_softness: 0.4 },
+        motion: {
+          archetype: 'stabilization',
+          flow_mode: 'calm_drift',
+          coherence_target: 0.8,
+          turbulence: 0.2,
+          rhythm_hz: 0.2,
+          attack_ms: 400,
+          settle_ms: 1200,
+        },
+        optics: {
+          palette: ['#ffffff'],
+          luminance_boost: 1.2,
+          glow_alpha: 0.6,
+          trail_alpha: 0.2,
+          color_mode: 'palette',
+        },
+        content: { text: null, scene_recipe: null },
+        constraints: { max_targets: 14000, max_photons: 7000, max_energy: 1.6 },
+        source_text: 'create a golden spiral',
+      },
     }));
   }
-  if (url.toString().endsWith('/manifest.yaml')) {
-    return new Response(JSON.stringify({ formations: [] }));
+
+  if (target.endsWith('/manifest.yaml')) {
+    return new Response(JSON.stringify({ formations: [] }), { status: 200 });
   }
-  return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
-};
 
-// --- Test Suite ---
+  return new Response(JSON.stringify({ readability: 0.7, coverage: 0.2, stability: 0.7 }), { status: 200 });
+}) as typeof fetch;
 
-describe('AetheriumKernel', () => {
-
-  let kernel: AetheriumKernel;
-  let canvas: HTMLCanvasElement;
-
-  beforeEach(() => {
-    // Create a new kernel instance before each test
-    canvas = document.createElement('canvas');
-    kernel = new AetheriumKernel({
-      canvas: canvas,
-      apiBaseUrl: 'http://mock-api.com',
-      formationBaseUrl: '.',
-      evaluatorMode: 'local',
-    });
+test('AetheriumKernel initializes without errors', () => {
+  const kernel = new AetheriumKernel({
+    canvas: document.createElement('canvas'),
+    apiBaseUrl: 'http://mock-api.com',
+    formationBaseUrl: '.',
+    evaluatorMode: 'local',
   });
 
-  test('should initialize without errors', () => {
-    // Assert that the kernel was created successfully
-    expect(kernel).toBeInstanceOf(AetheriumKernel);
+  assert.ok(kernel instanceof AetheriumKernel);
+});
+
+test('AetheriumKernel handles a user request and can reset state', async () => {
+  const kernel = new AetheriumKernel({
+    canvas: document.createElement('canvas'),
+    apiBaseUrl: 'http://mock-api.com',
+    formationBaseUrl: '.',
+    evaluatorMode: 'local',
   });
 
-  test('should start and stop the animation loop', () => {
-    // To test this properly, you might need to mock requestAnimationFrame
-    // and advance timers manually.
-    kernel.start();
-    // expect(requestAnimationFrame).toHaveBeenCalled();
-    kernel.stop();
-    // expect(cancelAnimationFrame).toHaveBeenCalled();
+  await kernel.handleUserLightRequest('create a golden spiral');
+  assert.equal(kernel.getLCLSchema()?.version, '4.0');
+
+  kernel.resetToVoid();
+  assert.equal(kernel.getLCLSchema(), null);
+});
+
+test('AetheriumKernel resizes and can start-stop animation safely', () => {
+  const kernel = new AetheriumKernel({
+    canvas: document.createElement('canvas'),
+    apiBaseUrl: 'http://mock-api.com',
+    formationBaseUrl: '.',
+    evaluatorMode: 'local',
   });
 
-  test('should handle a user light request and generate an LCL', async () => {
-    const userText = "create a golden spiral";
-    await kernel.handleUserLightRequest(userText);
-    
-    const lcl = kernel.getLCLSchema();
-    expect(lcl).not.toBeNull();
-    expect(lcl?.version).toBe('4.0');
-  });
-
-  test('should reset the kernel to a void state', async () => {
-    await kernel.handleUserLightRequest("some effect");
-    expect(kernel.getLCLSchema()).not.toBeNull(); // Ensure state is not null
-
-    kernel.resetToVoid();
-    expect(kernel.getLCLSchema()).toBeNull();
-    // You could also check if photons are in a default state
-  });
-  
-  test('should resize the viewport and re-apply LCL', () => {
-      // This test would require more detailed mocking of the renderer 
-      // and compiled field to verify the re-application.
-      kernel.resize(1920, 1080);
-      // expect(...) the viewport-dependent properties to be updated.
-  });
-
+  kernel.resize(1920, 1080);
+  kernel.start();
+  kernel.stop();
+  assert.ok(true);
 });

--- a/kernel.ts
+++ b/kernel.ts
@@ -1,25 +1,24 @@
 import {
   interpretWithBackendLLM,
-  LightControlLanguage,
   normalizeLCL,
-} from './light-control-language';
+} from './light-control-language.ts';
+import type { LightControlLanguage } from './light-control-language.ts';
 import {
   loadFormationBundle,
   mergeRetrievedFormation,
   retrieveFormation,
-} from './formation-retriever';
+} from './formation-retriever.ts';
 import {
   compileGlyphFieldFromAlphaMask,
   compileShapeField,
-  CompiledField,
-  Viewport,
-} from './shape-compiler';
+} from './shape-compiler.ts';
+import type { CompiledField, Viewport } from './shape-compiler.ts';
 import {
   BioVisionRemoteEvaluator,
   EdgeAwareLocalEvaluator,
   feedbackAdjustments,
-  PerceptualEvaluator,
-} from './perceptual-feedback';
+} from './perceptual-feedback.ts';
+import type { PerceptualEvaluator } from './perceptual-feedback.ts';
 
 export interface KernelConfig {
   apiBaseUrl: string;

--- a/light-control-language.ts
+++ b/light-control-language.ts
@@ -1,3 +1,16 @@
+export type MotionArchetype = string;
+
+export interface FormationReference {
+  id: string;
+  title: string;
+  archetype: MotionArchetype;
+  keywords: string[];
+  manifestPath?: string;
+  annotationPath?: string;
+  previewVideoPath?: string;
+  score?: number;
+}
+
 export interface LightControlLanguage {
   version: string;
   intent: 'create_light_form' | 'create_glyph' | 'create_scene';
@@ -27,6 +40,7 @@ export interface LightControlLanguage {
   content: {
     text: string | null;
     scene_recipe: Record<string, unknown> | null;
+    semantic_tags?: string[];
   };
   constraints: {
     max_targets: number;
@@ -34,6 +48,14 @@ export interface LightControlLanguage {
     max_energy: number;
   };
   source_text: string;
+  retrieved_formation?: FormationReference;
+  runtime_bias?: {
+    forceBias?: number;
+    flowBias?: number;
+    noiseBias?: number;
+    coherenceStart?: number;
+    archetypePhrase?: string;
+  };
 }
 
 const DEFAULT_TIMEOUT_MS = 6_000;
@@ -75,6 +97,68 @@ export async function generateLightControlLanguage(text: string): Promise<LightC
 
 // backward-compat alias for older kernel imports
 export const mockLocalLightModel = generateLightControlLanguage;
+
+export async function interpretWithBackendLLM(
+  apiBaseUrl: string,
+  payload: {
+    userText: string;
+    viewport?: { width: number; height: number };
+    limits?: Record<string, number>;
+  },
+): Promise<LightControlLanguage> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${apiBaseUrl.replace(/\/$/, '')}/api/light/interpret`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Interpretation request failed with status ${response.status}`);
+    }
+
+    const result = await response.json();
+    const lcl = result?.lcl ?? result;
+    return normalizeLCL(isLclPayload(lcl) ? lcl : fallbackHeuristicLcl(payload.userText));
+  } catch (error) {
+    console.warn('Interpretation backend unavailable, using deterministic fallback', error);
+    return fallbackHeuristicLcl(payload.userText);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function normalizeLCL(lcl: Partial<LightControlLanguage>): LightControlLanguage {
+  const fallback = fallbackHeuristicLcl(lcl.source_text ?? '');
+  return {
+    ...fallback,
+    ...lcl,
+    morphology: {
+      ...fallback.morphology,
+      ...lcl.morphology,
+    },
+    motion: {
+      ...fallback.motion,
+      ...lcl.motion,
+    },
+    optics: {
+      ...fallback.optics,
+      ...lcl.optics,
+    },
+    content: {
+      ...fallback.content,
+      ...lcl.content,
+    },
+    constraints: {
+      ...fallback.constraints,
+      ...lcl.constraints,
+    },
+  };
+}
 
 function isLclPayload(value: unknown): value is LightControlLanguage {
   const candidate = value as Partial<LightControlLanguage>;

--- a/perceptual-feedback.ts
+++ b/perceptual-feedback.ts
@@ -9,7 +9,88 @@ interface EvalMetrics {
   stability: number;
 }
 
+interface FrameSample {
+  width: number;
+  height: number;
+  rgba: Uint8Array;
+}
+
+interface PhotonSample {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+}
+
+export interface PerceptualEvaluator {
+  evaluate(frame: FrameSample, field: { points: Array<{ x: number; y: number }> }, photons: PhotonSample[]): Promise<EvalMetrics>;
+}
+
 let pendingEval: Promise<EvalMetrics> | null = null;
+
+export class BioVisionRemoteEvaluator implements PerceptualEvaluator {
+  private readonly apiBaseUrl: string;
+
+  constructor(apiBaseUrl: string) {
+    this.apiBaseUrl = apiBaseUrl;
+  }
+
+  async evaluate(frame: FrameSample, field: { points: Array<{ x: number; y: number }> }, photons: PhotonSample[]): Promise<EvalMetrics> {
+    const response = await fetch(`${this.apiBaseUrl.replace(/\/$/, '')}/api/perceptual/evaluate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        frame_width: frame.width,
+        frame_height: frame.height,
+        target_points: field.points.length,
+        sample: photons.slice(0, 1024),
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Remote evaluator failed with status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    return {
+      readability: Number(payload.readability ?? 0),
+      coverage: Number(payload.coverage ?? 0),
+      stability: Number(payload.stability ?? 0),
+    };
+  }
+}
+
+export class EdgeAwareLocalEvaluator implements PerceptualEvaluator {
+  async evaluate(frame: FrameSample, field: { points: Array<{ x: number; y: number }> }, photons: PhotonSample[]): Promise<EvalMetrics> {
+    const photonState: PhotonState[] = photons.map((photon) => ({
+      pos: { x: photon.x, y: photon.y },
+      vel: { x: photon.vx, y: photon.vy },
+    }));
+    return evaluateWithEdgeModel(photonState, frame.width, frame.height, { morphology: { family: field.points.length ? 'shape' : 'void' } });
+  }
+}
+
+export function feedbackAdjustments(
+  metrics: EvalMetrics,
+  coherence: number,
+  coherenceTarget: number,
+  flowMag: number,
+  noiseMax: number,
+): { coherence: number; flowMag: number; noiseMax: number } {
+  if (metrics.readability < 0.45) {
+    return {
+      coherence: clamp(coherence + 0.02, 0.05, coherenceTarget + 0.12),
+      flowMag: clamp(flowMag * 0.98, 0.1, 1.5),
+      noiseMax: clamp(noiseMax - 0.08, 0.35, 6.5),
+    };
+  }
+
+  return {
+    coherence: coherence + (coherenceTarget - coherence) * 0.04,
+    flowMag: clamp(flowMag + 0.01, 0.1, 1.5),
+    noiseMax: clamp(noiseMax * 0.995, 0.35, 6.5),
+  };
+}
 
 export function perceptualFeedbackLoop(
   photons: PhotonState[],
@@ -97,4 +178,8 @@ function evaluateWithEdgeModel(photons: PhotonState[], W: number, H: number, las
   const readability = Math.max(0, Math.min(1, 1 - Math.abs(coverage - targetCoverage) / Math.max(targetCoverage, 0.05)));
 
   return { readability, coverage, stability };
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
 }

--- a/shape-compiler.ts
+++ b/shape-compiler.ts
@@ -4,6 +4,38 @@ export interface TargetPoint {
   color: number[];
 }
 
+export interface Viewport {
+  width: number;
+  height: number;
+}
+
+export interface CompiledField {
+  points: TargetPoint[];
+}
+
+export function compileGlyphFieldFromAlphaMask(
+  alphaMask: Uint8Array,
+  viewport: Viewport,
+  colorHex: string,
+): CompiledField {
+  const points: TargetPoint[] = [];
+  const step = Math.max(1, Math.floor(viewport.width / 160));
+  const color = hexToLinear(colorHex);
+
+  for (let y = 0; y < viewport.height; y += step) {
+    for (let x = 0; x < viewport.width; x += step) {
+      const idx = y * viewport.width + x;
+      if (alphaMask[idx] > 120) {
+        points.push({ x, y, color });
+      }
+    }
+  }
+
+  return { points };
+}
+
+export function compileShapeField(lcl: any, viewport: Viewport): CompiledField;
+
 export function compileGlyphField(
   lcl: any,
   memCtx: CanvasRenderingContext2D,
@@ -84,37 +116,44 @@ export function compileSceneField(
 
 export function compileShapeField(
   lcl: any,
-  W: number,
-  H: number,
-  CX: number,
-  CY: number,
-  hexToLinear: (hex: string) => number[],
-  lerp: (a: number, b: number, t: number) => number,
-  clamp: (v: number, lo: number, hi: number) => number,
-  setTargetField: (pts: TargetPoint[]) => void,
-): void {
+  WOrViewport: number | Viewport,
+  H?: number,
+  CX?: number,
+  CY?: number,
+  hexToLinearFn: (hex: string) => number[] = hexToLinear,
+  lerpFn: (a: number, b: number, t: number) => number = lerp,
+  clampFn: (v: number, lo: number, hi: number) => number = clamp,
+  setTargetField?: (pts: TargetPoint[]) => void,
+): void | CompiledField {
   const pts: TargetPoint[] = [];
+  const viewport = typeof WOrViewport === 'number'
+    ? { width: WOrViewport, height: H ?? WOrViewport }
+    : WOrViewport;
+  const W = viewport.width;
+  const HResolved = viewport.height;
+  const CXResolved = CX ?? W / 2;
+  const CYResolved = CY ?? HResolved / 2;
   const family = lcl.morphology.family;
-  const density = clamp(lcl.morphology.density, 0.1, 1.0);
+  const density = clampFn(lcl.morphology.density, 0.1, 1.0);
   const count = Math.floor((lcl.constraints.max_targets || 12000) * density);
-  const scale = Math.min(W, H) * clamp(lcl.morphology.scale, 0.12, 0.55);
-  const palette = (lcl.optics.palette || ['#FFFFFF']).map(hexToLinear);
+  const scale = Math.min(W, HResolved) * clampFn(lcl.morphology.scale, 0.12, 0.55);
+  const palette = (lcl.optics.palette || ['#FFFFFF']).map(hexToLinearFn);
 
   for (let i = 0; i < count; i++) {
     const t = i / Math.max(count, 1);
-    let x = CX;
-    let y = CY;
+    let x = CXResolved;
+    let y = CYResolved;
 
     if (family === 'sphere') {
       const r = scale * Math.sqrt(Math.random());
       const ang = Math.random() * Math.PI * 2;
-      x = CX + Math.cos(ang) * r;
-      y = CY + Math.sin(ang) * r;
+      x = CXResolved + Math.cos(ang) * r;
+      y = CYResolved + Math.sin(ang) * r;
     } else if (family === 'spiral_vortex') {
       const theta = t * Math.PI * 18;
       const r = 8 + t * scale;
-      x = CX + Math.cos(theta) * r;
-      y = CY + Math.sin(theta) * r * 0.55 - t * scale * 0.28;
+      x = CXResolved + Math.cos(theta) * r;
+      y = CYResolved + Math.sin(theta) * r * 0.55 - t * scale * 0.28;
     }
 
     const c0 = palette[i % palette.length];
@@ -123,9 +162,28 @@ export function compileShapeField(
     pts.push({
       x,
       y,
-      color: [lerp(c0[0], c1[0], mix), lerp(c0[1], c1[1], mix), lerp(c0[2], c1[2], mix)],
+      color: [lerpFn(c0[0], c1[0], mix), lerpFn(c0[1], c1[1], mix), lerpFn(c0[2], c1[2], mix)],
     });
   }
 
-  setTargetField(pts);
+  if (setTargetField) {
+    setTargetField(pts);
+    return;
+  }
+
+  return { points: pts };
+}
+
+function hexToLinear(hex: string): number[] {
+  const normalized = hex.replace('#', '');
+  const values = [0, 2, 4].map((offset) => parseInt(normalized.substring(offset, offset + 2), 16) / 255);
+  return values.map((value) => (value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4));
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
 }


### PR DESCRIPTION
### Motivation
- Fix multiple TypeScript/Node runtime breakages that caused the Node test suite to fail and restore kernel → LCL → formation retrieval pipeline behavior. 
- Provide the runtime-facing helpers and types the kernel expects so front-end runtime and automated tests can run deterministically. 
- Add missing runtime modules used by tests (control governor/handler) and make compiler/perceptual layers return usable field objects instead of callback-only APIs. 

### Description
- Add and export LCL shapes and helpers in `light-control-language.ts`, including `MotionArchetype`, `FormationReference`, `interpretWithBackendLLM`, and `normalizeLCL`, plus `retrieved_formation`/`runtime_bias` fields to the `LightControlLanguage` structure. 
- Make `shape-compiler.ts` return a usable `CompiledField` and `Viewport`, add `compileGlyphFieldFromAlphaMask`, and provide helper functions (`hexToLinear`, `lerp`, `clamp`) so the kernel can consume compiled target points directly. 
- Implement `PerceptualEvaluator` and concrete evaluators in `perceptual-feedback.ts` (`BioVisionRemoteEvaluator`, `EdgeAwareLocalEvaluator`) and add `feedbackAdjustments` and small helper fixes to avoid unsupported TS syntax under Node strip-only mode. 
- Add missing `am_control_handler.js` containing `RuntimeGovernor` and `ControlHandlerV3` used by JS tests, adjust imports in `kernel.ts`/`formation-retriever.ts` to `.ts` ESM paths and convert some imports to `type` imports where appropriate, and simplify JSON parsing error handling. 
- Replace the placeholder kernel test with a runnable `node:test` suite in `kernel.test.ts` that provides deterministic mocks for Canvas/WebGL/fetch and covers init, interpret, reset, resize, and start/stop. 

### Testing
- Ran the Python test suite with `python -m pytest -q`, which completed successfully (45 tests passed). 
- Ran the Node test suite with `node --test`, which completed successfully (6 tests passed). 
- After changes, both automated test suites passed with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd3847fdd08320b2010e6a95a88da0)