### PR TITLE
Add canonical AI Particle Control contract and adapter

### DIFF
--- a/docs/03_INTERFACES.md
+++ b/docs/03_INTERFACES.md
@@ -13,9 +13,16 @@ Input:
 - certainty/latency signals
 
 Output:
-- visual_manifestation params (shape, turbulence, chroma, cadence)
+- canonical `AI Particle Control Contract` split into:
+  - `intent_state` (stateful intent semantics for cognition)
+  - `renderer_controls` (explicit renderer/runtime knobs)
 
 Rule: แสงต้องเป็นภาษาของ state ไม่ใช่ ambient effect
+
+Canonical control rules:
+- `intent_state` is the only authoring surface for AI/backend planners.
+- `renderer_controls` MUST be produced by `tools/contracts/particle_control_adapter.py` rather than ad-hoc frontend/backend normalization.
+- Shared governed fields: `state`, `shape`, `particle_density`, `velocity`, `turbulence`, `cohesion`, `flow_direction`, `glow_intensity`, `flicker`, `attractor`, `palette`.
 
 ### Manifestation Gate
 - CHAT intents ต้องผ่าน threshold
@@ -32,6 +39,7 @@ Pipeline stage contract (canonical):
 - `Intent -> SemanticField -> MorphogenesisEngine -> LightCompiler -> CognitiveFieldRuntime`
 
 Compatibility rules:
+- `CognitiveFieldRuntime` MUST compile `intent_state -> renderer_controls` through the canonical adapter before emitting `EMBODIMENT_V1` or `EMBODIMENT_V2`.
 - `CognitiveFieldRuntime` MUST emit the existing renderer ingestion ABI (`EMBODIMENT_V1`) without breaking field compatibility.
 - Direct visual mapping path remains available as fallback mode when either feature flag is disabled:
   - `light_cognition_layer_enabled`

--- a/docs/04_DATA_SCHEMAS.md
+++ b/docs/04_DATA_SCHEMAS.md
@@ -10,6 +10,15 @@
 - `payload_ptr` + `rkey`: zero-copy RDMA payload access
 - `ghost_flag`: แยก speculative message ออกจาก canonical flow
 
+## AI Particle Control Contract V1
+Canonical contract file: `docs/schemas/ai_particle_control_contract_v1.json`
+
+บล็อกหลักถูกแยกชัดเจนเป็น:
+- `intent_state` — semantic controls ที่ AI/agent ควร author เช่น `state`, `shape`, `particle_density`, `velocity`, `turbulence`, `cohesion`, `flow_direction`, `glow_intensity`, `flicker`, `attractor`, `palette`
+- `renderer_controls` — renderer/runtime specific fields เช่น `base_shape`, `chromatic_mode`, `particle_count`, `flow_field`, `shader_uniforms`, `runtime_profile`
+
+เหตุผล: ทำให้ authoring surface ซื่อสัตย์ต่อสถานะการคิดจริง ขณะเดียวกันก็ลด drift จากการ normalize คนละแบบระหว่าง backend/frontend ผ่าน adapter กลาง
+
 ## Embodiment Contract V1
 แยกเป็นบล็อกสำคัญ:
 - intent
@@ -52,6 +61,7 @@ Internal stage data models:
 Backwards compatibility:
 - Runtime output still targets `EMBODIMENT_V1` renderer ingestion shape.
 - New contracts are additive and can be gated by runtime feature flags.
+- Normalization from semantic intent into renderer/runtime controls MUST go through `tools/contracts/particle_control_adapter.py`.
 
 ## Embodiment Contract V2 (Explicit Envelope)
 Canonical contract file: `docs/schemas/embodiment_v2.json`
@@ -63,5 +73,7 @@ Required envelope sections:
 - `runtime_tick_policy`
 
 Compatibility policy:
-- Legacy consumers reading `visual_parameters` MUST use adapter `tools/contracts/protocol_adapter.py`.
+- `particle_control.intent_state` is the canonical semantic control block shared with `cognitive_emit_request_v1`.
+- `light_program.renderer_controls` is the canonical compiled renderer block shared with `embodiment_v2`.
+- Legacy consumers reading `visual_parameters` MUST use adapter `tools/contracts/protocol_adapter.py`, which in turn consumes the canonical particle control adapter output.
 - Schema lint enforces `x-field-evolution` metadata + required section presence for every governed contract.

--- a/docs/schemas/ai_particle_control_contract_v1.json
+++ b/docs/schemas/ai_particle_control_contract_v1.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aetherium.dev/schemas/ai_particle_control_contract_v1.json",
+  "title": "AIParticleControlContractV1",
+  "description": "Canonical AI particle control contract separating intent/state semantics from renderer/runtime fields.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["intent_state", "renderer_controls"],
+  "properties": {
+    "intent_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "shape",
+        "particle_density",
+        "velocity",
+        "turbulence",
+        "cohesion",
+        "flow_direction",
+        "glow_intensity",
+        "flicker",
+        "attractor",
+        "palette"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": ["idle", "thinking", "searching", "responding", "warning", "error", "transcendent"]
+        },
+        "shape": {
+          "type": "string",
+          "enum": ["ring", "helix", "spiral_vortex", "sphere", "stream", "burst", "lattice"]
+        },
+        "particle_density": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        "velocity": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        "turbulence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        "cohesion": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        "flow_direction": {
+          "type": "string",
+          "enum": ["clockwise", "counterclockwise", "inward", "outward", "centripetal", "centrifugal", "bidirectional", "still"]
+        },
+        "glow_intensity": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        "flicker": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        "attractor": {
+          "type": "string",
+          "enum": ["core", "halo", "axis", "orbit", "mesh", "none"]
+        },
+        "palette": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "primary", "secondary"],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["adaptive", "dual_tone", "thermal", "spectral", "monochrome"]
+            },
+            "primary": {"type": "string", "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"},
+            "secondary": {"type": "string", "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"},
+            "accent": {"type": "string", "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"}
+          }
+        }
+      }
+    },
+    "renderer_controls": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "base_shape",
+        "chromatic_mode",
+        "particle_count",
+        "flow_field",
+        "shader_uniforms",
+        "runtime_profile"
+      ],
+      "properties": {
+        "base_shape": {
+          "type": "string",
+          "enum": ["ring", "helix", "spiral_vortex", "sphere", "stream", "burst", "lattice"]
+        },
+        "chromatic_mode": {
+          "type": "string",
+          "enum": ["adaptive", "dual_tone", "thermal", "spectral", "monochrome"]
+        },
+        "particle_count": {"type": "integer", "minimum": 0, "maximum": 50000},
+        "flow_field": {
+          "type": "string",
+          "enum": ["clockwise", "counterclockwise", "inward", "outward", "centripetal", "centrifugal", "bidirectional", "still"]
+        },
+        "shader_uniforms": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [{"type": "number"}, {"type": "string"}, {"type": "boolean"}]
+          },
+          "required": ["glow_intensity", "flicker", "cohesion"]
+        },
+        "runtime_profile": {
+          "type": "string",
+          "enum": ["deterministic", "adaptive", "low_power", "cinematic"]
+        }
+      }
+    }
+  },
+  "x-field-evolution": {
+    "introduced_in": "ai_particle_control_contract_v1",
+    "supersedes": "none",
+    "compatibility_adapter": "tools.contracts.particle_control_adapter",
+    "required_evolution_sections": ["intent_state", "renderer_controls"]
+  }
+}

--- a/docs/schemas/cognitive_emit_request_v1.json
+++ b/docs/schemas/cognitive_emit_request_v1.json
@@ -4,28 +4,306 @@
   "title": "CognitiveEmitRequestV1",
   "type": "object",
   "additionalProperties": false,
-  "required": ["session_id", "model_response", "model_metadata"],
+  "required": [
+    "session_id",
+    "model_response",
+    "model_metadata"
+  ],
+  "$defs": {
+    "particle_control": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://aetherium.dev/schemas/ai_particle_control_contract_v1.json",
+      "title": "AIParticleControlContractV1",
+      "description": "Canonical AI particle control contract separating intent/state semantics from renderer/runtime fields.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "intent_state",
+        "renderer_controls"
+      ],
+      "properties": {
+        "intent_state": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "state",
+            "shape",
+            "particle_density",
+            "velocity",
+            "turbulence",
+            "cohesion",
+            "flow_direction",
+            "glow_intensity",
+            "flicker",
+            "attractor",
+            "palette"
+          ],
+          "properties": {
+            "state": {
+              "type": "string",
+              "enum": [
+                "idle",
+                "thinking",
+                "searching",
+                "responding",
+                "warning",
+                "error",
+                "transcendent"
+              ]
+            },
+            "shape": {
+              "type": "string",
+              "enum": [
+                "ring",
+                "helix",
+                "spiral_vortex",
+                "sphere",
+                "stream",
+                "burst",
+                "lattice"
+              ]
+            },
+            "particle_density": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "velocity": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "turbulence": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "cohesion": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "flow_direction": {
+              "type": "string",
+              "enum": [
+                "clockwise",
+                "counterclockwise",
+                "inward",
+                "outward",
+                "centripetal",
+                "centrifugal",
+                "bidirectional",
+                "still"
+              ]
+            },
+            "glow_intensity": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "flicker": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "attractor": {
+              "type": "string",
+              "enum": [
+                "core",
+                "halo",
+                "axis",
+                "orbit",
+                "mesh",
+                "none"
+              ]
+            },
+            "palette": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "mode",
+                "primary",
+                "secondary"
+              ],
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "adaptive",
+                    "dual_tone",
+                    "thermal",
+                    "spectral",
+                    "monochrome"
+                  ]
+                },
+                "primary": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+                },
+                "secondary": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+                },
+                "accent": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+                }
+              }
+            }
+          }
+        },
+        "renderer_controls": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "base_shape",
+            "chromatic_mode",
+            "particle_count",
+            "flow_field",
+            "shader_uniforms",
+            "runtime_profile"
+          ],
+          "properties": {
+            "base_shape": {
+              "type": "string",
+              "enum": [
+                "ring",
+                "helix",
+                "spiral_vortex",
+                "sphere",
+                "stream",
+                "burst",
+                "lattice"
+              ]
+            },
+            "chromatic_mode": {
+              "type": "string",
+              "enum": [
+                "adaptive",
+                "dual_tone",
+                "thermal",
+                "spectral",
+                "monochrome"
+              ]
+            },
+            "particle_count": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 50000
+            },
+            "flow_field": {
+              "type": "string",
+              "enum": [
+                "clockwise",
+                "counterclockwise",
+                "inward",
+                "outward",
+                "centripetal",
+                "centrifugal",
+                "bidirectional",
+                "still"
+              ]
+            },
+            "shader_uniforms": {
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ]
+              },
+              "required": [
+                "glow_intensity",
+                "flicker",
+                "cohesion"
+              ]
+            },
+            "runtime_profile": {
+              "type": "string",
+              "enum": [
+                "deterministic",
+                "adaptive",
+                "low_power",
+                "cinematic"
+              ]
+            }
+          }
+        }
+      },
+      "x-field-evolution": {
+        "introduced_in": "ai_particle_control_contract_v1",
+        "supersedes": "none",
+        "compatibility_adapter": "tools.contracts.particle_control_adapter",
+        "required_evolution_sections": [
+          "intent_state",
+          "renderer_controls"
+        ]
+      },
+      "x-canonical-source": "docs/schemas/ai_particle_control_contract_v1.json"
+    }
+  },
   "properties": {
-    "session_id": {"type": "string", "minLength": 1},
+    "session_id": {
+      "type": "string",
+      "minLength": 1
+    },
     "model_response": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["trace_id", "reasoning_trace", "intent_vector", "visual_manifestation"],
+      "required": [
+        "trace_id",
+        "reasoning_trace",
+        "intent_vector",
+        "particle_control",
+        "visual_manifestation"
+      ],
       "properties": {
-        "trace_id": {"type": "string", "minLength": 1},
-        "reasoning_trace": {"type": "string", "minLength": 1},
+        "trace_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reasoning_trace": {
+          "type": "string",
+          "minLength": 1
+        },
         "intent_vector": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["category", "emotional_valence", "energy_level"],
+          "required": [
+            "category",
+            "emotional_valence",
+            "energy_level"
+          ],
           "properties": {
-            "category": {"type": "string", "minLength": 1},
-            "emotional_valence": {"type": "number", "minimum": -1.0, "maximum": 1.0},
-            "energy_level": {"type": "number", "minimum": 0.0, "maximum": 1.0}
+            "category": {
+              "type": "string",
+              "minLength": 1
+            },
+            "emotional_valence": {
+              "type": "number",
+              "minimum": -1.0,
+              "maximum": 1.0
+            },
+            "energy_level": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            }
           }
+        },
+        "particle_control": {
+          "$ref": "#/$defs/particle_control"
         },
         "visual_manifestation": {
           "type": "object",
+          "description": "Legacy-compatible view. Producers SHOULD derive this block from particle_control via tools/contracts/particle_control_adapter.py.",
           "additionalProperties": false,
           "required": [
             "base_shape",
@@ -35,31 +313,110 @@
             "chromatic_mode"
           ],
           "properties": {
-            "base_shape": {"type": "string", "minLength": 1},
-            "transition_type": {"type": "string", "minLength": 1},
+            "base_shape": {
+              "type": "string",
+              "enum": [
+                "ring",
+                "helix",
+                "spiral_vortex",
+                "sphere",
+                "stream",
+                "burst",
+                "lattice"
+              ]
+            },
+            "transition_type": {
+              "type": "string",
+              "enum": [
+                "pulse",
+                "bloom",
+                "ripple",
+                "morph",
+                "strobe",
+                "fade"
+              ]
+            },
             "color_palette": {
               "type": "object",
               "additionalProperties": false,
-              "required": ["primary"],
+              "required": [
+                "primary"
+              ],
               "properties": {
-                "primary": {"type": "string", "minLength": 1},
-                "secondary": {"type": ["string", "null"]}
+                "primary": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+                },
+                "secondary": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+                }
               }
             },
             "particle_physics": {
               "type": "object",
               "additionalProperties": false,
-              "required": ["turbulence", "flow_direction", "luminance_mass"],
+              "required": [
+                "turbulence",
+                "flow_direction",
+                "luminance_mass",
+                "particle_count"
+              ],
               "properties": {
-                "turbulence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
-                "flow_direction": {"type": "string", "minLength": 1},
-                "luminance_mass": {"type": "number", "minimum": 0.0, "maximum": 1.0},
-                "particle_count": {"type": "integer", "minimum": 0, "default": 0}
+                "turbulence": {
+                  "type": "number",
+                  "minimum": 0.0,
+                  "maximum": 1.0
+                },
+                "flow_direction": {
+                  "type": "string",
+                  "enum": [
+                    "clockwise",
+                    "counterclockwise",
+                    "inward",
+                    "outward",
+                    "centripetal",
+                    "centrifugal",
+                    "bidirectional",
+                    "still"
+                  ]
+                },
+                "luminance_mass": {
+                  "type": "number",
+                  "minimum": 0.0,
+                  "maximum": 1.0
+                },
+                "particle_count": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 50000,
+                  "default": 0
+                }
               }
             },
-            "chromatic_mode": {"type": "string", "minLength": 1},
-            "emergency_override": {"type": "boolean", "default": false},
-            "device_tier": {"type": "integer", "minimum": 1, "maximum": 4, "default": 1}
+            "chromatic_mode": {
+              "type": "string",
+              "enum": [
+                "adaptive",
+                "dual_tone",
+                "thermal",
+                "spectral",
+                "monochrome"
+              ]
+            },
+            "emergency_override": {
+              "type": "boolean",
+              "default": false
+            },
+            "device_tier": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 4,
+              "default": 1
+            }
           }
         }
       }
@@ -67,18 +424,35 @@
     "model_metadata": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["model_name", "temperature", "max_tokens"],
+      "required": [
+        "model_name",
+        "temperature",
+        "max_tokens"
+      ],
       "properties": {
-        "model_name": {"type": "string", "minLength": 1},
-        "temperature": {"type": "number", "minimum": 0.0, "maximum": 2.0},
-        "max_tokens": {"type": "integer", "exclusiveMinimum": 0}
+        "model_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "temperature": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 2.0
+        },
+        "max_tokens": {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        }
       }
     }
   },
   "x-field-evolution": {
     "introduced_in": "cognitive_emit_request_v1",
     "supersedes": "none",
-    "compatibility_adapter": "runtime:api_gateway.main.CognitiveEmitRequest",
-    "required_evolution_sections": ["model_response", "model_metadata"]
+    "compatibility_adapter": "tools.contracts.particle_control_adapter.to_visual_manifestation",
+    "required_evolution_sections": [
+      "model_response",
+      "model_metadata"
+    ]
   }
 }

--- a/docs/schemas/embodiment_v2.json
+++ b/docs/schemas/embodiment_v2.json
@@ -1,6 +1,246 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "EmbodimentContractV2",
+  "$defs": {
+    "particle_control": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://aetherium.dev/schemas/ai_particle_control_contract_v1.json",
+      "title": "AIParticleControlContractV1",
+      "description": "Canonical AI particle control contract separating intent/state semantics from renderer/runtime fields.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "intent_state",
+        "renderer_controls"
+      ],
+      "properties": {
+        "intent_state": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "state",
+            "shape",
+            "particle_density",
+            "velocity",
+            "turbulence",
+            "cohesion",
+            "flow_direction",
+            "glow_intensity",
+            "flicker",
+            "attractor",
+            "palette"
+          ],
+          "properties": {
+            "state": {
+              "type": "string",
+              "enum": [
+                "idle",
+                "thinking",
+                "searching",
+                "responding",
+                "warning",
+                "error",
+                "transcendent"
+              ]
+            },
+            "shape": {
+              "type": "string",
+              "enum": [
+                "ring",
+                "helix",
+                "spiral_vortex",
+                "sphere",
+                "stream",
+                "burst",
+                "lattice"
+              ]
+            },
+            "particle_density": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "velocity": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "turbulence": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "cohesion": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "flow_direction": {
+              "type": "string",
+              "enum": [
+                "clockwise",
+                "counterclockwise",
+                "inward",
+                "outward",
+                "centripetal",
+                "centrifugal",
+                "bidirectional",
+                "still"
+              ]
+            },
+            "glow_intensity": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "flicker": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "attractor": {
+              "type": "string",
+              "enum": [
+                "core",
+                "halo",
+                "axis",
+                "orbit",
+                "mesh",
+                "none"
+              ]
+            },
+            "palette": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "mode",
+                "primary",
+                "secondary"
+              ],
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "adaptive",
+                    "dual_tone",
+                    "thermal",
+                    "spectral",
+                    "monochrome"
+                  ]
+                },
+                "primary": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+                },
+                "secondary": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+                },
+                "accent": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+                }
+              }
+            }
+          }
+        },
+        "renderer_controls": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "base_shape",
+            "chromatic_mode",
+            "particle_count",
+            "flow_field",
+            "shader_uniforms",
+            "runtime_profile"
+          ],
+          "properties": {
+            "base_shape": {
+              "type": "string",
+              "enum": [
+                "ring",
+                "helix",
+                "spiral_vortex",
+                "sphere",
+                "stream",
+                "burst",
+                "lattice"
+              ]
+            },
+            "chromatic_mode": {
+              "type": "string",
+              "enum": [
+                "adaptive",
+                "dual_tone",
+                "thermal",
+                "spectral",
+                "monochrome"
+              ]
+            },
+            "particle_count": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 50000
+            },
+            "flow_field": {
+              "type": "string",
+              "enum": [
+                "clockwise",
+                "counterclockwise",
+                "inward",
+                "outward",
+                "centripetal",
+                "centrifugal",
+                "bidirectional",
+                "still"
+              ]
+            },
+            "shader_uniforms": {
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ]
+              },
+              "required": [
+                "glow_intensity",
+                "flicker",
+                "cohesion"
+              ]
+            },
+            "runtime_profile": {
+              "type": "string",
+              "enum": [
+                "deterministic",
+                "adaptive",
+                "low_power",
+                "cinematic"
+              ]
+            }
+          }
+        }
+      },
+      "x-field-evolution": {
+        "introduced_in": "ai_particle_control_contract_v1",
+        "supersedes": "none",
+        "compatibility_adapter": "tools.contracts.particle_control_adapter",
+        "required_evolution_sections": [
+          "intent_state",
+          "renderer_controls"
+        ]
+      },
+      "x-canonical-source": "docs/schemas/ai_particle_control_contract_v1.json"
+    }
+  },
   "x-field-evolution": {
     "introduced_in": "2.0.0",
     "supersedes": "EMBODIMENT_V1",
@@ -9,7 +249,8 @@
       "semantic_field",
       "morphogenesis_plan",
       "light_program",
-      "runtime_tick_policy"
+      "runtime_tick_policy",
+      "particle_control"
     ]
   },
   "type": "object",
@@ -18,7 +259,8 @@
     "semantic_field",
     "morphogenesis_plan",
     "light_program",
-    "runtime_tick_policy"
+    "runtime_tick_policy",
+    "particle_control"
   ],
   "properties": {
     "contract_type": {
@@ -27,54 +269,214 @@
     },
     "semantic_field": {
       "type": "object",
-      "required": ["semantic_tensors", "polarity", "ambiguity"],
+      "required": [
+        "semantic_tensors",
+        "polarity",
+        "ambiguity"
+      ],
       "properties": {
         "semantic_tensors": {
           "type": "object",
-          "additionalProperties": {"type": "number"}
+          "additionalProperties": {
+            "type": "number"
+          }
         },
-        "polarity": {"type": "number", "minimum": -1, "maximum": 1},
-        "ambiguity": {"type": "number", "minimum": 0, "maximum": 1}
+        "polarity": {
+          "type": "number",
+          "minimum": -1,
+          "maximum": 1
+        },
+        "ambiguity": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
       },
       "additionalProperties": true
     },
     "morphogenesis_plan": {
       "type": "object",
-      "required": ["topology_seeds", "attractors", "constraints", "temporal_operators"],
+      "required": [
+        "topology_seeds",
+        "attractors",
+        "constraints",
+        "temporal_operators"
+      ],
       "properties": {
-        "topology_seeds": {"type": "array", "items": {"type": "string"}},
-        "attractors": {"type": "array", "items": {"type": "string"}},
-        "constraints": {"type": "array", "items": {"type": "string"}},
-        "temporal_operators": {"type": "array", "items": {"type": "string"}}
+        "topology_seeds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "attractors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "temporal_operators": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       },
       "additionalProperties": true
     },
+    "particle_control": {
+      "$ref": "#/$defs/particle_control"
+    },
     "light_program": {
       "type": "object",
-      "required": ["shader_uniforms", "particle_targets", "force_field_descriptors"],
+      "description": "Compiled renderer/runtime payload derived from particle_control.renderer_controls via tools/contracts/particle_control_adapter.py.",
+      "required": [
+        "renderer_controls",
+        "shader_uniforms",
+        "particle_targets",
+        "force_field_descriptors"
+      ],
       "properties": {
+        "renderer_controls": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "base_shape",
+            "chromatic_mode",
+            "particle_count",
+            "flow_field",
+            "shader_uniforms",
+            "runtime_profile"
+          ],
+          "properties": {
+            "base_shape": {
+              "type": "string",
+              "enum": [
+                "ring",
+                "helix",
+                "spiral_vortex",
+                "sphere",
+                "stream",
+                "burst",
+                "lattice"
+              ]
+            },
+            "chromatic_mode": {
+              "type": "string",
+              "enum": [
+                "adaptive",
+                "dual_tone",
+                "thermal",
+                "spectral",
+                "monochrome"
+              ]
+            },
+            "particle_count": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 50000
+            },
+            "flow_field": {
+              "type": "string",
+              "enum": [
+                "clockwise",
+                "counterclockwise",
+                "inward",
+                "outward",
+                "centripetal",
+                "centrifugal",
+                "bidirectional",
+                "still"
+              ]
+            },
+            "shader_uniforms": {
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ]
+              },
+              "required": [
+                "glow_intensity",
+                "flicker",
+                "cohesion"
+              ]
+            },
+            "runtime_profile": {
+              "type": "string",
+              "enum": [
+                "deterministic",
+                "adaptive",
+                "low_power",
+                "cinematic"
+              ]
+            }
+          }
+        },
         "shader_uniforms": {
           "type": "object",
           "additionalProperties": {
-            "oneOf": [{"type": "number"}, {"type": "string"}]
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
           }
         },
         "particle_targets": {
           "type": "object",
-          "additionalProperties": {"type": "number"}
+          "additionalProperties": {
+            "type": "number"
+          }
         },
-        "force_field_descriptors": {"type": "array", "items": {"type": "string"}
+        "force_field_descriptors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": true
     },
     "runtime_tick_policy": {
       "type": "object",
-      "required": ["tick_rate_hz", "mode"],
+      "required": [
+        "tick_rate_hz",
+        "mode"
+      ],
       "properties": {
-        "tick_rate_hz": {"type": "number", "exclusiveMinimum": 0},
-        "mode": {"type": "string", "enum": ["deterministic", "adaptive"]},
-        "jitter_budget_ms": {"type": "number", "minimum": 0}
+        "tick_rate_hz": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "deterministic",
+            "adaptive"
+          ]
+        },
+        "jitter_budget_ms": {
+          "type": "number",
+          "minimum": 0
+        }
       },
       "additionalProperties": false
     },
@@ -82,11 +484,37 @@
       "type": "object",
       "description": "Optional pre-adapted output for legacy consumers.",
       "properties": {
-        "base_shape": {"type": "string"},
-        "particle_density": {"type": "number"},
-        "turbulence": {"type": "number"},
-        "chromatic_aberration": {"type": "number"},
-        "tick_rate_hz": {"type": "number", "exclusiveMinimum": 0}
+        "base_shape": {
+          "type": "string",
+          "enum": [
+            "ring",
+            "helix",
+            "spiral_vortex",
+            "sphere",
+            "stream",
+            "burst",
+            "lattice"
+          ]
+        },
+        "particle_density": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "turbulence": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "chromatic_aberration": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "tick_rate_hz": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        }
       },
       "additionalProperties": true
     }

--- a/tools/contracts/particle_control_adapter.py
+++ b/tools/contracts/particle_control_adapter.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
+FLOW_DIRECTIONS = {
+    "clockwise",
+    "counterclockwise",
+    "inward",
+    "outward",
+    "centripetal",
+    "centrifugal",
+    "bidirectional",
+    "still",
+}
+
+SHAPES = {"ring", "helix", "spiral_vortex", "sphere", "stream", "burst", "lattice"}
+PALETTE_MODES = {"adaptive", "dual_tone", "thermal", "spectral", "monochrome"}
+
+
+def _clamp_float(value: Any, minimum: float = 0.0, maximum: float = 1.0, default: float = 0.0) -> float:
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError):
+        coerced = default
+    return max(minimum, min(maximum, coerced))
+
+
+def _coerce_enum(value: Any, allowed: set[str], default: str) -> str:
+    candidate = str(value or default)
+    return candidate if candidate in allowed else default
+
+
+def _particle_count_from_density(density: float) -> int:
+    return int(round(density * 50000))
+
+
+def to_renderer_controls(particle_control: dict[str, Any]) -> dict[str, Any]:
+    """Compile canonical particle intent/state into explicit renderer/runtime controls."""
+    intent = particle_control.get("intent_state", {})
+    palette = intent.get("palette", {})
+
+    shape = _coerce_enum(intent.get("shape"), SHAPES, "ring")
+    density = _clamp_float(intent.get("particle_density"), default=0.2)
+    glow_intensity = _clamp_float(intent.get("glow_intensity"), default=0.5)
+    flicker = _clamp_float(intent.get("flicker"), default=0.0)
+    cohesion = _clamp_float(intent.get("cohesion"), default=0.5)
+    velocity = _clamp_float(intent.get("velocity"), default=0.3)
+    turbulence = _clamp_float(intent.get("turbulence"), default=0.0)
+
+    return {
+        "base_shape": shape,
+        "chromatic_mode": _coerce_enum(palette.get("mode"), PALETTE_MODES, "adaptive"),
+        "particle_count": _particle_count_from_density(density),
+        "flow_field": _coerce_enum(intent.get("flow_direction"), FLOW_DIRECTIONS, "still"),
+        "shader_uniforms": {
+            "glow_intensity": glow_intensity,
+            "flicker": flicker,
+            "cohesion": cohesion,
+            "velocity": velocity,
+            "turbulence": turbulence,
+            "primary_color": palette.get("primary", "#FFFFFF"),
+            "secondary_color": palette.get("secondary", "#FFFFFF"),
+            "attractor": str(intent.get("attractor", "core")),
+            "state": str(intent.get("state", "idle")),
+        },
+        "runtime_profile": "cinematic" if density >= 0.75 else "adaptive" if velocity >= 0.6 else "deterministic",
+    }
+
+
+def to_visual_manifestation(particle_control: dict[str, Any], transition_type: str = "pulse", device_tier: int = 1) -> dict[str, Any]:
+    """Compile canonical particle control into legacy visual_manifestation shape."""
+    intent = particle_control.get("intent_state", {})
+    renderer = particle_control.get("renderer_controls") or to_renderer_controls(particle_control)
+    uniforms = renderer.get("shader_uniforms", {})
+
+    return {
+        "base_shape": renderer.get("base_shape", "ring"),
+        "transition_type": transition_type,
+        "color_palette": {
+            "primary": intent.get("palette", {}).get("primary", "#FFFFFF"),
+            "secondary": intent.get("palette", {}).get("secondary"),
+        },
+        "particle_physics": {
+            "turbulence": _clamp_float(intent.get("turbulence"), default=0.0),
+            "flow_direction": renderer.get("flow_field", "still"),
+            "luminance_mass": _clamp_float(intent.get("glow_intensity"), default=0.5),
+            "particle_count": int(renderer.get("particle_count", 0)),
+        },
+        "chromatic_mode": renderer.get("chromatic_mode", "adaptive"),
+        "emergency_override": False,
+        "device_tier": max(1, min(4, int(device_tier))),
+        "adapter_metadata": {
+            "cohesion": _clamp_float(uniforms.get("cohesion"), default=0.5),
+            "flicker": _clamp_float(uniforms.get("flicker"), default=0.0),
+            "velocity": _clamp_float(uniforms.get("velocity"), default=0.3),
+        },
+    }

--- a/tools/contracts/payloads/compatibility.embodiment_v2.payload.json
+++ b/tools/contracts/payloads/compatibility.embodiment_v2.payload.json
@@ -6,13 +6,60 @@
     "ambiguity": 0.21
   },
   "morphogenesis_plan": {
-    "topology_seeds": ["orb"],
+    "topology_seeds": ["sphere"],
     "attractors": ["coherence"],
     "constraints": ["turbulence<=0.21"],
     "temporal_operators": ["phase_lock"]
   },
+  "particle_control": {
+    "intent_state": {
+      "state": "responding",
+      "shape": "sphere",
+      "particle_density": 0.128,
+      "velocity": 0.5,
+      "turbulence": 0.21,
+      "cohesion": 0.58,
+      "flow_direction": "inward",
+      "glow_intensity": 0.66,
+      "flicker": 0.07,
+      "attractor": "core",
+      "palette": {
+        "mode": "adaptive",
+        "primary": "#88AAFF",
+        "secondary": "#CDE7FF"
+      }
+    },
+    "renderer_controls": {
+      "base_shape": "sphere",
+      "chromatic_mode": "adaptive",
+      "particle_count": 6400,
+      "flow_field": "inward",
+      "shader_uniforms": {
+        "glow_intensity": 0.66,
+        "flicker": 0.07,
+        "cohesion": 0.58,
+        "turbulence": 0.21,
+        "chromatic_aberration": 0.07
+      },
+      "runtime_profile": "deterministic"
+    }
+  },
   "light_program": {
-    "shader_uniforms": {"chromatic_aberration": 0.07},
+    "renderer_controls": {
+      "base_shape": "sphere",
+      "chromatic_mode": "adaptive",
+      "particle_count": 6400,
+      "flow_field": "inward",
+      "shader_uniforms": {
+        "glow_intensity": 0.66,
+        "flicker": 0.07,
+        "cohesion": 0.58,
+        "turbulence": 0.21,
+        "chromatic_aberration": 0.07
+      },
+      "runtime_profile": "deterministic"
+    },
+    "shader_uniforms": {"chromatic_aberration": 0.07, "turbulence": 0.21},
     "particle_targets": {"count": 6400},
     "force_field_descriptors": ["turbulence<=0.21"]
   },

--- a/tools/contracts/payloads/embodiment_v2.payload.json
+++ b/tools/contracts/payloads/embodiment_v2.payload.json
@@ -14,10 +14,58 @@
     "constraints": ["turbulence<=0.2", "chroma=adaptive"],
     "temporal_operators": ["phase_lock", "cadence_stabilize"]
   },
+  "particle_control": {
+    "intent_state": {
+      "state": "thinking",
+      "shape": "ring",
+      "particle_density": 0.156,
+      "velocity": 0.42,
+      "turbulence": 0.18,
+      "cohesion": 0.61,
+      "flow_direction": "clockwise",
+      "glow_intensity": 0.62,
+      "flicker": 0.04,
+      "attractor": "core",
+      "palette": {
+        "mode": "adaptive",
+        "primary": "#7C8CFF",
+        "secondary": "#4FC3FF"
+      }
+    },
+    "renderer_controls": {
+      "base_shape": "ring",
+      "chromatic_mode": "adaptive",
+      "particle_count": 7800,
+      "flow_field": "clockwise",
+      "shader_uniforms": {
+        "glow_intensity": 0.62,
+        "flicker": 0.04,
+        "cohesion": 0.61,
+        "turbulence": 0.18,
+        "chromatic_aberration": 0.04
+      },
+      "runtime_profile": "deterministic"
+    }
+  },
   "light_program": {
+    "renderer_controls": {
+      "base_shape": "ring",
+      "chromatic_mode": "adaptive",
+      "particle_count": 7800,
+      "flow_field": "clockwise",
+      "shader_uniforms": {
+        "glow_intensity": 0.62,
+        "flicker": 0.04,
+        "cohesion": 0.61,
+        "turbulence": 0.18,
+        "chromatic_aberration": 0.04
+      },
+      "runtime_profile": "deterministic"
+    },
     "shader_uniforms": {
       "shape": "ring",
-      "chromatic_aberration": 0.04
+      "chromatic_aberration": 0.04,
+      "turbulence": 0.18
     },
     "particle_targets": {
       "count": 7800,

--- a/tools/contracts/payloads/replay.embodiment_envelope_roundtrip.json
+++ b/tools/contracts/payloads/replay.embodiment_envelope_roundtrip.json
@@ -35,8 +35,55 @@
         "constraints": ["turbulence<=0.2"],
         "temporal_operators": ["phase_lock"]
       },
+      "particle_control": {
+        "intent_state": {
+          "state": "thinking",
+          "shape": "helix",
+          "particle_density": 0.1,
+          "velocity": 0.3,
+          "turbulence": 0.2,
+          "cohesion": 0.55,
+          "flow_direction": "counterclockwise",
+          "glow_intensity": 0.7,
+          "flicker": 0.05,
+          "attractor": "axis",
+          "palette": {
+            "mode": "spectral",
+            "primary": "#112233",
+            "secondary": "#445566"
+          }
+        },
+        "renderer_controls": {
+          "base_shape": "helix",
+          "chromatic_mode": "spectral",
+          "particle_count": 5000,
+          "flow_field": "counterclockwise",
+          "shader_uniforms": {
+            "glow_intensity": 0.7,
+            "flicker": 0.05,
+            "cohesion": 0.55,
+            "turbulence": 0.2,
+            "chromatic_aberration": 0.08
+          },
+          "runtime_profile": "deterministic"
+        }
+      },
       "light_program": {
-        "shader_uniforms": {"chromatic_aberration": 0.08},
+        "renderer_controls": {
+          "base_shape": "helix",
+          "chromatic_mode": "spectral",
+          "particle_count": 5000,
+          "flow_field": "counterclockwise",
+          "shader_uniforms": {
+            "glow_intensity": 0.7,
+            "flicker": 0.05,
+            "cohesion": 0.55,
+            "turbulence": 0.2,
+            "chromatic_aberration": 0.08
+          },
+          "runtime_profile": "deterministic"
+        },
+        "shader_uniforms": {"chromatic_aberration": 0.08, "turbulence": 0.2},
         "particle_targets": {"count": 5000},
         "force_field_descriptors": []
       },
@@ -49,7 +96,7 @@
       "contract_type": "EMBODIMENT_V1",
       "visual_parameters": {
         "base_shape": "helix",
-        "particle_density": 0.5,
+        "particle_density": 0.1,
         "turbulence": 0.2,
         "chromatic_aberration": 0.08,
         "tick_rate_hz": 25.0

--- a/tools/contracts/payloads/runtime_drift_cases.json
+++ b/tools/contracts/payloads/runtime_drift_cases.json
@@ -11,9 +11,40 @@
           "emotional_valence": -0.7,
           "energy_level": 0.8
         },
+        "particle_control": {
+          "intent_state": {
+            "state": "thinking",
+            "shape": "spiral_vortex",
+            "particle_density": 0.24,
+            "velocity": 0.6,
+            "turbulence": 0.4,
+            "cohesion": 0.7,
+            "flow_direction": "centripetal",
+            "glow_intensity": 0.9,
+            "flicker": 0.1,
+            "attractor": "core",
+            "palette": {
+              "mode": "spectral",
+              "primary": "#800080",
+              "secondary": "#00FFFF"
+            }
+          },
+          "renderer_controls": {
+            "base_shape": "spiral_vortex",
+            "chromatic_mode": "spectral",
+            "particle_count": 12000,
+            "flow_field": "centripetal",
+            "shader_uniforms": {
+              "glow_intensity": 0.9,
+              "flicker": 0.1,
+              "cohesion": 0.7
+            },
+            "runtime_profile": "adaptive"
+          }
+        },
         "visual_manifestation": {
           "base_shape": "spiral_vortex",
-          "transition_type": "morph_fluid",
+          "transition_type": "morph",
           "color_palette": {
             "primary": "#800080",
             "secondary": "#00FFFF"
@@ -24,7 +55,7 @@
             "luminance_mass": 0.9,
             "particle_count": 12000
           },
-          "chromatic_mode": "BIT_24_RGB",
+          "chromatic_mode": "spectral",
           "device_tier": 3
         }
       },
@@ -58,7 +89,7 @@
             "luminance_mass": 0.8,
             "particle_count": 1000
           },
-          "chromatic_mode": "BIT_24_RGB"
+          "chromatic_mode": "spectral"
         }
       },
       "model_metadata": {
@@ -92,7 +123,7 @@
             "luminance_mass": 0.8,
             "particle_count": 1000
           },
-          "chromatic_mode": "BIT_24_RGB"
+          "chromatic_mode": "spectral"
         }
       },
       "model_metadata": {
@@ -126,7 +157,38 @@
             "luminance_mass": 0.7,
             "particle_count": 400
           },
-          "chromatic_mode": "BIT_24_RGB"
+          "chromatic_mode": "spectral"
+        },
+        "particle_control": {
+          "intent_state": {
+            "state": "warning",
+            "shape": "ring",
+            "particle_density": 0.008,
+            "velocity": 0.2,
+            "turbulence": 0.1,
+            "cohesion": 0.6,
+            "flow_direction": "centripetal",
+            "glow_intensity": 0.7,
+            "flicker": 0.0,
+            "attractor": "core",
+            "palette": {
+              "mode": "spectral",
+              "primary": "#DC143C",
+              "secondary": "#FFB3C1"
+            }
+          },
+          "renderer_controls": {
+            "base_shape": "ring",
+            "chromatic_mode": "spectral",
+            "particle_count": 400,
+            "flow_field": "centripetal",
+            "shader_uniforms": {
+              "glow_intensity": 0.7,
+              "flicker": 0.0,
+              "cohesion": 0.6
+            },
+            "runtime_profile": "deterministic"
+          }
         }
       },
       "model_metadata": {

--- a/tools/contracts/protocol_adapter.py
+++ b/tools/contracts/protocol_adapter.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from tools.contracts.particle_control_adapter import to_renderer_controls
+
 
 def _to_float(value: Any, default: float = 0.0) -> float:
     if value is None or isinstance(value, bool):
@@ -44,11 +46,21 @@ def to_legacy_visual_parameters(payload: dict[str, Any]) -> dict[str, Any]:
         tick_policy = payload.get("runtime_tick_policy", {})
         shader_uniforms = light_program.get("shader_uniforms", {})
 
+        if isinstance(payload.get("particle_control"), dict):
+            renderer_controls = to_renderer_controls(payload["particle_control"])
+            shader_uniforms = renderer_controls.get("shader_uniforms", {})
+            particle_count = _to_float(renderer_controls.get("particle_count"), 0.0)
+            base_shape = renderer_controls.get("base_shape", "ring")
+        else:
+            renderer_controls = {}
+            particle_count = _to_float(light_program.get("particle_targets", {}).get("count"), 0.0)
+            base_shape = morphogenesis.get("topology_seeds", ["ring"])[0]
+
         return {
-            "base_shape": morphogenesis.get("topology_seeds", ["ring"])[0],
-            "particle_density": _to_float(light_program.get("particle_targets", {}).get("count"), 0.0) / 10_000.0,
-            "turbulence": _to_float(semantic_field.get("ambiguity"), 0.0),
-            "chromatic_aberration": _to_float(shader_uniforms.get("chromatic_aberration"), 0.0),
+            "base_shape": base_shape,
+            "particle_density": particle_count / 50_000.0,
+            "turbulence": _to_float(shader_uniforms.get("turbulence"), _to_float(semantic_field.get("ambiguity"), 0.0)),
+            "chromatic_aberration": _to_float(shader_uniforms.get("chromatic_aberration"), _to_float(light_program.get("shader_uniforms", {}).get("chromatic_aberration"), 0.0)),
             "tick_rate_hz": max(_to_float(tick_policy.get("tick_rate_hz"), 24.0), 0.001),
         }
 

--- a/tools/contracts/test_particle_control_adapter.py
+++ b/tools/contracts/test_particle_control_adapter.py
@@ -1,0 +1,63 @@
+from tools.contracts.particle_control_adapter import to_renderer_controls, to_visual_manifestation
+
+
+def test_to_renderer_controls_maps_canonical_fields() -> None:
+    payload = {
+        "intent_state": {
+            "state": "thinking",
+            "shape": "helix",
+            "particle_density": 0.5,
+            "velocity": 0.7,
+            "turbulence": 0.3,
+            "cohesion": 0.6,
+            "flow_direction": "counterclockwise",
+            "glow_intensity": 0.8,
+            "flicker": 0.1,
+            "attractor": "axis",
+            "palette": {
+                "mode": "spectral",
+                "primary": "#112233",
+                "secondary": "#445566"
+            }
+        }
+    }
+
+    renderer = to_renderer_controls(payload)
+
+    assert renderer["base_shape"] == "helix"
+    assert renderer["chromatic_mode"] == "spectral"
+    assert renderer["particle_count"] == 25000
+    assert renderer["flow_field"] == "counterclockwise"
+    assert renderer["shader_uniforms"]["glow_intensity"] == 0.8
+    assert renderer["runtime_profile"] == "adaptive"
+
+
+def test_to_visual_manifestation_uses_compiled_renderer_controls() -> None:
+    payload = {
+        "intent_state": {
+            "state": "responding",
+            "shape": "sphere",
+            "particle_density": 0.2,
+            "velocity": 0.3,
+            "turbulence": 0.2,
+            "cohesion": 0.4,
+            "flow_direction": "inward",
+            "glow_intensity": 0.9,
+            "flicker": 0.2,
+            "attractor": "core",
+            "palette": {
+                "mode": "adaptive",
+                "primary": "#AABBCC",
+                "secondary": "#DDEEFF"
+            }
+        }
+    }
+
+    visual = to_visual_manifestation(payload, transition_type="morph", device_tier=3)
+
+    assert visual["base_shape"] == "sphere"
+    assert visual["transition_type"] == "morph"
+    assert visual["particle_physics"]["flow_direction"] == "inward"
+    assert visual["particle_physics"]["particle_count"] == 10000
+    assert visual["chromatic_mode"] == "adaptive"
+    assert visual["device_tier"] == 3


### PR DESCRIPTION
### Motivation
- Unify AI→renderer contract by introducing a single canonical schema that cleanly separates intent/state from renderer/runtime controls to avoid ad-hoc normalization drift across frontend/backend.
- Provide an explicit compile/adapter surface so cognitive planners author `intent_state` while renderer-specific knobs are produced deterministically by a governed adapter.
- Surface and validate key control fields (`state`, `shape`, `particle_density`, `velocity`, `turbulence`, `cohesion`, `flow_direction`, `glow_intensity`, `flicker`, `attractor`, `palette`) with enums and bounds to reduce free-form string drift.

### Description
- Add canonical schema `docs/schemas/ai_particle_control_contract_v1.json` that splits `intent_state` and `renderer_controls` and specifies `enum`, `minimum`/`maximum`, and `required` for core fields. 
- Update documentation `docs/03_INTERFACES.md` and `docs/04_DATA_SCHEMAS.md` to reference the canonical contract and require the adapter-based compilation step. 
- Update `docs/schemas/cognitive_emit_request_v1.json` and `docs/schemas/embodiment_v2.json` to embed/reference the canonical particle control contract (added `particle_control` section) and to make legacy `visual_manifestation` / `light_program.renderer_controls` a derived/compiled view. 
- Implement `tools/contracts/particle_control_adapter.py` with `to_renderer_controls` and `to_visual_manifestation` functions and wire the adapter into `tools/contracts/protocol_adapter.py`; add mapping tests and refresh payload fixtures used by the contract checker. 

### Testing
- Ran unit tests: `python -m pytest tools/contracts/test_particle_control_adapter.py tools/contracts/contract_checker.py`, and the adapter tests plus contract checks passed. 
- Validated JSON files with `python -m json.tool` for `ai_particle_control_contract_v1.json`, `cognitive_emit_request_v1.json`, and `embodiment_v2.json`, which succeeded. 
- Executed `python tools/contracts/contract_checker.py` and the compatibility/round-trip checks and runtime drift guard completed with passing audits (envelope round-trip integrity and structural match satisfied). 
- All automated checks referenced above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdd487cb34832092de9f3f1d623d5c)