### PR TITLE
Refactor kernel to add ParticleControlSurface and formalize `particle_control` contract

### DIFF
--- a/formation-retriever.ts
+++ b/formation-retriever.ts
@@ -22,10 +22,13 @@ export interface FormationAnnotation {
   id: string;
   semanticTags?: string[];
   preferredFamilies?: string[];
-  forceBias?: number;
-  flowBias?: number;
-  noiseBias?: number;
-  coherenceStart?: number;
+  velocity?: number;
+  flowDirection?: string;
+  turbulence?: number;
+  cohesion?: number;
+  glowIntensity?: number;
+  flicker?: number;
+  attractor?: string;
   notes?: string;
 }
 
@@ -127,12 +130,15 @@ export function mergeRetrievedFormation(
   return {
     ...lcl,
     retrieved_formation: retrieved.reference,
-    runtime_bias: {
-      forceBias: annotation?.forceBias ?? 0.8,
-      flowBias: annotation?.flowBias ?? 0.7,
-      noiseBias: annotation?.noiseBias ?? 0.6,
-      coherenceStart: annotation?.coherenceStart ?? 0.12,
-      archetypePhrase: annotation?.notes ?? retrieved.reference.title,
+    particle_control: {
+      ...lcl.particle_control,
+      velocity: annotation?.velocity ?? lcl.particle_control.velocity,
+      flow_direction: annotation?.flowDirection ?? lcl.particle_control.flow_direction,
+      turbulence: annotation?.turbulence ?? lcl.particle_control.turbulence,
+      cohesion: annotation?.cohesion ?? lcl.particle_control.cohesion,
+      glow_intensity: annotation?.glowIntensity ?? lcl.particle_control.glow_intensity,
+      flicker: annotation?.flicker ?? lcl.particle_control.flicker,
+      attractor: annotation?.attractor ?? lcl.particle_control.attractor,
     },
   };
 }

--- a/kernel.test.ts
+++ b/kernel.test.ts
@@ -77,6 +77,16 @@ globalThis.fetch = (async (url: string | URL) => {
         content: { text: null, scene_recipe: null },
         constraints: { max_targets: 14000, max_photons: 7000, max_energy: 1.6 },
         source_text: 'create a golden spiral',
+        particle_control: {
+          velocity: 0.7,
+          turbulence: 0.2,
+          cohesion: 0.8,
+          flow_direction: 'still',
+          glow_intensity: 0.6,
+          flicker: 0.1,
+          attractor: 'core',
+          rhythm_hz: 0.2,
+        },
       },
     }));
   }

--- a/kernel.ts
+++ b/kernel.ts
@@ -2,7 +2,7 @@ import {
   interpretWithBackendLLM,
   normalizeLCL,
 } from './light-control-language.ts';
-import type { LightControlLanguage } from './light-control-language.ts';
+import type { LightControlLanguage, ParticleControlContract } from './light-control-language.ts';
 import {
   loadFormationBundle,
   mergeRetrievedFormation,
@@ -37,6 +37,109 @@ interface Photon {
   retargetCooldown: number;
 }
 
+interface PhotonMotionState {
+  attractorForce: number;
+  flow: [number, number];
+  turbulence: number;
+  damping: number;
+  glowBlend: number;
+  flicker: number;
+}
+
+interface PhotonDriftState {
+  damping: number;
+  glowFade: number;
+}
+
+interface RendererState {
+  glowIntensity: number;
+  flicker: number;
+}
+
+export class ParticleControlSurface {
+  private readonly viewport: Viewport;
+  private readonly time: number;
+  private readonly control: ParticleControlContract;
+  private readonly rhythm: number;
+  private readonly coherence: number;
+  readonly renderer: RendererState;
+  readonly drift: PhotonDriftState;
+
+  constructor(control: ParticleControlContract, viewport: Viewport, time: number, coherence: number) {
+    this.control = control;
+    this.viewport = viewport;
+    this.time = time;
+    this.coherence = clamp(coherence, 0, 1);
+    this.rhythm = (control.rhythm_hz ?? 0.1) * Math.PI * 2;
+    this.renderer = {
+      glowIntensity: clamp(control.glow_intensity, 0, 1),
+      flicker: clamp(control.flicker, 0, 1),
+    };
+    this.drift = {
+      damping: 0.86 + (this.coherence * 0.08),
+      glowFade: 0.94 + (this.renderer.glowIntensity * 0.04),
+    };
+  }
+
+  static fromLCL(lcl: LightControlLanguage, viewport: Viewport, time: number, coherence: number): ParticleControlSurface {
+    return new ParticleControlSurface(lcl.particle_control, viewport, time, coherence);
+  }
+
+  nextPhotonState(photon: Photon, target: CompiledField['points'][number]): PhotonMotionState {
+    const dx = target.x - photon.pos[0];
+    const dy = target.y - photon.pos[1];
+    const dist = Math.hypot(dx, dy) || 1;
+    const cohesion = clamp(this.control.cohesion, 0, 1);
+    const velocity = clamp(this.control.velocity, 0, 1);
+    const attractorForce = Math.min(dist * (0.03 + cohesion * 0.05), 1 + velocity * 6) * (0.25 + velocity * 0.75);
+
+    return {
+      attractorForce,
+      flow: this.sampleFlowField(photon.pos[0], photon.pos[1]),
+      turbulence: (1 - this.coherence) * (0.2 + this.control.turbulence * 5),
+      damping: 0.84 + cohesion * 0.12,
+      glowBlend: 0.04 + this.renderer.glowIntensity * 0.18,
+      flicker: (Math.random() - 0.5) * this.renderer.flicker * 0.08,
+    };
+  }
+
+  private sampleFlowField(x: number, y: number): [number, number] {
+    const { width, height } = this.viewport;
+    const cx = width * 0.5;
+    const cy = height * 0.5;
+    const dx = x - cx;
+    const dy = y - cy;
+    const len = Math.hypot(dx, dy) || 1;
+    const velocity = 0.15 + this.control.velocity * 1.1;
+    const turbulence = this.control.turbulence;
+    const waveX = Math.sin(y * 0.006 + this.time * this.rhythm);
+    const waveY = Math.cos(x * 0.005 - this.time * (this.rhythm * 0.8 + 0.2));
+    const attractorSign = this.control.attractor === 'edge' ? -1 : 1;
+
+    switch (this.control.flow_direction) {
+      case 'clockwise':
+      case 'orbit':
+        return [(-dy / len) * velocity, (dx / len) * velocity];
+      case 'counterclockwise':
+        return [(dy / len) * velocity, (-dx / len) * velocity];
+      case 'inward':
+      case 'centripetal':
+        return [(-dx / len) * velocity * attractorSign, (-dy / len) * velocity * attractorSign];
+      case 'outward':
+      case 'centrifugal':
+        return [(dx / len) * velocity * attractorSign, (dy / len) * velocity * attractorSign];
+      case 'upward':
+        return [waveX * velocity * 0.25, -velocity + waveY * turbulence * 0.35];
+      case 'ribbon':
+        return [waveX * velocity, waveY * velocity * 0.35];
+      case 'still':
+        return [0, 0];
+      default:
+        return [waveX * velocity * (0.4 + turbulence * 0.3), waveY * velocity * (0.35 + turbulence * 0.25)];
+    }
+  }
+}
+
 export class AetheriumKernel {
   private readonly gl: WebGL2RenderingContext;
   private readonly config: Required<KernelConfig>;
@@ -53,10 +156,7 @@ export class AetheriumKernel {
 
   private coherence = 0.1;
   private coherenceTarget = 0.1;
-  private force = 0.0;
-  private flowMag = 0.8;
-  private noiseMax = 5.0;
-  private damp = 0.92;
+  private controlSurface: ParticleControlSurface | null = null;
 
   constructor(config: KernelConfig) {
     this.config = {
@@ -106,18 +206,17 @@ export class AetheriumKernel {
 
       this.applyLCL(enriched);
     } catch (error) {
-      console.error("Error handling user light request:", error);
-      // Optionally, update the UI to show an error state.
+      console.error('Error handling user light request:', error);
     }
   }
 
   resetToVoid(): void {
-    this.pipelineRevision++; // Invalidate any pending operations
+    this.pipelineRevision++;
     this.lcl = null;
     this.compiledField = null;
-    this.initParticles(); // Reset photons to a default state
-    // The render loop will naturally fade to the void state.
-    console.log("Kernel reset to void.");
+    this.controlSurface = null;
+    this.initParticles();
+    console.log('Kernel reset to void.');
   }
 
   getLCLSchema(): LightControlLanguage | null {
@@ -171,16 +270,13 @@ export class AetheriumKernel {
     gl.clearColor(0.01, 0.01, 0.015, 1.0);
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.ONE, gl.ONE);
-    // Production: Create buffers, programs, glow pass framebuffer, and ping-pong accumulation.
   }
 
   private applyLCL(lcl: LightControlLanguage): void {
     this.lcl = lcl;
-    this.coherence = lcl.runtime_bias?.coherenceStart ?? 0.12;
+    this.coherence = lcl.particle_control.cohesion;
     this.coherenceTarget = lcl.motion.coherence_target;
-    this.force = 0.15 * (lcl.runtime_bias?.forceBias ?? 1.0);
-    this.flowMag = 0.7 * (lcl.runtime_bias?.flowBias ?? 1.0);
-    this.noiseMax = 5.0 * (lcl.runtime_bias?.noiseBias ?? 0.6);
+    this.controlSurface = ParticleControlSurface.fromLCL(lcl, this.viewport, this.time, this.coherence);
 
     if (lcl.intent === 'create_glyph') {
       const alphaMask = this.renderGlyphToAlphaMask(lcl.content.text ?? 'AETHERIUM');
@@ -217,18 +313,18 @@ export class AetheriumKernel {
   }
 
   private updatePhotons(): void {
-    if (!this.compiledField || this.compiledField.points.length === 0) {
-        // If there's no field, let particles drift and fade.
-        for (const photon of this.photons) {
-            photon.vel[0] *= 0.95;
-            photon.vel[1] *= 0.95;
-            photon.pos[0] += photon.vel[0];
-            photon.pos[1] += photon.vel[1];
-            photon.color[0] *= 0.97;
-            photon.color[1] *= 0.97;
-            photon.color[2] *= 0.97;
-        }
-        return;
+    const controlSurface = this.controlSurface;
+    if (!controlSurface || !this.compiledField || this.compiledField.points.length === 0) {
+      for (const photon of this.photons) {
+        photon.vel[0] *= controlSurface?.drift.damping ?? 0.95;
+        photon.vel[1] *= controlSurface?.drift.damping ?? 0.95;
+        photon.pos[0] += photon.vel[0];
+        photon.pos[1] += photon.vel[1];
+        photon.color[0] *= controlSurface?.drift.glowFade ?? 0.97;
+        photon.color[1] *= controlSurface?.drift.glowFade ?? 0.97;
+        photon.color[2] *= controlSurface?.drift.glowFade ?? 0.97;
+      }
+      return;
     }
 
     const points = this.compiledField.points;
@@ -251,65 +347,32 @@ export class AetheriumKernel {
       const dx = target.x - photon.pos[0];
       const dy = target.y - photon.pos[1];
       const dist = Math.hypot(dx, dy) || 1;
-      const pull = Math.min(dist * 0.05, 5) * this.force;
+      const state = controlSurface.nextPhotonState(photon, target);
 
-      const flow = this.sampleFlowField(photon.pos[0], photon.pos[1]);
-      const noiseGain = (1 - this.coherence) * this.noiseMax;
-
-      photon.vel[0] = (photon.vel[0] + (dx / dist) * pull + flow[0] + (Math.random() - 0.5) * noiseGain) * this.damp;
-      photon.vel[1] = (photon.vel[1] + (dy / dist) * pull + flow[1] + (Math.random() - 0.5) * noiseGain) * this.damp;
+      photon.vel[0] = (photon.vel[0] + (dx / dist) * state.attractorForce + state.flow[0] + (Math.random() - 0.5) * state.turbulence) * state.damping;
+      photon.vel[1] = (photon.vel[1] + (dy / dist) * state.attractorForce + state.flow[1] + (Math.random() - 0.5) * state.turbulence) * state.damping;
       photon.pos[0] += photon.vel[0];
       photon.pos[1] += photon.vel[1];
 
-      photon.color[0] += (target.color[0] - photon.color[0]) * 0.1;
-      photon.color[1] += (target.color[1] - photon.color[1]) * 0.1;
-      photon.color[2] += (target.color[2] - photon.color[2]) * 0.1;
+      photon.color[0] += (target.color[0] - photon.color[0]) * state.glowBlend + state.flicker;
+      photon.color[1] += (target.color[1] - photon.color[1]) * state.glowBlend + state.flicker;
+      photon.color[2] += (target.color[2] - photon.color[2]) * state.glowBlend + state.flicker;
     }
-  }
-
-  private sampleFlowField(x: number, y: number): [number, number] {
-    const mode = this.lcl?.motion.flow_mode ?? 'calm_drift';
-    const { width, height } = this.viewport;
-    const cx = width * 0.5;
-    const cy = height * 0.5;
-    const localRhythm = (this.lcl?.motion.rhythm_hz ?? 0.1) * 6.28318;
-
-    if (mode === 'upward_spiral') {
-      const angle = Math.sin(x * 0.0025 + this.time * localRhythm) + Math.cos(y * 0.003 - this.time * 0.4);
-      return [Math.cos(angle) * this.flowMag * 0.7, -this.flowMag * 0.65 + Math.sin(angle) * this.flowMag * 0.3];
-    }
-
-    if (mode === 'orbit') {
-      const dx = x - cx;
-      const dy = y - cy;
-      const len = Math.hypot(dx, dy) || 1;
-      return [(-dy / len) * this.flowMag, (dx / len) * this.flowMag];
-    }
-
-    if (mode === 'radial') {
-      const dx = x - cx;
-      const dy = y - cy;
-      const len = Math.hypot(dx, dy) || 1;
-      return [(dx / len) * this.flowMag * 0.6, (dy / len) * this.flowMag * 0.6];
-    }
-
-    if (mode === 'ribbon') {
-      return [Math.sin(y * 0.01 + this.time * localRhythm) * this.flowMag, Math.cos(x * 0.004 - this.time * localRhythm) * this.flowMag * 0.35];
-    }
-
-    return [Math.sin(y * 0.006 + this.time * localRhythm) * this.flowMag * 0.55, Math.cos(x * 0.005 - this.time * localRhythm) * this.flowMag * 0.45];
   }
 
   private renderFrame(): void {
     this.time += 0.016;
+    if (this.lcl) {
+      this.controlSurface = ParticleControlSurface.fromLCL(this.lcl, this.viewport, this.time, this.coherence);
+    }
     this.frameCounter += 1;
     this.updatePhotons();
 
     const gl = this.gl;
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-    // Production: Upload photon positions/colors to GPU buffers and draw points.
-    // Production: Render glow pass to FBO, then composite to screen.
+    // Production renderer boundary: upload the photon buffer to Canvas/WebGL/etc.
+    // Motion and behavior rules remain in ParticleControlSurface, so the renderer can swap independently.
   }
 
   private async runPerceptualFeedback(): Promise<void> {
@@ -327,25 +390,35 @@ export class AetheriumKernel {
     }));
 
     try {
-        const metrics = await this.evaluator.evaluate(
-          { width, height, rgba: pixels },
-          this.compiledField,
-          photonSample,
-        );
+      const metrics = await this.evaluator.evaluate(
+        { width, height, rgba: pixels },
+        this.compiledField,
+        photonSample,
+      );
 
-        const next = feedbackAdjustments(
-          metrics,
-          this.coherence,
-          this.lcl.motion.coherence_target,
-          this.flowMag,
-          this.noiseMax,
-        );
+      const next = feedbackAdjustments(
+        metrics,
+        this.coherence,
+        this.lcl.motion.coherence_target,
+        this.lcl.particle_control.velocity,
+        0.2 + this.lcl.particle_control.turbulence * 5,
+      );
 
-        this.coherence = next.coherence;
-        this.flowMag = next.flowMag;
-        this.noiseMax = next.noiseMax;
+      this.coherence = next.coherence;
+      const nextVelocity = clamp(next.flowMag / 1.1, 0, 1);
+      const nextTurbulence = clamp((next.noiseMax - 0.2) / 5, 0, 1);
+      this.lcl = {
+        ...this.lcl,
+        particle_control: {
+          ...this.lcl.particle_control,
+          velocity: nextVelocity,
+          turbulence: nextTurbulence,
+          cohesion: next.coherence,
+        },
+      };
+      this.controlSurface = ParticleControlSurface.fromLCL(this.lcl, this.viewport, this.time, this.coherence);
     } catch (error) {
-        console.warn("Perceptual feedback failed:", error);
+      console.warn('Perceptual feedback failed:', error);
     }
   }
 }

--- a/lcl_schema.json
+++ b/lcl_schema.json
@@ -2,87 +2,291 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Light Control Language (LCL)",
   "type": "object",
-  "required": ["intent", "morphology", "motion", "optics", "constraints"],
+  "required": [
+    "intent",
+    "morphology",
+    "motion",
+    "optics",
+    "constraints",
+    "particle_control"
+  ],
   "properties": {
-    "version": { "type": "string", "default": "3.1" },
+    "version": {
+      "type": "string",
+      "default": "3.1"
+    },
     "intent": {
       "type": "object",
-      "required": ["user_request", "primary_goal"],
+      "required": [
+        "user_request",
+        "primary_goal"
+      ],
       "properties": {
-        "user_request": { "type": "string" },
-        "primary_goal": { "type": "string" },
-        "abstraction_level": { "enum": ["concrete", "symbolic", "abstract"] },
-        "mode": { "enum": ["symbol", "world", "shape", "scene", "motion", "feedback", "auto"] }
+        "user_request": {
+          "type": "string"
+        },
+        "primary_goal": {
+          "type": "string"
+        },
+        "abstraction_level": {
+          "enum": [
+            "concrete",
+            "symbolic",
+            "abstract"
+          ]
+        },
+        "mode": {
+          "enum": [
+            "symbol",
+            "world",
+            "shape",
+            "scene",
+            "motion",
+            "feedback",
+            "auto"
+          ]
+        }
       }
     },
     "morphology": {
       "type": "object",
-      "required": ["family"],
+      "required": [
+        "family"
+      ],
       "properties": {
-        "family": { "type": "string" },
-        "symmetry": { "type": "integer", "minimum": 1, "maximum": 12 },
-        "edge_softness": { "type": "number", "minimum": 0, "maximum": 1 },
-        "density": { "type": "number", "minimum": 0, "maximum": 1 }
+        "family": {
+          "type": "string"
+        },
+        "symmetry": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 12
+        },
+        "edge_softness": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "density": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
       }
     },
     "motion": {
       "type": "object",
-      "required": ["archetype", "flow_mode"],
+      "required": [
+        "archetype",
+        "flow_mode"
+      ],
       "properties": {
-        "archetype": { "type": "string" },
-        "tempo_hz": { "type": "number", "minimum": 0.1, "maximum": 4 },
-        "coherence_target": { "type": "number", "minimum": 0, "maximum": 1 },
-        "flow_mode": { "type": "string" },
-        "attack_ms": { "type": "integer", "minimum": 50 },
-        "settle_ms": { "type": "integer", "minimum": 50 },
-        "release_ms": { "type": "integer", "minimum": 50 }
+        "archetype": {
+          "type": "string"
+        },
+        "tempo_hz": {
+          "type": "number",
+          "minimum": 0.1,
+          "maximum": 4
+        },
+        "coherence_target": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "flow_mode": {
+          "type": "string"
+        },
+        "attack_ms": {
+          "type": "integer",
+          "minimum": 50
+        },
+        "settle_ms": {
+          "type": "integer",
+          "minimum": 50
+        },
+        "release_ms": {
+          "type": "integer",
+          "minimum": 50
+        }
       }
     },
     "motion_bias": {
       "type": "object",
       "properties": {
-        "archetype": { "type": "string" },
-        "rhythm_hz": { "type": "number", "minimum": 0.05, "maximum": 4 },
-        "attack": { "type": "number", "minimum": 0, "maximum": 1 },
-        "settling": { "type": "number", "minimum": 0, "maximum": 1 },
-        "drift": { "type": "number", "minimum": 0, "maximum": 1 },
-        "collapse_tendency": { "type": "number", "minimum": 0, "maximum": 1 }
+        "archetype": {
+          "type": "string"
+        },
+        "rhythm_hz": {
+          "type": "number",
+          "minimum": 0.05,
+          "maximum": 4
+        },
+        "attack": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "settling": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "drift": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "collapse_tendency": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
       }
     },
     "optics": {
       "type": "object",
       "properties": {
-        "palette_mode": { "type": "string" },
-        "primary_colors": { "type": "array", "items": { "type": "string" } },
-        "secondary_colors": { "type": "array", "items": { "type": "string" } },
-        "glow_strength": { "type": "number", "minimum": 0, "maximum": 1 },
-        "luminance": { "type": "number", "minimum": 0, "maximum": 1 }
+        "palette_mode": {
+          "type": "string"
+        },
+        "primary_colors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "secondary_colors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "glow_strength": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "luminance": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
       }
     },
     "field": {
       "type": "object",
       "properties": {
-        "coherence": { "type": "number", "minimum": 0, "maximum": 1 },
-        "turbulence": { "type": "number", "minimum": 0, "maximum": 1 },
-        "flow_magnitude": { "type": "number", "minimum": 0, "maximum": 1 },
-        "noise_level": { "type": "number", "minimum": 0, "maximum": 1 },
-        "vorticity": { "type": "number", "minimum": -1, "maximum": 1 }
+        "coherence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "turbulence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "flow_magnitude": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "noise_level": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "vorticity": {
+          "type": "number",
+          "minimum": -1,
+          "maximum": 1
+        }
       }
     },
     "constraints": {
       "type": "object",
       "properties": {
-        "max_targets": { "type": "integer", "minimum": 100 },
-        "max_particles": { "type": "integer", "minimum": 100 },
-        "max_energy": { "type": "number", "minimum": 0.1 },
-        "max_brightness": { "type": "number", "minimum": 0, "maximum": 1 }
+        "max_targets": {
+          "type": "integer",
+          "minimum": 100
+        },
+        "max_particles": {
+          "type": "integer",
+          "minimum": 100
+        },
+        "max_energy": {
+          "type": "number",
+          "minimum": 0.1
+        },
+        "max_brightness": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
       }
     },
     "safety": {
       "type": "object",
       "properties": {
-        "max_targets": { "type": "integer", "minimum": 100 },
-        "max_particle_energy": { "type": "number", "minimum": 0.1 }
+        "max_targets": {
+          "type": "integer",
+          "minimum": 100
+        },
+        "max_particle_energy": {
+          "type": "number",
+          "minimum": 0.1
+        }
+      }
+    },
+    "particle_control": {
+      "type": "object",
+      "required": [
+        "velocity",
+        "turbulence",
+        "cohesion",
+        "flow_direction",
+        "glow_intensity",
+        "flicker",
+        "attractor"
+      ],
+      "properties": {
+        "velocity": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "turbulence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "cohesion": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "flow_direction": {
+          "type": "string"
+        },
+        "glow_intensity": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "flicker": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "attractor": {
+          "type": "string"
+        },
+        "rhythm_hz": {
+          "type": "number",
+          "minimum": 0.05,
+          "maximum": 4
+        }
       }
     }
   }

--- a/light-control-language.ts
+++ b/light-control-language.ts
@@ -11,6 +11,17 @@ export interface FormationReference {
   score?: number;
 }
 
+export interface ParticleControlContract {
+  velocity: number;
+  turbulence: number;
+  cohesion: number;
+  flow_direction: string;
+  glow_intensity: number;
+  flicker: number;
+  attractor: string;
+  rhythm_hz?: number;
+}
+
 export interface LightControlLanguage {
   version: string;
   intent: 'create_light_form' | 'create_glyph' | 'create_scene';
@@ -49,13 +60,7 @@ export interface LightControlLanguage {
   };
   source_text: string;
   retrieved_formation?: FormationReference;
-  runtime_bias?: {
-    forceBias?: number;
-    flowBias?: number;
-    noiseBias?: number;
-    coherenceStart?: number;
-    archetypePhrase?: string;
-  };
+  particle_control: ParticleControlContract;
 }
 
 const DEFAULT_TIMEOUT_MS = 6_000;
@@ -95,7 +100,6 @@ export async function generateLightControlLanguage(text: string): Promise<LightC
   return fallbackHeuristicLcl(text);
 }
 
-// backward-compat alias for older kernel imports
 export const mockLocalLightModel = generateLightControlLanguage;
 
 export async function interpretWithBackendLLM(
@@ -157,6 +161,11 @@ export function normalizeLCL(lcl: Partial<LightControlLanguage>): LightControlLa
       ...fallback.constraints,
       ...lcl.constraints,
     },
+    particle_control: {
+      ...fallback.particle_control,
+      ...lcl.particle_control,
+      rhythm_hz: lcl.particle_control?.rhythm_hz ?? lcl.motion?.rhythm_hz ?? fallback.particle_control.rhythm_hz,
+    },
   };
 }
 
@@ -168,7 +177,8 @@ function isLclPayload(value: unknown): value is LightControlLanguage {
       candidate.morphology?.family &&
       candidate.motion?.archetype &&
       candidate.optics?.palette &&
-      candidate.constraints?.max_targets,
+      candidate.constraints?.max_targets &&
+      candidate.particle_control?.flow_direction,
   );
 }
 
@@ -185,6 +195,7 @@ function fallbackHeuristicLcl(text: string): LightControlLanguage {
   let density = 0.76;
   let scale = 0.35;
   let textContent = null;
+  let rhythm_hz = 0.2;
 
   if (/เกลียว|vortex|spiral|หมุน|คิด/.test(text)) {
     family = 'spiral_vortex';
@@ -219,8 +230,10 @@ function fallbackHeuristicLcl(text: string): LightControlLanguage {
     turbulence = 0.2;
   }
 
+  rhythm_hz = /ช้า|สงบ|gentle/.test(text) ? 0.08 : 0.2;
+
   return {
-    version: '3.0',
+    version: '4.0',
     intent: render_mode,
     morphology: {
       family,
@@ -234,7 +247,7 @@ function fallbackHeuristicLcl(text: string): LightControlLanguage {
       flow_mode,
       coherence_target,
       turbulence,
-      rhythm_hz: /ช้า|สงบ|gentle/.test(text) ? 0.08 : 0.2,
+      rhythm_hz,
       attack_ms: /เร็ว|ทันที|fast/.test(text) ? 250 : 700,
       settle_ms: /เร็ว|ทันที|fast/.test(text) ? 400 : 1200,
     },
@@ -255,10 +268,56 @@ function fallbackHeuristicLcl(text: string): LightControlLanguage {
       max_energy: 1.6,
     },
     source_text: text,
+    particle_control: deriveParticleControl({
+      flow_mode,
+      coherence_target,
+      turbulence,
+      luminance_boost: /เรือง|สว่าง|glow/.test(text) ? 1.65 : 1.25,
+      rhythm_hz,
+    }),
   };
 }
 
+function deriveParticleControl(params: {
+  flow_mode: string;
+  coherence_target: number;
+  turbulence: number;
+  luminance_boost: number;
+  rhythm_hz: number;
+}): ParticleControlContract {
+  return {
+    velocity: clampNumber(0.25 + params.coherence_target * 0.5, 0, 1),
+    turbulence: clampNumber(params.turbulence, 0, 1),
+    cohesion: clampNumber(params.coherence_target, 0, 1),
+    flow_direction: mapFlowDirection(params.flow_mode),
+    glow_intensity: clampNumber(0.45 + (params.luminance_boost - 1) * 0.4, 0, 1),
+    flicker: clampNumber(params.turbulence * 0.35, 0, 1),
+    attractor: params.coherence_target >= 0.85 ? 'core' : 'axis',
+    rhythm_hz: params.rhythm_hz,
+  };
+}
+
+function mapFlowDirection(flowMode: string): string {
+  switch (flowMode) {
+    case 'orbit':
+      return 'clockwise';
+    case 'radial':
+      return 'outward';
+    case 'upward_spiral':
+      return 'upward';
+    case 'ribbon':
+      return 'ribbon';
+    case 'calm_drift':
+    default:
+      return 'still';
+  }
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
 function extractQuotedText(text: string): string | null {
-  const m = text.match(/["“”']([^"“”']+)["“”']/);
-  return m ? m[1] : null;
+  const match = text.match(/["'“”](.+?)["'“”]/);
+  return match?.[1] ?? null;
 }


### PR DESCRIPTION
### Motivation
- Separate engine tuning from AI/governor semantics by creating a dedicated control surface that maps governed fields to per-photon physics parameters.  
- Replace ad-hoc kernel tuning and ephemeral `runtime_bias` values with an explicit, explainable `particle_control` contract to make behavior reproducible and auditable.  
- Decouple renderer concerns from motion/behavior so Canvas/WebGL swap-out does not require rewriting particle rules.  

### Description
- Add `ParticleControlSurface` in `kernel.ts` that converts `particle_control` fields into per-photon motion state (`attractorForce`, `flow`, `turbulence`, `damping`, `glowBlend`, `flicker`) and exposes drift/renderer state.  
- Refactor `AetheriumKernel` to consume `particle_control` via the control surface; remove embedded tuning constants and `runtime_bias` usage, and route perceptual-feedback updates back into `particle_control`.  
- Extend `light-control-language.ts` with a `ParticleControlContract` type, add `particle_control` to `LightControlLanguage`, include deterministic fallback (`deriveParticleControl`) and helpers (`mapFlowDirection`, `clampNumber`).  
- Update `formation-retriever.ts` to merge formation annotations into `particle_control` fields, update `lcl_schema.json` to require and document `particle_control`, and adjust the test fixture in `kernel.test.ts` to include the new payload.  

### Testing
- Ran the unit tests with `node --test kernel.test.ts`, all tests passed (3/3).  
- The changes were committed and the repository diff includes updates to `kernel.ts`, `light-control-language.ts`, `formation-retriever.ts`, `lcl_schema.json`, and `kernel.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bddd1b2484832084e95d44517ac74e)