### PR TITLE
Refactor kernel timing/tick policy, offload glyph compilation, integrate renderer, and add runtime telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,8 @@ The prototype gateway currently uses an in-memory time-series structure for tele
 
 This structure is designed for deterministic local/runtime testing. For production durability, move to a persistent TSDB backend while preserving endpoint contracts.
 
+Current frontend/kernel runtime telemetry mirrors the proposed control-plane observability fields and now tracks `fps`, `dropped_frames`, `particle_count`, `average_velocity`, `last_ai_command`, and `policy_block_count` before forwarding or persisting samples.
+
 ---
 
 ## Validation & Tests

--- a/kernel.test.ts
+++ b/kernel.test.ts
@@ -13,12 +13,41 @@ class MockCanvasElement {
       return {
         BLEND: 1,
         ONE: 1,
+        POINTS: 0,
+        ARRAY_BUFFER: 0x8892,
+        DYNAMIC_DRAW: 0x88E8,
+        FLOAT: 0x1406,
         COLOR_BUFFER_BIT: 0x4000,
         RGBA: 0x1908,
         UNSIGNED_BYTE: 0x1401,
+        VERTEX_SHADER: 0x8B31,
+        FRAGMENT_SHADER: 0x8B30,
+        LINK_STATUS: 0x8B82,
+        COMPILE_STATUS: 0x8B81,
+        createBuffer: () => ({}),
+        createProgram: () => ({}),
+        createShader: () => ({}),
+        shaderSource: () => {},
+        compileShader: () => {},
+        getShaderParameter: () => true,
+        getShaderInfoLog: () => '',
+        attachShader: () => {},
+        linkProgram: () => {},
+        getProgramParameter: () => true,
+        getProgramInfoLog: () => '',
+        bindBuffer: () => {},
+        bufferData: () => {},
+        getAttribLocation: () => 0,
+        enableVertexAttribArray: () => {},
+        vertexAttribPointer: () => {},
+        getUniformLocation: () => ({}),
+        uniform1f: () => {},
+        useProgram: () => {},
+        drawArrays: () => {},
         clear: () => {},
         clearColor: () => {},
         enable: () => {},
+        disable: () => {},
         blendFunc: () => {},
         viewport: () => {},
         readPixels: () => {},
@@ -46,8 +75,11 @@ globalThis.window = { innerWidth: 800, innerHeight: 600 } as Window & typeof glo
 globalThis.document = {
   createElement: () => new MockCanvasElement(),
 } as Document;
+let rafCalls = 0;
 globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
-  return 1;
+  rafCalls += 1;
+  if (rafCalls === 1) cb(16.67);
+  return rafCalls;
 }) as typeof requestAnimationFrame;
 globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
 globalThis.fetch = (async (url: string | URL) => {
@@ -108,6 +140,7 @@ test('AetheriumKernel initializes without errors', () => {
   });
 
   assert.ok(kernel instanceof AetheriumKernel);
+  assert.equal(kernel.getTelemetrySnapshot().particle_count, 7000);
 });
 
 test('AetheriumKernel handles a user request and can reset state', async () => {
@@ -120,9 +153,11 @@ test('AetheriumKernel handles a user request and can reset state', async () => {
 
   await kernel.handleUserLightRequest('create a golden spiral');
   assert.equal(kernel.getLCLSchema()?.version, '4.0');
+  assert.equal(kernel.getTelemetrySnapshot().last_ai_command, 'create a golden spiral');
 
   kernel.resetToVoid();
   assert.equal(kernel.getLCLSchema(), null);
+  assert.equal(kernel.getTelemetrySnapshot().last_ai_command, null);
 });
 
 test('AetheriumKernel resizes and can start-stop animation safely', () => {
@@ -136,5 +171,5 @@ test('AetheriumKernel resizes and can start-stop animation safely', () => {
   kernel.resize(1920, 1080);
   kernel.start();
   kernel.stop();
-  assert.ok(true);
+  assert.ok(kernel.getTelemetrySnapshot().fps > 0);
 });

--- a/kernel.ts
+++ b/kernel.ts
@@ -19,6 +19,8 @@ import {
   feedbackAdjustments,
 } from './perceptual-feedback.ts';
 import type { PerceptualEvaluator } from './perceptual-feedback.ts';
+import { RendererWebGL } from './renderer-webgl.ts';
+import type { RendererFrameSnapshot, RendererPhotonSnapshot } from './renderer-webgl.ts';
 
 export interface KernelConfig {
   apiBaseUrl: string;
@@ -56,6 +58,31 @@ interface RendererState {
   flicker: number;
 }
 
+interface TickPolicy {
+  velocityScale: number;
+  cooldownScale: number;
+  flowScale: number;
+  feedbackCadenceFrames: number;
+  feedbackCadenceMs: number;
+}
+
+export interface RuntimeTelemetry {
+  fps: number;
+  dropped_frames: number;
+  particle_count: number;
+  average_velocity: number;
+  last_ai_command: string | null;
+  policy_block_count: number;
+}
+
+interface FieldCompilationRequest {
+  intent: LightControlLanguage['intent'];
+  text: string;
+  viewport: Viewport;
+  colorHex: string;
+  lcl: LightControlLanguage;
+}
+
 const STATE_PROFILES: Record<string, Partial<ParticleControlContract>> = {
   IDLE: { velocity: 0.08, turbulence: 0.04, cohesion: 0.92, flow_direction: 'still', glow_intensity: 0.28, flicker: 0.01, attractor: 'core' },
   LISTENING: { velocity: 0.16, turbulence: 0.08, cohesion: 0.84, flow_direction: 'clockwise', glow_intensity: 0.38, flicker: 0.03, attractor: 'orbit' },
@@ -71,6 +98,10 @@ const STATE_PROFILES: Record<string, Partial<ParticleControlContract>> = {
   SENSOR_ACTIVE: { velocity: 0.42, turbulence: 0.20, cohesion: 0.70, flow_direction: 'centripetal', glow_intensity: 0.60, flicker: 0.05, attractor: 'axis' },
   SENSOR_UNAVAILABLE: { velocity: 0.08, turbulence: 0.02, cohesion: 0.93, flow_direction: 'still', glow_intensity: 0.30, flicker: 0.01, attractor: 'core' },
 };
+
+const TARGET_FRAME_SECONDS = 1 / 60;
+const MAX_FRAME_SECONDS = 0.1;
+const FRAME_DROP_THRESHOLD_SECONDS = TARGET_FRAME_SECONDS * 1.5;
 
 export class ParticleControlSurface {
   private readonly viewport: Viewport;
@@ -105,32 +136,32 @@ export class ParticleControlSurface {
     return new ParticleControlSurface(lcl.particle_control, viewport, time, coherence);
   }
 
-  nextPhotonState(photon: Photon, target: CompiledField['points'][number]): PhotonMotionState {
+  nextPhotonState(photon: Photon, target: CompiledField['points'][number], tickPolicy: TickPolicy): PhotonMotionState {
     const dx = target.x - photon.pos[0];
     const dy = target.y - photon.pos[1];
     const dist = Math.hypot(dx, dy) || 1;
     const cohesion = clamp(this.control.cohesion, 0, 1);
     const velocity = clamp(this.control.velocity, 0, 1);
-    const attractorForce = Math.min(dist * (0.03 + cohesion * 0.05), 1 + velocity * 6) * (0.25 + velocity * 0.75);
+    const attractorForce = Math.min(dist * (0.03 + cohesion * 0.05), 1 + velocity * 6) * (0.25 + velocity * 0.75) * tickPolicy.velocityScale;
 
     return {
       attractorForce,
-      flow: this.sampleFlowField(photon.pos[0], photon.pos[1]),
-      turbulence: (1 - this.coherence) * (0.2 + this.control.turbulence * 5),
-      damping: 0.84 + cohesion * 0.12,
-      glowBlend: 0.04 + this.renderer.glowIntensity * 0.18,
-      flicker: (Math.random() - 0.5) * this.renderer.flicker * 0.08,
+      flow: this.sampleFlowField(photon.pos[0], photon.pos[1], tickPolicy),
+      turbulence: (1 - this.coherence) * (0.2 + this.control.turbulence * 5) * tickPolicy.velocityScale,
+      damping: Math.pow(0.84 + cohesion * 0.12, tickPolicy.velocityScale),
+      glowBlend: clamp((0.04 + this.renderer.glowIntensity * 0.18) * tickPolicy.velocityScale, 0, 1),
+      flicker: (Math.random() - 0.5) * this.renderer.flicker * 0.08 * tickPolicy.velocityScale,
     };
   }
 
-  private sampleFlowField(x: number, y: number): [number, number] {
+  private sampleFlowField(x: number, y: number, tickPolicy: TickPolicy): [number, number] {
     const { width, height } = this.viewport;
     const cx = width * 0.5;
     const cy = height * 0.5;
     const dx = x - cx;
     const dy = y - cy;
     const len = Math.hypot(dx, dy) || 1;
-    const velocity = 0.15 + this.control.velocity * 1.1;
+    const velocity = (0.15 + this.control.velocity * 1.1) * tickPolicy.flowScale;
     const turbulence = this.control.turbulence;
     const waveX = Math.sin(y * 0.006 + this.time * this.rhythm);
     const waveY = Math.cos(x * 0.005 - this.time * (this.rhythm * 0.8 + 0.2));
@@ -149,7 +180,7 @@ export class ParticleControlSurface {
       case 'centrifugal':
         return [(dx / len) * velocity * attractorSign, (dy / len) * velocity * attractorSign];
       case 'upward':
-        return [waveX * velocity * 0.25, -velocity + waveY * turbulence * 0.35];
+        return [waveX * velocity * 0.25, -velocity + waveY * turbulence * 0.35 * tickPolicy.flowScale];
       case 'ribbon':
         return [waveX * velocity, waveY * velocity * 0.35];
       case 'still':
@@ -161,9 +192,18 @@ export class ParticleControlSurface {
 }
 
 export class AetheriumKernel {
-  private readonly gl: WebGL2RenderingContext;
   private readonly config: Required<KernelConfig>;
   private readonly evaluator: PerceptualEvaluator;
+  private readonly renderer: RendererWebGL;
+  private readonly gl: WebGL2RenderingContext;
+  private readonly telemetry: RuntimeTelemetry = {
+    fps: 0,
+    dropped_frames: 0,
+    particle_count: 0,
+    average_velocity: 0,
+    last_ai_command: null,
+    policy_block_count: 0,
+  };
 
   private formationBundlePromise: ReturnType<typeof loadFormationBundle>;
   private lcl: LightControlLanguage | null = null;
@@ -173,6 +213,10 @@ export class AetheriumKernel {
   private pipelineRevision = 0;
   private time = 0;
   private frameCounter = 0;
+  private lastAnimationTimestamp: number | null = null;
+  private lastFeedbackTimestamp = 0;
+  private fieldCompilationRevision = 0;
+  private fieldCompilerWorker: Worker | null = null;
 
   private coherence = 0.1;
   private coherenceTarget = 0.1;
@@ -186,9 +230,8 @@ export class AetheriumKernel {
       evaluatorMode: config.evaluatorMode ?? 'remote',
     };
 
-    const gl = config.canvas.getContext('webgl2', { antialias: true, alpha: false });
-    if (!gl) throw new Error('WebGL2 is required for AetheriumKernel');
-    this.gl = gl;
+    this.renderer = new RendererWebGL(config.canvas);
+    this.gl = this.renderer.context;
 
     this.evaluator = this.config.evaluatorMode === 'remote'
       ? new BioVisionRemoteEvaluator(this.config.apiBaseUrl)
@@ -202,6 +245,7 @@ export class AetheriumKernel {
   async handleUserLightRequest(userText: string): Promise<void> {
     const rev = ++this.pipelineRevision;
     const viewport = this.viewport;
+    this.telemetry.last_ai_command = userText;
 
     try {
       const raw = await interpretWithBackendLLM(
@@ -224,7 +268,7 @@ export class AetheriumKernel {
       const retrieved = retrieveFormation(bundle, raw);
       const enriched = normalizeLCL(mergeRetrievedFormation(raw, retrieved));
 
-      this.applyLCL(enriched);
+      await this.applyLCL(enriched);
     } catch (error) {
       console.error('Error handling user light request:', error);
     }
@@ -232,9 +276,12 @@ export class AetheriumKernel {
 
   resetToVoid(): void {
     this.pipelineRevision++;
+    this.fieldCompilationRevision++;
     this.lcl = null;
     this.compiledField = null;
     this.controlSurface = null;
+    this.lastAnimationTimestamp = null;
+    this.telemetry.last_ai_command = null;
     this.initParticles();
     console.log('Kernel reset to void.');
   }
@@ -243,11 +290,16 @@ export class AetheriumKernel {
     return this.lcl;
   }
 
+  getTelemetrySnapshot(): RuntimeTelemetry {
+    return { ...this.telemetry };
+  }
+
   start(): void {
     cancelAnimationFrame(this.animationHandle);
-    const tick = async () => {
-      this.renderFrame();
-      if (this.frameCounter % 24 === 0) await this.runPerceptualFeedback();
+    this.lastAnimationTimestamp = null;
+    const tick = (timestamp: number) => {
+      const deltaTime = this.computeDeltaTime(timestamp);
+      void this.renderFrame(deltaTime, timestamp);
       this.animationHandle = requestAnimationFrame(tick);
     };
     this.animationHandle = requestAnimationFrame(tick);
@@ -263,7 +315,7 @@ export class AetheriumKernel {
     this.gl.viewport(0, 0, width, height);
 
     if (this.lcl) {
-      this.applyLCL(this.lcl);
+      void this.applyLCL(this.lcl);
     }
   }
 
@@ -281,8 +333,10 @@ export class AetheriumKernel {
       vel: [0, 0],
       color: [0.08, 0.09, 0.12],
       targetIndex: 0,
-      retargetCooldown: Math.random() * 60,
+      retargetCooldown: Math.random() * 0.75,
     }));
+    this.telemetry.particle_count = this.photons.length;
+    this.telemetry.average_velocity = 0;
   }
 
   private initRenderer(): void {
@@ -292,32 +346,80 @@ export class AetheriumKernel {
     gl.blendFunc(gl.ONE, gl.ONE);
   }
 
-  private applyLCL(lcl: LightControlLanguage): void {
+  private async applyLCL(lcl: LightControlLanguage): Promise<void> {
     this.lcl = lcl;
     this.coherence = lcl.particle_control.cohesion;
     this.coherenceTarget = lcl.motion.coherence_target;
     this.controlSurface = ParticleControlSurface.fromLCL(lcl, this.viewport, this.time, this.coherence);
-
-    if (lcl.intent === 'create_glyph') {
-      const alphaMask = this.renderGlyphToAlphaMask(lcl.content.text ?? 'AETHERIUM');
-      this.compiledField = compileGlyphFieldFromAlphaMask(
-        alphaMask,
-        this.viewport,
-        lcl.optics.palette[0] ?? '#FFFFFF',
-      );
-    } else {
-      this.compiledField = compileShapeField(lcl, this.viewport);
-    }
+    this.compiledField = await this.compileField(lcl);
   }
 
-  private renderGlyphToAlphaMask(text: string): Uint8Array {
-    const { width, height } = this.viewport;
+  private async compileField(lcl: LightControlLanguage): Promise<CompiledField> {
+    const request: FieldCompilationRequest = {
+      intent: lcl.intent,
+      text: lcl.content.text ?? 'AETHERIUM',
+      viewport: this.viewport,
+      colorHex: lcl.optics.palette[0] ?? '#FFFFFF',
+      lcl,
+    };
+
+    const revision = ++this.fieldCompilationRevision;
+    const compiledField = await this.compileFieldAsync(request);
+    if (revision !== this.fieldCompilationRevision) {
+      return this.compiledField ?? { points: [] };
+    }
+    return compiledField.points.length > this.config.maxTargets
+      ? { points: compiledField.points.slice(0, this.config.maxTargets) }
+      : compiledField;
+  }
+
+  private async compileFieldAsync(request: FieldCompilationRequest): Promise<CompiledField> {
+    if (request.intent === 'create_glyph') {
+      const alphaMask = await this.buildGlyphAlphaMask(request.text, request.viewport);
+      return compileGlyphFieldFromAlphaMask(alphaMask, request.viewport, request.colorHex);
+    }
+
+    return compileShapeField(request.lcl, request.viewport);
+  }
+
+  private async buildGlyphAlphaMask(text: string, viewport: Viewport): Promise<Uint8Array> {
+    if (typeof Worker === 'function' && typeof OffscreenCanvas === 'function') {
+      try {
+        return await this.renderGlyphToAlphaMaskWithWorker(text, viewport);
+      } catch (error) {
+        console.warn('Worker glyph compilation fallback:', error);
+      }
+    }
+
+    if (typeof OffscreenCanvas === 'function') {
+      try {
+        return this.renderGlyphToAlphaMaskOffscreen(text, viewport);
+      } catch (error) {
+        console.warn('Offscreen glyph compilation fallback:', error);
+      }
+    }
+
+    return this.renderGlyphToAlphaMask(text, viewport);
+  }
+
+  private renderGlyphToAlphaMask(text: string, viewport: Viewport): Uint8Array {
     const offscreen = document.createElement('canvas');
-    offscreen.width = width;
-    offscreen.height = height;
+    offscreen.width = viewport.width;
+    offscreen.height = viewport.height;
     const ctx = offscreen.getContext('2d');
     if (!ctx) throw new Error('Failed to create glyph mask canvas');
+    return this.paintGlyphAlphaMask(ctx, text, viewport);
+  }
 
+  private renderGlyphToAlphaMaskOffscreen(text: string, viewport: Viewport): Uint8Array {
+    const offscreen = new OffscreenCanvas(viewport.width, viewport.height);
+    const ctx = offscreen.getContext('2d');
+    if (!ctx) throw new Error('Failed to create offscreen glyph mask canvas');
+    return this.paintGlyphAlphaMask(ctx, text, viewport);
+  }
+
+  private paintGlyphAlphaMask(ctx: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D, text: string, viewport: Viewport): Uint8Array {
+    const { width, height } = viewport;
     ctx.clearRect(0, 0, width, height);
     const fontSize = Math.min(width / Math.max(text.length, 4) * 1.3, 160);
     ctx.font = `800 ${fontSize}px JetBrains Mono`;
@@ -332,18 +434,85 @@ export class AetheriumKernel {
     return alpha;
   }
 
-  private updatePhotons(): void {
+  private async renderGlyphToAlphaMaskWithWorker(text: string, viewport: Viewport): Promise<Uint8Array> {
+    const worker = this.getFieldCompilerWorker();
+    const requestId = `${Date.now()}-${Math.random()}`;
+
+    return await new Promise<Uint8Array>((resolve, reject) => {
+      const handleMessage = (event: MessageEvent) => {
+        if (event.data?.requestId !== requestId) return;
+        cleanup();
+        if (event.data?.error) {
+          reject(new Error(event.data.error));
+          return;
+        }
+        resolve(new Uint8Array(event.data.alphaMask));
+      };
+      const handleError = (event: ErrorEvent) => {
+        cleanup();
+        reject(event.error ?? new Error(event.message));
+      };
+      const cleanup = () => {
+        worker.removeEventListener('message', handleMessage as EventListener);
+        worker.removeEventListener('error', handleError as EventListener);
+      };
+
+      worker.addEventListener('message', handleMessage as EventListener);
+      worker.addEventListener('error', handleError as EventListener);
+      worker.postMessage({ requestId, text, viewport });
+    });
+  }
+
+  private getFieldCompilerWorker(): Worker {
+    if (this.fieldCompilerWorker) {
+      return this.fieldCompilerWorker;
+    }
+
+    const workerSource = `
+      self.onmessage = (event) => {
+        const { requestId, text, viewport } = event.data;
+        try {
+          const canvas = new OffscreenCanvas(viewport.width, viewport.height);
+          const ctx = canvas.getContext('2d');
+          if (!ctx) throw new Error('2D context unavailable');
+          ctx.clearRect(0, 0, viewport.width, viewport.height);
+          const fontSize = Math.min(viewport.width / Math.max(text.length, 4) * 1.3, 160);
+          ctx.font = '800 ' + fontSize + 'px JetBrains Mono';
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillStyle = '#FFFFFF';
+          ctx.fillText(text, viewport.width * 0.5, viewport.height * 0.5);
+          const rgba = ctx.getImageData(0, 0, viewport.width, viewport.height).data;
+          const alpha = new Uint8Array(viewport.width * viewport.height);
+          for (let i = 0; i < alpha.length; i++) alpha[i] = rgba[i * 4 + 3];
+          self.postMessage({ requestId, alphaMask: alpha }, [alpha.buffer]);
+        } catch (error) {
+          self.postMessage({ requestId, error: error instanceof Error ? error.message : String(error) });
+        }
+      };
+    `;
+
+    const blob = new Blob([workerSource], { type: 'application/javascript' });
+    this.fieldCompilerWorker = new Worker(URL.createObjectURL(blob));
+    return this.fieldCompilerWorker;
+  }
+
+  private updatePhotons(deltaTime: number, tickPolicy: TickPolicy): void {
     const controlSurface = this.controlSurface;
+    const driftDamping = controlSurface ? Math.pow(controlSurface.drift.damping, tickPolicy.velocityScale) : Math.pow(0.95, tickPolicy.velocityScale);
+    const glowFade = controlSurface ? Math.pow(controlSurface.drift.glowFade, tickPolicy.velocityScale) : Math.pow(0.97, tickPolicy.velocityScale);
+
     if (!controlSurface || !this.compiledField || this.compiledField.points.length === 0) {
       for (const photon of this.photons) {
-        photon.vel[0] *= controlSurface?.drift.damping ?? 0.95;
-        photon.vel[1] *= controlSurface?.drift.damping ?? 0.95;
-        photon.pos[0] += photon.vel[0];
-        photon.pos[1] += photon.vel[1];
-        photon.color[0] *= controlSurface?.drift.glowFade ?? 0.97;
-        photon.color[1] *= controlSurface?.drift.glowFade ?? 0.97;
-        photon.color[2] *= controlSurface?.drift.glowFade ?? 0.97;
+        photon.vel[0] *= driftDamping;
+        photon.vel[1] *= driftDamping;
+        photon.pos[0] += photon.vel[0] * tickPolicy.velocityScale;
+        photon.pos[1] += photon.vel[1] * tickPolicy.velocityScale;
+        photon.color[0] *= glowFade;
+        photon.color[1] *= glowFade;
+        photon.color[2] *= glowFade;
       }
+      this.updateVelocityTelemetry();
       return;
     }
 
@@ -356,9 +525,9 @@ export class AetheriumKernel {
         const base = (i * 17 + Math.floor(this.time * 8)) % points.length;
         const jitter = Math.floor((Math.random() - 0.5) * 12);
         photon.targetIndex = clamp(base + jitter, 0, points.length - 1);
-        photon.retargetCooldown = 15 + Math.random() * 35;
+        photon.retargetCooldown = (0.25 + Math.random() * 0.6) * tickPolicy.cooldownScale;
       } else {
-        photon.retargetCooldown -= 1;
+        photon.retargetCooldown -= deltaTime;
       }
 
       const target = points[photon.targetIndex] ?? points[i % points.length];
@@ -367,32 +536,94 @@ export class AetheriumKernel {
       const dx = target.x - photon.pos[0];
       const dy = target.y - photon.pos[1];
       const dist = Math.hypot(dx, dy) || 1;
-      const state = controlSurface.nextPhotonState(photon, target);
+      const state = controlSurface.nextPhotonState(photon, target, tickPolicy);
 
       photon.vel[0] = (photon.vel[0] + (dx / dist) * state.attractorForce + state.flow[0] + (Math.random() - 0.5) * state.turbulence) * state.damping;
       photon.vel[1] = (photon.vel[1] + (dy / dist) * state.attractorForce + state.flow[1] + (Math.random() - 0.5) * state.turbulence) * state.damping;
-      photon.pos[0] += photon.vel[0];
-      photon.pos[1] += photon.vel[1];
+      photon.pos[0] += photon.vel[0] * tickPolicy.velocityScale;
+      photon.pos[1] += photon.vel[1] * tickPolicy.velocityScale;
 
       photon.color[0] += (target.color[0] - photon.color[0]) * state.glowBlend + state.flicker;
       photon.color[1] += (target.color[1] - photon.color[1]) * state.glowBlend + state.flicker;
       photon.color[2] += (target.color[2] - photon.color[2]) * state.glowBlend + state.flicker;
     }
+
+    this.updateVelocityTelemetry();
   }
 
-  private renderFrame(): void {
-    this.time += 0.016;
+  private async renderFrame(deltaTime: number, timestamp: number): Promise<void> {
+    this.time += deltaTime;
     if (this.lcl) {
       this.controlSurface = ParticleControlSurface.fromLCL(this.lcl, this.viewport, this.time, this.coherence);
     }
+
+    const tickPolicy = this.buildTickPolicy(deltaTime);
     this.frameCounter += 1;
-    this.updatePhotons();
+    this.updateFrameTelemetry(deltaTime);
+    this.updatePhotons(deltaTime, tickPolicy);
+    this.renderer.render(this.buildRendererFrameSnapshot());
 
-    const gl = this.gl;
-    gl.clear(gl.COLOR_BUFFER_BIT);
+    if (this.frameCounter % tickPolicy.feedbackCadenceFrames === 0 || (timestamp - this.lastFeedbackTimestamp) >= tickPolicy.feedbackCadenceMs) {
+      this.lastFeedbackTimestamp = timestamp;
+      await this.runPerceptualFeedback();
+    }
+  }
 
-    // Production renderer boundary: upload the photon buffer to Canvas/WebGL/etc.
-    // Motion and behavior rules remain in ParticleControlSurface, so the renderer can swap independently.
+  private buildRendererFrameSnapshot(): RendererFrameSnapshot {
+    const viewport = this.viewport;
+    const glowAlpha = this.lcl?.optics.glow_alpha ?? this.controlSurface?.renderer.glowIntensity ?? 0.35;
+    return {
+      width: viewport.width,
+      height: viewport.height,
+      glowAlpha,
+      photons: this.photons.map<RendererPhotonSnapshot>((photon) => ({
+        x: photon.pos[0],
+        y: photon.pos[1],
+        color: photon.color,
+      })),
+    };
+  }
+
+  private computeDeltaTime(timestamp: number): number {
+    if (this.lastAnimationTimestamp == null) {
+      this.lastAnimationTimestamp = timestamp;
+      return TARGET_FRAME_SECONDS;
+    }
+
+    const deltaSeconds = clamp((timestamp - this.lastAnimationTimestamp) / 1000, 0, MAX_FRAME_SECONDS);
+    this.lastAnimationTimestamp = timestamp;
+    return deltaSeconds || TARGET_FRAME_SECONDS;
+  }
+
+  private buildTickPolicy(deltaTime: number): TickPolicy {
+    const ratio = clamp(deltaTime / TARGET_FRAME_SECONDS, 0.5, 6);
+    return {
+      velocityScale: ratio,
+      cooldownScale: 1 / ratio,
+      flowScale: ratio,
+      feedbackCadenceFrames: Math.max(8, Math.round(24 / Math.max(ratio, 0.75))),
+      feedbackCadenceMs: Math.max(180, Math.round(400 * ratio)),
+    };
+  }
+
+  private updateFrameTelemetry(deltaTime: number): void {
+    this.telemetry.fps = deltaTime > 0 ? 1 / deltaTime : 0;
+    this.telemetry.particle_count = this.photons.length;
+    if (deltaTime > FRAME_DROP_THRESHOLD_SECONDS) {
+      this.telemetry.dropped_frames += 1;
+    }
+  }
+
+  private updateVelocityTelemetry(): void {
+    if (this.photons.length === 0) {
+      this.telemetry.average_velocity = 0;
+      return;
+    }
+    let total = 0;
+    for (const photon of this.photons) {
+      total += Math.hypot(photon.vel[0], photon.vel[1]);
+    }
+    this.telemetry.average_velocity = total / this.photons.length;
   }
 
   private async runPerceptualFeedback(): Promise<void> {
@@ -439,6 +670,7 @@ export class AetheriumKernel {
       this.controlSurface = ParticleControlSurface.fromLCL(this.lcl, this.viewport, this.time, this.coherence);
     } catch (error) {
       console.warn('Perceptual feedback failed:', error);
+      this.telemetry.policy_block_count += 1;
     }
   }
 }

--- a/renderer-webgl.ts
+++ b/renderer-webgl.ts
@@ -1,20 +1,57 @@
-import particleVertexSource from './particle.vert.glsl';
-import particleFragmentSource from './particle.frag.glsl';
-import glowFragmentSource from './glow.frag.glsl';
+const particleVertexSource = `#version 300 es
+precision highp float;
+in vec2 a_position;
+in vec3 a_color;
+out vec3 v_color;
+void main() {
+  v_color = a_color;
+  gl_Position = vec4(a_position, 0.0, 1.0);
+  gl_PointSize = 2.5;
+}`;
 
-interface ParticleLike {
-  pos: { x: number; y: number };
-  color: number[];
+const particleFragmentSource = `#version 300 es
+precision highp float;
+in vec3 v_color;
+uniform float u_glowAlpha;
+out vec4 fragColor;
+void main() {
+  fragColor = vec4(v_color, u_glowAlpha);
+}`;
+
+const glowFragmentSource = `#version 300 es
+precision highp float;
+in vec3 v_color;
+uniform float u_glowAlpha;
+out vec4 fragColor;
+void main() {
+  vec2 uv = gl_PointCoord - vec2(0.5);
+  float halo = exp(-12.0 * dot(uv, uv));
+  fragColor = vec4(v_color * 1.25, halo * u_glowAlpha);
+}`;
+
+export interface RendererPhotonSnapshot {
+  x: number;
+  y: number;
+  color: [number, number, number];
+}
+
+export interface RendererFrameSnapshot {
+  width: number;
+  height: number;
+  glowAlpha: number;
+  photons: RendererPhotonSnapshot[];
 }
 
 export class RendererWebGL {
-  private gl: WebGL2RenderingContext;
-  private particleProgram: WebGLProgram;
-  private glowProgram: WebGLProgram;
-  private positionBuffer: WebGLBuffer;
-  private colorBuffer: WebGLBuffer;
+  private readonly canvas: HTMLCanvasElement;
+  private readonly gl: WebGL2RenderingContext;
+  private readonly particleProgram: WebGLProgram;
+  private readonly glowProgram: WebGLProgram;
+  private readonly positionBuffer: WebGLBuffer;
+  private readonly colorBuffer: WebGLBuffer;
 
-  constructor(private readonly canvas: HTMLCanvasElement) {
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
     const gl = canvas.getContext('webgl2', { alpha: false, premultipliedAlpha: false });
     if (!gl) {
       throw new Error('WebGL2 unavailable');
@@ -27,36 +64,40 @@ export class RendererWebGL {
     this.colorBuffer = must(gl.createBuffer(), 'color buffer');
   }
 
-  render(photons: ParticleLike[], width: number, height: number, glowAlpha: number): void {
+  get context(): WebGL2RenderingContext {
+    return this.gl;
+  }
+
+  render(frame: RendererFrameSnapshot): void {
     const gl = this.gl;
-    gl.viewport(0, 0, width, height);
+    gl.viewport(0, 0, frame.width, frame.height);
     gl.clearColor(0.003, 0.003, 0.008, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-    const positions = new Float32Array(photons.length * 2);
-    const colors = new Float32Array(photons.length * 3);
-    for (let i = 0; i < photons.length; i++) {
-      const p = photons[i];
-      positions[i * 2] = (p.pos.x / width) * 2 - 1;
-      positions[i * 2 + 1] = 1 - (p.pos.y / height) * 2;
-      colors[i * 3] = p.color[0];
-      colors[i * 3 + 1] = p.color[1];
-      colors[i * 3 + 2] = p.color[2];
+    const positions = new Float32Array(frame.photons.length * 2);
+    const colors = new Float32Array(frame.photons.length * 3);
+    for (let i = 0; i < frame.photons.length; i++) {
+      const photon = frame.photons[i];
+      positions[i * 2] = (photon.x / frame.width) * 2 - 1;
+      positions[i * 2 + 1] = 1 - (photon.y / frame.height) * 2;
+      colors[i * 3] = photon.color[0];
+      colors[i * 3 + 1] = photon.color[1];
+      colors[i * 3 + 2] = photon.color[2];
     }
 
     gl.useProgram(this.particleProgram);
     bindAttribute(gl, this.particleProgram, this.positionBuffer, 'a_position', positions, 2);
     bindAttribute(gl, this.particleProgram, this.colorBuffer, 'a_color', colors, 3);
-    gl.uniform1f(gl.getUniformLocation(this.particleProgram, 'u_glowAlpha'), glowAlpha);
-    gl.drawArrays(gl.POINTS, 0, photons.length);
+    gl.uniform1f(gl.getUniformLocation(this.particleProgram, 'u_glowAlpha'), frame.glowAlpha);
+    gl.drawArrays(gl.POINTS, 0, frame.photons.length);
 
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.ONE, gl.ONE);
     gl.useProgram(this.glowProgram);
     bindAttribute(gl, this.glowProgram, this.positionBuffer, 'a_position', positions, 2);
     bindAttribute(gl, this.glowProgram, this.colorBuffer, 'a_color', colors, 3);
-    gl.uniform1f(gl.getUniformLocation(this.glowProgram, 'u_glowAlpha'), glowAlpha * 0.5);
-    gl.drawArrays(gl.POINTS, 0, photons.length);
+    gl.uniform1f(gl.getUniformLocation(this.glowProgram, 'u_glowAlpha'), frame.glowAlpha * 0.5);
+    gl.drawArrays(gl.POINTS, 0, frame.photons.length);
     gl.disable(gl.BLEND);
   }
 }


### PR DESCRIPTION
### Motivation
- Replace a fixed per-frame step with real `requestAnimationFrame` timestamps so motion and cadence scale correctly with actual frame time. 
- Ensure all motion-related updates (velocity, cooldown, flow sampling, feedback cadence) are driven by a single timing/tick policy to avoid inconsistent behavior across frame rates. 
- Offload expensive alpha-mask / field compilation to `OffscreenCanvas` or a worker when available to avoid blocking the main thread. 
- Enforce a strict renderer boundary so the renderer only receives a snapshot for drawing and contains no behavior logic, and expose runtime telemetry to match observability contracts.

### Description
- Kernel loop now consumes the `requestAnimationFrame` `timestamp`, computes a bounded `deltaTime`, and uses `computeDeltaTime` + `buildTickPolicy` to derive `velocityScale`, `cooldownScale`, `flowScale`, and feedback cadence. (`kernel.ts`) 
- Updated photon update logic to multiply velocity, cooldowns, flow sampling, and feedback cadence by the tick policy derived from `deltaTime`, replacing ad-hoc `this.time += 0.016` and fixed-step updates. (`kernel.ts`) 
- Added async field compilation with `OffscreenCanvas` and a Worker path with a fallback to main-thread canvas painting for glyph alpha masks; field compilation is now cancellable by revision. (`kernel.ts`, worker blob) 
- Wired `renderer-webgl.ts` into the kernel via explicit `RendererFrameSnapshot` / `RendererPhotonSnapshot` interfaces and limited the renderer to upload/draw responsibilities only; renderer now accepts a frame snapshot object. (`renderer-webgl.ts`, `kernel.ts`) 
- Introduced in-kernel runtime telemetry (`fps`, `dropped_frames`, `particle_count`, `average_velocity`, `last_ai_command`, `policy_block_count`) with a `getTelemetrySnapshot()` accessor and updated README to document these fields. (`kernel.ts`, `README.md`) 
- Tests updated to exercise the renderer-backed path and telemetry (expanded `kernel.test.ts` mocks and assertions). (`kernel.test.ts`) 

### Testing
- Executed `node --test kernel.test.ts`, which passed (3 tests, 0 failures). 
- Unit test harness was extended to mock `WebGL2` and `2D` contexts and assert telemetry values such as `particle_count`, `last_ai_command`, and `fps` during lifecycle operations. 
- Updated `README.md` to reflect the new runtime telemetry fields and behaviors; no automated docs failures reported by the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bde5dee5f48320967e288819ad812b)