### PR TITLE
docs: align README architecture diagram with runtime DB and canonicalize 7 visual states

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,29 +58,24 @@ The current prototype architecture is centered on runtime state semantics and th
 ┌──────────────────────────────────────────────────────────────────────────────────────────────┐
 │                           RUNTIME GOVERNOR (canonical middleware)                            │
 │              schema check • state profile map • clamp • fallback • policy block             │
-└───────────────────────┬─────────────────────────────────────────────┬────────────────────────┘
-                        │ accepted canonical state                     │ telemetry events
-                        ▼                                              ▼
-┌───────────────────────────────────────────────┐        ┌─────────────────────────────────────┐
-│ FRONTEND RUNTIME (Manifest / HUD / Renderer) │        │ TELEMETRY INGEST + QUERY API        │
-│ consumes governor-approved state only          │        │ validate points + aggregate windows  │
-└───────────────────────┬───────────────────────┘        └──────────────┬──────────────────────┘
-                        │ websocket state updates                        │
-                        │                                                │ writes/reads
-                        ▼                                                ▼
-         ┌─────────────────────────────────────┐          ┌─────────────────────────────────────┐
-         │ STATE_SYNC_ROOMS (in-memory)       │          │ TELEMETRY_TS_DB (in-memory TSDB)   │
-         │ dict[room_id, StateSyncRoom]       │          │ dict[metric, list[point]]          │
-         │ version + shared_state + user_state│          │ trim latest 2500 points / metric   │
-         └──────────────────┬──────────────────┘          └──────────────────┬──────────────────┘
-                            │ snapshots / broadcast                           │
-                            ▼                                                 ▼
-                  ┌──────────────────────────────┐                 ┌──────────────────────────────┐
-                  │ /ws/state-sync/{room_id}    │                 │ /api/v1/telemetry/query      │
-                  │ multi-user state visibility │                 │ count / mean / p95 / latest  │
-                  └──────────────────────────────┘                 └──────────────┬───────────────┘
-                                                                                   ▼
-                                                                  telemetry-driven HUD + alerts
+└──────────────────────────────┬──────────────────────────────────────────────┬────────────────┘
+                               │ canonical visual + control envelope           │ telemetry emit
+                               ▼                                               ▼
+┌───────────────────────────────────────────────────────────────┐  ┌─────────────────────────────┐
+│ FRONTEND RUNTIME (Manifest / HUD / Renderer)                 │  │ TELEMETRY API               │
+│ consumes governor-approved state only                         │  │ ingest + query windows       │
+└──────────────────────────────┬────────────────────────────────┘  └──────────────┬──────────────┘
+                               │ websocket state sync                           writes/reads
+                               ▼                                                    ▼
+┌───────────────────────────────────────────────────────────────┐  ┌─────────────────────────────┐
+│ STATE_SYNC_ROOMS (in-memory)                                 │  │ TELEMETRY_TS_DB (in-memory) │
+│ dict[room_id, StateSyncRoom]                                 │  │ dict[metric, list[point]]   │
+│ room = {version, shared_state, user_state, updated_at}       │  │ point={metric,value,ts,tags}│
+│ endpoint: /ws/state-sync/{room_id}                           │  │ trim to latest 2500/metric  │
+└──────────────────────────────┬────────────────────────────────┘  └──────────────┬──────────────┘
+                               │ snapshots / broadcast                            │ aggregates
+                               ▼                                                  ▼
+                multi-user visibility + replay hooks             /api/v1/telemetry/query (count/mean/p95/latest)
 ```
 
 This diagram aligns with the current implementation documented under **Runtime Database Structure (Current)**:
@@ -337,6 +332,37 @@ Then applies deterministic AM-UI mapping for:
 - HUD accent
 
 See `docs/10_AMUI_COLOR_SYSTEM.md` for palette tables, state mapping, and shader binding contracts.
+
+### Canonical Visual States (MVP v1)
+
+Manifest MVP locks seven canonical visual states as the center of runtime semantics:
+
+- `IDLE`
+- `LISTENING`
+- `THINKING`
+- `RESPONDING`
+- `WARNING`
+- `ERROR`
+- `NIRODHA`
+
+```ts
+export type VisualState =
+  | "IDLE"
+  | "LISTENING"
+  | "THINKING"
+  | "RESPONDING"
+  | "WARNING"
+  | "ERROR"
+  | "NIRODHA";
+```
+
+Governor and renderer rules for v1:
+- `WARNING`, `ERROR`, `NIRODHA` are reserved semantics and must keep their core palette meaning.
+- `LISTENING` must be triggerable from voice/sensor events.
+- `THINKING -> RESPONDING` should transition smoothly (no hard-cut flicker).
+- `ERROR` semantics override aesthetic renderer/plugin preferences.
+
+Non-canonical overlays should remain separate from the core state machine (examples: `SENSOR_ACTIVE`, `LOW_POWER`, `NETWORK_DEGRADED`, `HUMAN_OVERRIDE`, `MUTED`).
 
 ### Voice Interaction Pipeline
 Simulated voice interface including:
@@ -652,8 +678,5 @@ Gateway: `http://localhost:8000` (เอกสาร API ที่ `/docs`)
 
 ### แนวทางต่อยอด
 รายละเอียดแผนระยะถัดไปถูกรวมไว้เพียงจุดเดียวในส่วน **Research & Engineering Roadmap** ด้านภาษาอังกฤษ เพื่อลดข้อมูลซ้ำซ้อนและให้มีแหล่งอ้างอิงเดียวของระบบ.
-
-### หมายเหตุการจัดการข้อเสนอแนะ
-รายการ “ข้อเสนอแนะที่ทำเสร็จแล้ว” ถูกลบออกจาก README ทั้งภาษาอังกฤษและภาษาไทยแล้ว เพื่อแยกงานที่ปิดแล้วออกจาก roadmap ที่ยังดำเนินการอยู่.
 
 ---


### PR DESCRIPTION
### Motivation

- Align the README System Architecture diagram with the actual in-memory runtime database model so documentation matches the implemented stores and endpoints.
- Codify a minimal, stable visual-state contract for the Manifest MVP to keep Governor, HUD, and renderer semantics interoperable across implementations.
- Remove a confusing Thai-language note about completed suggestions so the roadmap and active proposals are not mixed with closed items.

### Description

- Updated the ASCII System Architecture diagram in `README.md` to explicitly describe `STATE_SYNC_ROOMS` (shape, websocket endpoint) and `TELEMETRY_TS_DB` (point shape, retention trimming) and their access paths. 
- Added a new `Canonical Visual States (MVP v1)` section that defines the `VisualState` union and lists the seven locked states (`IDLE`, `LISTENING`, `THINKING`, `RESPONDING`, `WARNING`, `ERROR`, `NIRODHA`) and key Governor/renderer rules. 
- Documented v1 rules including reserved semantics for `WARNING`/`ERROR`/`NIRODHA`, `LISTENING` activation from voice/sensor events, smooth `THINKING -> RESPONDING` transitions, and `ERROR` semantic precedence over cosmetic renderer choices. 
- Removed the Thai note about “completed suggestions” from the README to keep roadmap content focused on active work.

### Testing

- Ran `git diff --check` on the modified files and the check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c333f91a14832098409e6d80ed528c)