### PR TITLE
docs: document Ajv governor schema-validation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,39 @@ uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 - Frontend: `http://localhost:4173`
 - Gateway: `http://localhost:8000` (OpenAPI docs at `/docs`)
 
+### TypeScript Governor Schema Validation (Ajv)
+
+The Manifest runtime is intentionally positioned as a visualization runtime that consumes transport-level signals (API/WebSocket). To preserve that contract boundary, place schema validation in the Governor path before state is released to the renderer.
+
+Core helper APIs in `ajv_validator.ts`:
+- `createParticleControlAjv()`
+- `compileParticleControlValidator()`
+- `validateParticleControlPayload()`
+- `createGovernorSchemaValidator()`
+- `createAjvGovernor()`
+- `assertParticleControlSchemaCompiles()`
+
+Install required packages:
+
+```bash
+npm install ajv ajv-formats
+```
+
+`ajv-formats` is required because Ajv v7+ separates format validators (for example `date-time`) from the core package.
+
+Example:
+
+```ts
+import { createAjvGovernor } from "./ajv_validator";
+
+const governor = createAjvGovernor();
+
+const decision = governor.process(payload, {
+  previous_state: "THINKING",
+  device_tier: "MID",
+});
+```
+
 ---
 
 ## Project Structure


### PR DESCRIPTION
### Motivation

- Make it explicit that schema validation must run in the Governor middleware before the renderer consumes state to preserve the project's visualization-runtime contract.
- Provide a clear, discoverable TypeScript integration path for Ajv-based schema validation used by the runtime governor.
- Clarify required runtime dependencies and a minimal usage example so integrators can wire Ajv into the governor quickly.

### Description

- Added a new README subsection, `TypeScript Governor Schema Validation (Ajv)`, describing the Governor-first validation placement and rationale.
- Documented the exported helper APIs from `ajv_validator.ts`: `createParticleControlAjv()`, `compileParticleControlValidator()`, `validateParticleControlPayload()`, `createGovernorSchemaValidator()`, `createAjvGovernor()`, and `assertParticleControlSchemaCompiles()`.
- Added the required install command `npm install ajv ajv-formats` and a short usage snippet showing `createAjvGovernor()` + `governor.process(...)`.

### Testing

- Ran repository checks: `git diff --check` to ensure no whitespace/patch-format issues, which passed.
- Verified the updated README content was written and viewable with a file listing command, which succeeded.
- No runtime unit tests or TypeScript compilation against `ajv`/`ajv-formats` were executed in this environment due to missing npm dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c33b54c57883208cd96aa4a7ce0e76)