### PR TITLE
docs: remove completed recommendation references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ python3 tools/benchmarks/runtime_semantic_benchmark.py --input tools/benchmarks/
 
 ## Research & Engineering Roadmap
 
-Future directions only:
+Future directions only (completed recommendations have been removed from this section):
 
 - **Distributed Runtime State**  
   Move mutable runtime state to Redis for multi-worker consistency.
@@ -710,6 +710,6 @@ Gateway: `http://localhost:8000` (เอกสาร API ที่ `/docs`)
 โครงสร้างนี้เหมาะกับการพัฒนา/ทดสอบแบบ deterministic และสามารถย้ายไปใช้ TSDB จริงใน production โดยคงสัญญา API เดิมได้.
 
 ### แนวทางต่อยอด
-รายละเอียดแผนระยะถัดไปถูกรวมไว้เพียงจุดเดียวในส่วน **Research & Engineering Roadmap** ด้านภาษาอังกฤษ เพื่อลดข้อมูลซ้ำซ้อนและให้มีแหล่งอ้างอิงเดียวของระบบ.
+รายละเอียดแผนระยะถัดไปถูกรวมไว้เพียงจุดเดียวในส่วน **Research & Engineering Roadmap** ด้านภาษาอังกฤษ โดยตัดรายการ “ข้อเสนอแนะที่ทำเสร็จแล้ว” ออกแล้ว เพื่อลดข้อมูลซ้ำซ้อนและให้มีแหล่งอ้างอิงเดียวของระบบ.
 
 ---


### PR DESCRIPTION
### Motivation
- Align the README with the project guidance in `AGENTS.md` by removing references to completed recommendations so the roadmap only lists forward-looking work.

### Description
- Edited `README.md` to update the English `Research & Engineering Roadmap` intro to state that completed recommendations have been removed and to revise the Thai `แนวทางต่อยอด` paragraph to confirm the removal of the “ข้อเสนอแนะที่ทำเสร็จแล้ว” entries.

### Testing
- Documentation-only change; no automated tests were required or run and no runtime/code paths were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c34330966c832097d48a70d825e857)