### PR TITLE
Add psycho-safety gate to governor pipeline (flicker/glow/velocity caps)

### DIFF
--- a/governor.ts
+++ b/governor.ts
@@ -487,6 +487,11 @@ export const SCALAR_PATHS: readonly ScalarPath[] = [
 export const SAFE_SENSOR_STATES = new Set<GovernorState>(["LISTENING", "SENSOR_ACTIVE"]);
 export const MAX_SHADER_UNIFORMS = 16;
 export const MAX_TELEMETRY_EVENTS = 2048;
+export const PSYCHO_SAFETY_LIMITS = {
+  flicker: 0.12,
+  glow_intensity: 0.72,
+  velocity: 0.5,
+} as const;
 
 function deepCopy<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
@@ -640,6 +645,14 @@ export class RuntimeGovernor {
       log("fallback", "mutated", { count: fallbackNotes.length });
     } else {
       log("fallback", "ok");
+    }
+
+    const psychoNotes = this.applyPsychoSafetyGate(normalizedWork, ctx);
+    if (psychoNotes.length) {
+      mutations.push(...psychoNotes);
+      log("psycho_safety_gate", "mutated", { count: psychoNotes.length });
+    } else {
+      log("psycho_safety_gate", "ok");
     }
 
     const schemaErrors = this.validateAgainstSchema(normalizedWork);
@@ -849,6 +862,32 @@ export class RuntimeGovernor {
       notes.push(`intent_state.state_duration_ms: ${JSON.stringify(originalDuration)} -> ${normalizedDuration}`);
     }
     intent.state_duration_ms = normalizedDuration;
+
+    return notes;
+  }
+
+  applyPsychoSafetyGate(payload: Required<ParticleControlContract>, _ctx: Required<GovernorContext>): string[] {
+    const notes: string[] = [];
+    const intent = payload.intent_state;
+    const renderer = payload.renderer_controls;
+
+    if ((intent.flicker ?? 0) > PSYCHO_SAFETY_LIMITS.flicker) {
+      const original = Number(intent.flicker ?? 0);
+      intent.flicker = PSYCHO_SAFETY_LIMITS.flicker;
+      notes.push(`psycho_safety_gate intent_state.flicker: ${original} -> ${intent.flicker}`);
+    }
+
+    if ((intent.glow_intensity ?? 0) > PSYCHO_SAFETY_LIMITS.glow_intensity) {
+      const original = Number(intent.glow_intensity ?? 0);
+      intent.glow_intensity = PSYCHO_SAFETY_LIMITS.glow_intensity;
+      notes.push(`psycho_safety_gate intent_state.glow_intensity: ${original} -> ${intent.glow_intensity}`);
+    }
+
+    if ((renderer.velocity ?? 0) > PSYCHO_SAFETY_LIMITS.velocity) {
+      const original = Number(renderer.velocity ?? 0);
+      renderer.velocity = PSYCHO_SAFETY_LIMITS.velocity;
+      notes.push(`psycho_safety_gate renderer_controls.velocity: ${original} -> ${renderer.velocity}`);
+    }
 
     return notes;
   }

--- a/runtime_governor.py
+++ b/runtime_governor.py
@@ -356,6 +356,11 @@ SCALAR_PATHS = [
 SAFE_SENSOR_STATES = {"LISTENING", "SENSOR_ACTIVE"}
 MAX_SHADER_UNIFORMS = 16
 MAX_TELEMETRY_EVENTS = 2048
+PSYCHO_SAFETY_LIMITS = {
+    "flicker": 0.12,
+    "glow_intensity": 0.72,
+    "velocity": 0.50,
+}
 
 
 def _utc_now() -> datetime:
@@ -416,7 +421,8 @@ class RuntimeGovernor:
 
     Pipeline:
         validate -> transition -> profile_map -> clamp -> fallback
-        -> policy_block -> capability_gate -> telemetry_log
+        -> psycho_safety_gate -> validate_schema -> policy_block
+        -> capability_gate -> telemetry_log
 
     Notes:
     - This V1 accepts partial payloads and normalizes them into a full contract.
@@ -500,6 +506,14 @@ class RuntimeGovernor:
             log("fallback", "mutated", count=len(fallback_note))
         else:
             log("fallback", "ok")
+
+        # 5.5) psycho_safety_gate
+        psycho_note = self._apply_psycho_safety_gate(work, ctx)
+        if psycho_note:
+            mutations.extend(psycho_note)
+            log("psycho_safety_gate", "mutated", count=len(psycho_note))
+        else:
+            log("psycho_safety_gate", "ok")
 
         # Full schema validation after normalization
         schema_errors = self._validate_against_schema(work)
@@ -685,6 +699,29 @@ class RuntimeGovernor:
         if original_duration != normalized_duration:
             notes.append(f"intent_state.state_duration_ms: {original_duration!r} -> {normalized_duration}")
         intent["state_duration_ms"] = normalized_duration
+
+        return notes
+
+    def _apply_psycho_safety_gate(self, payload: Dict[str, Any], ctx: GovernorContext) -> List[str]:
+        _ = ctx
+        notes: List[str] = []
+        intent = payload["intent_state"]
+        renderer = payload["renderer_controls"]
+
+        if intent.get("flicker", 0.0) > PSYCHO_SAFETY_LIMITS["flicker"]:
+            original = intent.get("flicker", 0.0)
+            intent["flicker"] = PSYCHO_SAFETY_LIMITS["flicker"]
+            notes.append(f"psycho_safety_gate intent_state.flicker: {original} -> {intent['flicker']}")
+
+        if intent.get("glow_intensity", 0.0) > PSYCHO_SAFETY_LIMITS["glow_intensity"]:
+            original = intent.get("glow_intensity", 0.0)
+            intent["glow_intensity"] = PSYCHO_SAFETY_LIMITS["glow_intensity"]
+            notes.append(f"psycho_safety_gate intent_state.glow_intensity: {original} -> {intent['glow_intensity']}")
+
+        if renderer.get("velocity", 0.0) > PSYCHO_SAFETY_LIMITS["velocity"]:
+            original = renderer.get("velocity", 0.0)
+            renderer["velocity"] = PSYCHO_SAFETY_LIMITS["velocity"]
+            notes.append(f"psycho_safety_gate renderer_controls.velocity: {original} -> {renderer['velocity']}")
 
         return notes
 

--- a/test_runtime_governor_psycho_safety.py
+++ b/test_runtime_governor_psycho_safety.py
@@ -1,0 +1,82 @@
+import unittest
+
+from runtime_governor import GovernorContext, RuntimeGovernor
+
+
+def make_payload(*, flicker: float, glow_intensity: float, velocity: float) -> dict:
+    return {
+        "contract_name": "AI Particle Control Contract V1",
+        "contract_version": "1.0.0",
+        "intent_state": {
+            "state": "THINKING",
+            "shape": "SPIRAL_VORTEX",
+            "particle_density": 0.78,
+            "turbulence": 0.24,
+            "glow_intensity": glow_intensity,
+            "flicker": flicker,
+            "palette": {
+                "mode": "DEEP_REASONING",
+                "primary": "#6A0DAD",
+                "secondary": "#D8C7FF",
+                "accent": "#55C7FF",
+            },
+            "state_entered_at": "2026-03-25T00:00:00Z",
+            "state_duration_ms": 1000,
+            "transition_reason": "test",
+        },
+        "renderer_controls": {
+            "runtime_profile": "DETERMINISTIC",
+            "shader_uniforms": {},
+            "velocity": velocity,
+        },
+    }
+
+
+class PsychoSafetyGateTests(unittest.TestCase):
+    def test_pipeline_order_includes_psycho_safety_gate(self) -> None:
+        governor = RuntimeGovernor()
+        decision = governor.process(make_payload(flicker=0.05, glow_intensity=0.5, velocity=0.2), GovernorContext())
+        stages = [event["stage"] for event in decision.telemetry]
+        self.assertIn("psycho_safety_gate", stages)
+        self.assertIn("validate_schema", stages)
+        self.assertLess(stages.index("fallback"), stages.index("psycho_safety_gate"))
+        self.assertLess(stages.index("psycho_safety_gate"), stages.index("validate_schema"))
+        self.assertLess(stages.index("validate_schema"), stages.index("policy_block"))
+        self.assertLess(stages.index("psycho_safety_gate"), stages.index("policy_block"))
+
+    def test_noop_for_safe_inputs(self) -> None:
+        governor = RuntimeGovernor()
+        payload = make_payload(flicker=0.05, glow_intensity=0.5, velocity=0.2)
+        decision = governor.process(payload, GovernorContext())
+
+        self.assertTrue(decision.accepted)
+        self.assertEqual(decision.effective_contract["intent_state"]["flicker"], 0.05)
+        self.assertEqual(decision.effective_contract["intent_state"]["glow_intensity"], 0.5)
+        self.assertEqual(decision.effective_contract["renderer_controls"]["velocity"], 0.2)
+        self.assertFalse(any(note.startswith("psycho_safety_gate") for note in decision.mutations))
+
+    def test_unsafe_per_field_caps_are_reduced(self) -> None:
+        governor = RuntimeGovernor()
+        payload = make_payload(flicker=0.19, glow_intensity=0.9, velocity=0.9)
+        decision = governor.process(payload, GovernorContext())
+
+        self.assertTrue(decision.accepted)
+        self.assertEqual(decision.effective_contract["intent_state"]["flicker"], 0.12)
+        self.assertEqual(decision.effective_contract["intent_state"]["glow_intensity"], 0.72)
+        self.assertEqual(decision.effective_contract["renderer_controls"]["velocity"], 0.5)
+        self.assertTrue(any(note.startswith("psycho_safety_gate") for note in decision.mutations))
+
+    def test_backward_compatibility_for_existing_safe_contract(self) -> None:
+        governor = RuntimeGovernor()
+        payload = make_payload(flicker=0.0, glow_intensity=0.22, velocity=0.1)
+        decision = governor.process(payload, GovernorContext(previous_state="IDLE"))
+
+        self.assertTrue(decision.accepted)
+        self.assertEqual(decision.effective_contract["intent_state"]["state"], "THINKING")
+        self.assertEqual(decision.effective_contract["intent_state"]["flicker"], 0.0)
+        self.assertEqual(decision.effective_contract["intent_state"]["glow_intensity"], 0.22)
+        self.assertEqual(decision.effective_contract["renderer_controls"]["velocity"], 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce an automated safety layer that limits potentially harmful visual effects by capping high-frequency or intense renderer/intent fields to defined psycho-safety thresholds.
- Ensure the new gate runs as part of the normalization pipeline so unsafe values are clipped early and reported as mutations before schema validation and policy checks.

### Description
- Add `PSYCHO_SAFETY_LIMITS` in both `governor.ts` and `runtime_governor.py` to centralize caps for `flicker`, `glow_intensity`, and `velocity`.
- Implement `applyPsychoSafetyGate` (TypeScript) and `_apply_psycho_safety_gate` (Python) that clamp `intent_state.flicker`, `intent_state.glow_intensity`, and `renderer_controls.velocity` to the limits and append mutation notes when reductions occur.
- Insert the psycho-safety gate into the processing pipeline immediately after fallbacks and before schema validation/policy checks, and emit telemetry/logging for the new stage (`psycho_safety_gate`).
- Add unit tests in `test_runtime_governor_psycho_safety.py` to validate pipeline ordering, no-op behavior for safe inputs, enforcement of caps for unsafe inputs, and backward compatibility with existing safe contracts.

### Testing
- Executed the new Python unit tests with `python -m unittest test_runtime_governor_psycho_safety.py` which runs 4 tests and they all passed.
- Verified telemetry stages include `psycho_safety_gate` and that mutation notes are emitted when values exceed configured limits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c350fd818c83209db7ab64e56d37c5)