### PR TITLE
Add tests for RuntimeGovernor psycho_safety_gate parity

### DIFF
--- a/test_runtime_governor_psycho_safety.test.ts
+++ b/test_runtime_governor_psycho_safety.test.ts
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { RuntimeGovernor, type ParticleControlContract } from './governor.ts';
+
+// Verification note:
+// - Run with: npx --yes tsx --test test_runtime_governor_psycho_safety.test.ts
+// - Plain `node --test` currently fails due to ESM resolution of extensionless imports in `governor.ts`.
+
+function makePayload(params: { flicker: number; glow_intensity: number; velocity: number }): ParticleControlContract {
+  return {
+    contract_name: 'AI Particle Control Contract V1',
+    contract_version: '1.0.0',
+    intent_state: {
+      state: 'THINKING',
+      shape: 'SPIRAL_VORTEX',
+      particle_density: 0.78,
+      turbulence: 0.24,
+      glow_intensity: params.glow_intensity,
+      flicker: params.flicker,
+      palette: {
+        mode: 'DEEP_REASONING',
+        primary: '#6A0DAD',
+        secondary: '#D8C7FF',
+        accent: '#55C7FF',
+      },
+      state_entered_at: '2026-03-25T00:00:00Z',
+      state_duration_ms: 1000,
+      transition_reason: 'test',
+    },
+    renderer_controls: {
+      runtime_profile: 'DETERMINISTIC',
+      shader_uniforms: {},
+      velocity: params.velocity,
+    },
+  };
+}
+
+test('psycho_safety_gate stage order parity with Python governor tests', () => {
+  const governor = new RuntimeGovernor();
+  const decision = governor.process(makePayload({ flicker: 0.05, glow_intensity: 0.5, velocity: 0.2 }));
+  const stages = decision.telemetry.map((event) => event.stage);
+
+  assert.ok(stages.includes('psycho_safety_gate'));
+  assert.ok(stages.includes('validate_schema'));
+  assert.ok(stages.indexOf('fallback') < stages.indexOf('psycho_safety_gate'));
+  assert.ok(stages.indexOf('psycho_safety_gate') < stages.indexOf('validate_schema'));
+  assert.ok(stages.indexOf('validate_schema') < stages.indexOf('policy_block'));
+  assert.ok(stages.indexOf('psycho_safety_gate') < stages.indexOf('policy_block'));
+});
+
+test('psycho_safety_gate no-op parity for safe inputs', () => {
+  const governor = new RuntimeGovernor();
+  const decision = governor.process(makePayload({ flicker: 0.05, glow_intensity: 0.5, velocity: 0.2 }));
+
+  assert.equal(decision.accepted, true);
+  assert.equal(decision.effective_contract.intent_state.flicker, 0.05);
+  assert.equal(decision.effective_contract.intent_state.glow_intensity, 0.5);
+  assert.equal(decision.effective_contract.renderer_controls.velocity, 0.2);
+  assert.equal(decision.mutations.some((note) => note.startsWith('psycho_safety_gate')), false);
+});
+
+test('psycho_safety_gate per-field cap reduction parity', () => {
+  const governor = new RuntimeGovernor();
+  const decision = governor.process(makePayload({ flicker: 0.19, glow_intensity: 0.9, velocity: 0.9 }));
+
+  assert.equal(decision.accepted, true);
+  assert.equal(decision.effective_contract.intent_state.flicker, 0.12);
+  assert.equal(decision.effective_contract.intent_state.glow_intensity, 0.72);
+  assert.equal(decision.effective_contract.renderer_controls.velocity, 0.5);
+  assert.equal(decision.mutations.some((note) => note.startsWith('psycho_safety_gate')), true);
+});


### PR DESCRIPTION
### Motivation

- Ensure the JavaScript `RuntimeGovernor` implements the `psycho_safety_gate` stage ordering and per-field cap behavior consistently with the Python governor tests.

### Description

- Add `test_runtime_governor_psycho_safety.test.ts` which defines a `makePayload` helper and three focused tests for `psycho_safety_gate` behavior.
- Tests verify telemetry stage ordering, that safe inputs are no-ops, and that high values are reduced to expected per-field caps on the effective contract.
- The tests import `RuntimeGovernor` and `ParticleControlContract` from `./governor.ts` and assert on `decision.telemetry`, `decision.accepted`, `decision.effective_contract` fields, and `decision.mutations`.
- The file documents that the suite should be run with `npx --yes tsx --test` due to ESM resolution limitations with plain `node --test`.

### Testing

- Ran `npx --yes tsx --test test_runtime_governor_psycho_safety.test.ts` and all three tests passed.
- The test run notes that `node --test` currently fails for this file due to extensionless ESM import resolution and was not used.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c35974cc8c8320a185732b7928612b)