### PR TITLE
docs: add TypeScript psycho-safety test instruction and verification note

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,6 @@ const decision = governor.process(payload, {
   device_tier: "MID",
 });
 ```
-
 ---
 
 ## Project Structure
@@ -573,7 +572,12 @@ python3 tools/contracts/contract_fuzz.py
 
 # release benchmark gates (performance + semantics)
 python3 tools/benchmarks/runtime_semantic_benchmark.py --input tools/benchmarks/runtime_semantic_samples.sample.json
+
+# TypeScript psycho-safety parity test (run via tsx)
+npx --yes tsx --test test_runtime_governor_psycho_safety.test.ts
 ```
+
+> Verification note: `node --test test_runtime_governor_psycho_safety.test.ts` currently fails in this repo because Node ESM resolution does not resolve extensionless imports in `governor.ts`. Use the `tsx` command above for this test without changing runtime implementation.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Final documentation polish to clarify how to run the TypeScript psycho-safety parity test without changing runtime logic, schema, or thresholds, and to call out a known Node ESM resolution limitation.

### Description
- Updated `README.md` `Validation & Tests` section to add the TypeScript psycho-safety parity test command `npx --yes tsx --test test_runtime_governor_psycho_safety.test.ts` and to include a verification note that `node --test` currently fails due to Node ESM extensionless import resolution in `governor.ts` (no implementation changes were made).

### Testing
- Ran `npx --yes tsx --test test_runtime_governor_psycho_safety.test.ts` and the TypeScript test suite passed (3 tests OK).
- Ran `node --test test_runtime_governor_psycho_safety.test.ts` and it failed as expected with `ERR_MODULE_NOT_FOUND` caused by ESM extensionless import resolution, which is noted in the README and not changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c35c1b48548320a70b0b76b2d1b7b2)