### PR TITLE
docs: refresh README architecture and roadmap; add SECURITY.md and COPYRIGHT.md

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,14 @@
+# Copyright
+
+Copyright (c) 2026 Aetherium Manifest contributors.
+
+This repository content (source code, documentation, schemas, and assets) is protected by copyright.
+Unless a file states otherwise, usage and redistribution are governed by the project license.
+
+## Third-Party Material
+
+Any third-party libraries, tools, or assets remain the property of their respective owners and are governed by their own license terms.
+
+## Attribution
+
+When redistributing substantial portions of this project, preserve copyright notices and license references.

--- a/README.md
+++ b/README.md
@@ -49,33 +49,32 @@ Manifest is the visual language of Aetherium intelligence.
 The current prototype architecture is centered on runtime state semantics and the runtime database structure, with the Governor as the single mutation authority and telemetry/state-sync stores modeled explicitly:
 
 ```text
-┌──────────────────────────────────────────────────────────────────────────────────────────────┐
-│                              AI PARTICLE CONTROL CONTRACT (Schema = ABI)                    │
-│                  versioned envelopes for intent_state + renderer_controls                    │
-└──────────────────────────────────────────────┬───────────────────────────────────────────────┘
-                                               │ validate + normalize
-                                               ▼
-┌──────────────────────────────────────────────────────────────────────────────────────────────┐
-│                           RUNTIME GOVERNOR (canonical middleware)                            │
-│              schema check • state profile map • clamp • fallback • policy block             │
-└──────────────────────────────┬──────────────────────────────────────────────┬────────────────┘
-                               │ canonical visual + control envelope           │ telemetry emit
-                               ▼                                               ▼
-┌───────────────────────────────────────────────────────────────┐  ┌─────────────────────────────┐
-│ FRONTEND RUNTIME (Manifest / HUD / Renderer)                 │  │ TELEMETRY API               │
-│ consumes governor-approved state only                         │  │ ingest + query windows       │
-└──────────────────────────────┬────────────────────────────────┘  └──────────────┬──────────────┘
-                               │ websocket state sync                           writes/reads
-                               ▼                                                    ▼
-┌───────────────────────────────────────────────────────────────┐  ┌─────────────────────────────┐
-│ STATE_SYNC_ROOMS (in-memory)                                 │  │ TELEMETRY_TS_DB (in-memory) │
-│ dict[room_id, StateSyncRoom]                                 │  │ dict[metric, list[point]]   │
-│ room = {version, shared_state, user_state, updated_at}       │  │ point={metric,value,ts,tags}│
-│ endpoint: /ws/state-sync/{room_id}                           │  │ trim to latest 2500/metric  │
-└──────────────────────────────┬────────────────────────────────┘  └──────────────┬──────────────┘
-                               │ snapshots / broadcast                            │ aggregates
-                               ▼                                                  ▼
-                multi-user visibility + replay hooks             /api/v1/telemetry/query (count/mean/p95/latest)
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                           AI PARTICLE CONTROL CONTRACT (Schema = ABI, versioned)                            │
+│                 payload envelope: intent_state + renderer_controls + optional metadata                       │
+└──────────────────────────────────────────────────┬───────────────────────────────────────────────────────────┘
+                                                   │ validate + normalize
+                                                   ▼
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                     RUNTIME GOVERNOR (single mutable control boundary / canonical path)                     │
+│ validate → transition → profile_map → clamp → fallback → policy_block → capability_gate → telemetry_log    │
+└──────────────────────────────┬───────────────────────────────────────────────────────────────┬───────────────┘
+                               │ governor-approved state envelope                              │ telemetry events
+                               ▼                                                                ▼
+┌────────────────────────────────────────────────────────────────────────────┐   ┌─────────────────────────────────┐
+│ FRONTEND RUNTIME (Manifest/HUD/Renderer)                                  │   │ TELEMETRY INGEST + QUERY API    │
+│ consumes state-first contract only                                         │   │ /api/v1/telemetry/ingest|query  │
+└──────────────────────────────┬─────────────────────────────────────────────┘   └─────────────────┬───────────────┘
+                               │ websocket sync / snapshots                                  writes + retention
+                               ▼                                                                      ▼
+┌────────────────────────────────────────────────────────────────────────────┐   ┌─────────────────────────────────┐
+│ STATE_SYNC_ROOMS (in-memory room store)                                   │   │ TELEMETRY_TS_DB (in-memory TSDB)│
+│ dict[room_id, StateSyncRoom]                                               │   │ dict[str, list[point]]          │
+│ StateSyncRoom = {                                                           │   │ point={metric,value,ts,tags}    │
+│   version:int, shared_state:dict, user_state:dict, updated_at:datetime     │   │ partition key: metric           │
+│ }                                                                           │   │ retention: keep latest 2500/metric
+│ endpoint: /ws/state-sync/{room_id}                                          │   │ query window: count/mean/p95/latest
+└────────────────────────────────────────────────────────────────────────────┘   └─────────────────────────────────┘
 ```
 
 This diagram aligns with the current implementation documented under **Runtime Database Structure (Current)**:
@@ -474,6 +473,11 @@ Collaborative sessions are available via:
 
 allowing multiple users to observe and interact with shared cognitive state.
 
+
+### Policy Documents
+- Security policy: `SECURITY.md`
+- Copyright notice: `COPYRIGHT.md`
+
 ---
 
 ## Developer Quick Start
@@ -583,7 +587,7 @@ npx --yes tsx --test test_runtime_governor_psycho_safety.test.ts
 
 ## Research & Engineering Roadmap
 
-Future directions only (completed recommendations have been removed from this section):
+Future directions only (completed recommendations have been removed from this section in both English and Thai):
 
 - **Distributed Runtime State**  
   Move mutable runtime state to Redis for multi-worker consistency.
@@ -617,6 +621,18 @@ Future directions only (completed recommendations have been removed from this se
 
 - **Runtime Anomaly Detection**  
   Detect outlier combinations such as `fps` collapse + `policy_block_count` spikes and publish operator-facing alerts.
+
+- **Psycho-Safety Gate Hardening**  
+  Add dedicated psycho-safety metrics (flicker cadence, luminance drift budget, consent mode flags) and enforce deny-by-default mutation for high-risk render transitions.
+
+- **State-Sync Persistence Adapter**  
+  Introduce optional snapshot persistence for `STATE_SYNC_ROOMS` (Redis/Postgres adapter) while preserving websocket contract and room version semantics.
+
+- **Governance Audit Trail Ledger**  
+  Record schema/version approvals, compatibility decisions, and rollout exceptions with trace IDs for incident replay and compliance review.
+
+- **Edge Runtime Degradation Profiles**  
+  Add deterministic low-power profiles that couple renderer quality, telemetry sampling rate, and policy thresholds for constrained devices.
 
 ---
 
@@ -713,7 +729,22 @@ Gateway: `http://localhost:8000` (เอกสาร API ที่ `/docs`)
 
 โครงสร้างนี้เหมาะกับการพัฒนา/ทดสอบแบบ deterministic และสามารถย้ายไปใช้ TSDB จริงใน production โดยคงสัญญา API เดิมได้.
 
-### แนวทางต่อยอด
-รายละเอียดแผนระยะถัดไปถูกรวมไว้เพียงจุดเดียวในส่วน **Research & Engineering Roadmap** ด้านภาษาอังกฤษ โดยตัดรายการ “ข้อเสนอแนะที่ทำเสร็จแล้ว” ออกแล้ว เพื่อลดข้อมูลซ้ำซ้อนและให้มีแหล่งอ้างอิงเดียวของระบบ.
+### แนวทางต่อยอด (ภาษาไทย)
+> หมายเหตุ: ตัดรายการ “ข้อเสนอแนะที่ทำเสร็จแล้ว” ออกจากทั้งภาษาอังกฤษและภาษาไทยแล้ว เพื่อไม่ให้ปะปนกับงานที่ปิดไปแล้ว
+
+- **เสริม Psycho-Safety Gate เชิงรุก**  
+  เพิ่มตัวชี้วัด cadence/flicker/luminance drift พร้อม consent mode (`low-sensory`, `no-flicker`, `monochrome`) และบังคับ deny-by-default สำหรับการเปลี่ยนค่าสี/แสงที่มีความเสี่ยง
+
+- **เพิ่มตัวเลือก Persistent Store ให้ State Sync**  
+  รองรับ adapter แบบ Redis/Postgres สำหรับ snapshot ของห้อง (`STATE_SYNC_ROOMS`) โดยยังคง contract ของ websocket และ room version เดิม
+
+- **สร้าง Governance Audit Trail แบบตรวจสอบย้อนหลังได้**  
+  บันทึกการอนุมัติ schema/version, ผล compatibility check, และ rollout exception ผูกกับ trace ID เพื่อช่วย incident replay และ compliance review
+
+- **Edge Degradation Profiles สำหรับอุปกรณ์ทรัพยากรจำกัด**  
+  ผูกการลดคุณภาพ renderer, อัตรา sampling telemetry, และ policy thresholds เข้าด้วยกันแบบ deterministic เพื่อคงเสถียรภาพการรับรู้
+
+- **Spatial Extension Contract สำหรับ AR/VR**  
+  เพิ่มสัญญาเสริมด้าน anchor/depth/occlusion แยกจาก `intent_state` หลัก เพื่อรองรับ WebXR/OpenXR โดยไม่กระทบ ABI ปัจจุบัน
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported Versions
+
+The repository is currently pre-1.0 and maintained on a rolling basis from `main`.
+Security fixes are prioritized for the latest commit history and active release artifacts.
+
+| Version | Supported |
+| --- | --- |
+| main (latest) | ✅ |
+| historical snapshots | ⚠️ best effort only |
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately and include enough detail for deterministic reproduction.
+
+- Preferred channel: create a private security report to project maintainers (do **not** open a public issue for unpatched vulnerabilities).
+- Include:
+  - affected component/file path
+  - impact assessment (confidentiality/integrity/availability/safety)
+  - reproduction steps and payload samples
+  - observed logs/trace IDs and runtime context
+  - suggested mitigation (if available)
+
+## Response Targets
+
+- Initial acknowledgement: within **3 business days**.
+- Triage decision and severity classification: within **7 business days** after acknowledgement.
+- Mitigation plan or compensating control: as soon as validated, based on severity and exploitability.
+
+## Scope Notes
+
+Given the architecture of Aetherium Manifest:
+
+- Treat all model output as untrusted input.
+- Runtime Governor policy checks are the canonical control boundary.
+- Prototype telemetry/state-sync stores are currently in-memory and non-durable.
+- Contract/schema changes are ABI changes and require governance review.
+
+## Safe Harbor
+
+Good-faith security research and responsible disclosure are welcomed. Please avoid privacy violations, destructive testing, service disruption, and social engineering.


### PR DESCRIPTION
### Motivation
- Align the `README.md` system architecture diagram with the actual runtime database structure and the canonical Governor control flow to reduce ambiguity.
- Remove mixed “completed recommendations” content so the roadmap only lists future-facing proposals in both English and Thai.
- Surface repository policy artifacts from the top-level documentation so maintainers and auditors can quickly find security and copyright guidance.
- Record a small set of prioritized extension proposals (psycho-safety, state-sync persistence, governance audit trail, edge degradation, spatial contract) for follow-up work.

### Description
- Updated the `System Architecture` block in `README.md` to clarify the `AI PARTICLE CONTROL CONTRACT`, the canonical Governor path (`validate → transition → profile_map → clamp → fallback → policy_block → capability_gate → telemetry_log`), `STATE_SYNC_ROOMS`, and `TELEMETRY_TS_DB` shapes and contracts.
- Revised `Research & Engineering Roadmap` (English) to state it is future-only and added new extension proposals including psycho-safety hardening, state-sync persistence adapter, governance audit trail, and edge degradation profiles.
- Replaced the Thai “แนวทางต่อยอด” section with a future-only Thai roadmap and added the matching extension proposals including a `Spatial Extension Contract` entry.
- Added `SECURITY.md` (repository security disclosure/response policy) and `COPYRIGHT.md` (copyright notice and third-party attribution guidance) and linked them from the `README.md` `Policy Documents` section.
- Documentation-only changes; no runtime or ABI code was modified.

### Testing
- Validation commands executed: `git diff -- README.md SECURITY.md COPYRIGHT.md` (inspected changes) and `git status --short` (checked staged files), both completed successfully.
- Changes were staged and committed with `git add` + `git commit -m "docs: refresh architecture roadmap and add policy files"`, and verified with `git show --stat --name-only --oneline HEAD`; all commands succeeded.
- No runtime/unit test changes were required for this docs-only update; no automated test failures were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a103d6c483209c250df1a2e41460)