### PR TITLE
[docs] Replace AGENTS.md template with project-specific contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,61 +1,74 @@
 # AGENTS.md
 
-## Project Closure Status
-- Scope completed: README documentation update aligned with current runtime telemetry database structure and AI-agent extension proposals.
-- Last updated by role: Codex implementation agent.
-- Date: 2026-03-25.
+## Project Overview
 
-## Roles
-- **Maintainer**: approves roadmap and architecture-level contract changes.
-- **Backend Agent**: maintains `api_gateway/` API contract, runtime guards, and telemetry semantics.
-- **Frontend Agent**: maintains Manifest rendering contract (`am_color_system.js`, runtime UI semantics).
-- **Documentation Agent**: keeps `README.md` and `docs/` synchronized with actual implementation state.
-- **QA Agent**: validates schema/runtime consistency, regression tests, and benchmark gates.
+Aetherium Manifest is a real-time AI cognition visualization runtime that maps validated intent/state signals into perceptual light/particle rendering. The repository combines a static frontend runtime with a FastAPI gateway, contract-first schemas, runtime governor safety stages, and telemetry/benchmark tooling.
 
-## Current Notes
-- Telemetry persistence in prototype remains in-memory (`TELEMETRY_TS_DB`) and should be treated as non-durable.
-- Suggested extension priorities are tracked in `README.md` under roadmap and AI-agent proposal sections.
+Key technologies:
+- Frontend runtime: HTML/CSS/JavaScript + shader assets
+- API gateway: Python + FastAPI + Uvicorn
+- Contracts/testing: JSON Schema, Python validation tools, TypeScript psycho-safety parity tests
+- Tooling: pytest, benchmark scripts, contract checker/fuzzer
 
-## Architectural Truths (Grounded in Repository)
-- Canonical control boundary is **Runtime Governor** only: `validate → transition → profile_map → clamp → fallback → policy_block → capability_gate → telemetry_log`.
-- AI contract must preserve **state-first semantics** and keep renderer-level style controls bounded by policy.
-- Contract-first is mandatory: schema changes are ABI changes and require versioning, compatibility checks, and governance review.
-- Deterministic observability is a release gate: replay, benchmark, and telemetry must stay lockstep.
+## Setup Commands
 
-## Global AI Embodiment Guidance
+- Install gateway dependencies: `cd api_gateway && python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`
+- Start frontend dev server: `python3 -m http.server 4173`
+- Start API gateway (dev): `cd api_gateway && source .venv/bin/activate && uvicorn main:app --host 0.0.0.0 --port 8000 --reload`
+- Build for production: No dedicated frontend bundling step in-repo (static assets served directly). For backend packaging, standard Python deployment flows apply.
 
-### 1) Cross-model semantic standardization
-- Keep a compact semantic core shared across providers (`intent`, `state`, uncertainty, relational intent).
-- Preserve provider identity through approved style channels (e.g., shader uniforms / runtime profile), without violating semantic invariants.
-- Centralize normalization/mapping through shared adapter logic to avoid frontend/backend drift.
+## Development Workflow
 
-### 2) Evolution boundaries (self-modifying behavior)
-- Runtime AI must **not** directly mutate ABI/schema at run time.
-- Evolution is allowed via:
-  - substate expression inside existing state contracts,
-  - additive renderer/runtime extensions behind feature flags,
-  - governed proposal artifacts that pass CI checks before promotion.
+- Run frontend and gateway in separate terminals (frontend on `:4173`, gateway on `:8000`).
+- Use Uvicorn `--reload` for backend hot-reload during development.
+- Keep schema/contract changes synchronized with runtime governor behavior before renderer consumption.
+- Environment setup:
+  - Python 3.x with virtualenv for `api_gateway/`
+  - Optional Node tooling for TypeScript parity test (`npx --yes tsx --test ...`)
 
-### 3) Psychological safety and anti-manipulation
-- Clamp-only safety is insufficient for long-horizon risk.
-- Add a dedicated **psycho-safety gate** before policy block with:
-  - temporal/frequency constraints for light pulses,
-  - cumulative drift detection on cadence/flicker/luminance proxies,
-  - user capability + consent modes (low sensory / no flicker / monochrome).
-- Treat all model output as untrusted control signal; enforce deny-by-default control mutation.
+## Testing Instructions
 
-### 4) Spatial expansion (AR/VR/Holographic path)
-- Preserve `intent_state` semantics; add spatial extensions as separate contracts (anchors, depth source, occlusion policy).
-- Web path: WebXR adapters (layers/hit-test/depth/dom-overlay where applicable).
-- Native path: OpenXR-compatible runtime adapter.
+- Run all core checks:
+  - `cd api_gateway && pytest -q`
+  - `python3 tools/contracts/contract_checker.py`
+  - `python3 tools/contracts/contract_fuzz.py`
+  - `python3 tools/benchmarks/runtime_semantic_benchmark.py --input tools/benchmarks/runtime_semantic_samples.sample.json`
+  - `npx --yes tsx --test test_runtime_governor_psycho_safety.test.ts`
+- Run unit/integration tests:
+  - API tests are in the pytest suite under `api_gateway/`
+  - TypeScript psycho-safety parity test validates governor behavioral parity path
+- Coverage: no dedicated coverage command currently documented in-repo.
+- Important pattern: prefer `tsx` for the TS test; `node --test` currently fails due to ESM extensionless import resolution in `governor.ts`.
 
-### 5) Latency and mind-body coherence
-- Optimize for **perceived latency**, not raw RTT alone.
-- Use predictive execution/ghost previews with explicit commit/rollback semantics.
-- Keep timeline coupling through trace IDs + shared timestamps across token, state, and frame streams.
+## Code Style
 
-## Quality Gates for World-Scale Rollout
-- Contract checker enforcement: field evolution metadata + compatibility + runtime/schema anti-drift.
-- Runtime benchmark gates: latency p95, semantic continuity, render stability, containment activation targets.
-- Drift-detection acceptance criteria must be explicit and auditable before canary/GA promotion.
-- Rollback drills and incident replay are required definition-of-done for risky releases.
+- Preserve contract-first semantics: schema changes are ABI changes and must remain versioned/compatible.
+- Keep runtime mutation authority in governor path only (`validate → transition → profile_map → clamp → fallback → policy_block → capability_gate → telemetry_log`).
+- Treat model output as untrusted control signal; enforce deny-by-default style controls via runtime policy.
+- Use existing repository conventions and keep README/docs synchronized with implementation updates.
+- Lint/format: no single canonical lint/format command is currently enforced project-wide in documentation.
+
+## Build and Deployment
+
+- Frontend is static and can be served by any static host or simple HTTP server.
+- API deploys as a FastAPI/Uvicorn service (or equivalent ASGI deployment stack).
+- Runtime output/data is currently in-memory for prototype telemetry (`TELEMETRY_TS_DB`), non-durable by default.
+- Environment-specific hardening for production should include persistent telemetry storage, key rotation strategy, and governance/compatibility gates.
+
+## Pull Request Guidelines
+
+- Title format: `[component] Brief description`
+- Required checks (recommended minimum):
+  - `cd api_gateway && pytest -q`
+  - `python3 tools/contracts/contract_checker.py`
+- Include scope, contract/safety impact, and any schema/runtime compatibility considerations in PR description.
+- For ABI-affecting changes, include explicit versioning and migration/compat notes.
+
+## Additional Notes
+
+- Prototype telemetry persistence is intentionally non-durable and intended for deterministic runtime testing.
+- Architectural truths to preserve:
+  - Governor is canonical control boundary.
+  - State-first AI contract semantics are mandatory.
+  - Deterministic observability (replay/benchmark/telemetry lockstep) is a release gate.
+- Suggested extension priorities remain tracked in `README.md` roadmap and AI-agent proposal sections.


### PR DESCRIPTION
### Motivation
- Provide a concrete, repository-specific `AGENTS.md` that captures the project overview, development workflow, setup commands, testing guidance, and PR expectations to replace the placeholder/template content.

### Description
- Replaced the root `AGENTS.md` content with a contributor guide describing the Aetherium Manifest overview, key technologies, and runtime/governor architecture semantics.
- Added actionable setup commands for frontend and API gateway development, environment notes, and TypeScript test caveat (`tsx` vs `node`).
- Documented testing commands, required checks, code-style guidance emphasizing contract-first governance, and PR checklist recommendations.

### Testing
- Ran `python3 -m py_compile api_gateway/main.py` and the check passed.
- Ran `cd api_gateway && pytest -q` and the suite produced 46 passing tests and 1 failing test (`ContractCheckerCliTests::test_cli_emits_audit_even_when_validation_fails`) due to a test path expecting `tools/contracts/payloads/ipw_v1.payload.json` from the test working directory.
- Ran `python3 tools/contracts/contract_checker.py` and it completed successfully, reporting schema audit results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8669c72b48320bc28c3b7b26a02a0)