### PR TITLE
[docs] Add integrated 2026 development plan and formal architecture report (TH)

### DIFF
--- a/docs/13_INTEGRATED_DEVELOPMENT_PLAN_2026_TH.md
+++ b/docs/13_INTEGRATED_DEVELOPMENT_PLAN_2026_TH.md
@@ -288,7 +288,7 @@ AETHERIUM ถูกออกแบบเป็น **Governed Real-time Control L
 
 **Exit Criteria**
 - public-safe profile ใช้งานได้ในพื้นที่จำกัด
-- reconnect reconcile < 3s P95
+- reconnect reconcile < 2s P95
 
 **Metrics**
 - policy decision latency P95 < 80ms


### PR DESCRIPTION
### Motivation
- Provide a production-grade, contract-first integrated development plan and full formal architectural report (Thai) that defines the runtime/workflow, safety/governance model, and a 4-phase rollout roadmap for the AETHERIUM ecosystem with focus on `Aetherium-Manifest` integration. 
- Capture concrete requirements (contracts, latency budgets, benchmark suites, reliability, safety, and observability) so future implementation work across the six repositories can be scoped, versioned, and audited.

### Description
- Added a new document at `docs/13_INTEGRATED_DEVELOPMENT_PLAN_2026_TH.md` containing a 1-page architecture summary, C4 text diagrams (Context/Container/Component), dataflow/controlflow, an interface-contract table, latency budgets, benchmark plans, reliability strategy, safety/governance rules, a 4-phase roadmap with exit criteria, and explicit unknowns/assumptions. 
- The document formalizes `Intent/Visual/Scene` contract-first guidance, Governor/PRGX deny-by-default enforcement and audit model, Tachyon timing/jitter constraints, and Inspira-Firma duality for OS-native vs light-native modes. 
- This change is documentation-only and does not modify runtime code, schemas, or ABI.

### Testing
- Performed file-level sanity checks by printing and validating the new document with `nl -ba docs/13_INTEGRATED_DEVELOPMENT_PLAN_2026_TH.md | sed -n '1,260p'` and `sed -n '260,420p'`, and confirmed the file appears in repository file listings; these checks succeeded. 
- No unit or integration tests were required for this docs-only change; recommended repo checks for code changes remain `cd api_gateway && pytest -q` and `python3 tools/contracts/contract_checker.py` for future implementation work. 
- The new document is ready to be reviewed in architecture review and used as the basis for follow-up implementation tickets and benchmarks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c99b8282f88320a11f4f2b0a84768c)