### PR TITLE
[github] add path-based labeler rules and safer PR trigger

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,34 @@
+# Path-based labels applied by actions/labeler
+api_gateway:
+  - changed-files:
+      - any-glob-to-any-file: 'api_gateway/**'
+
+charts:
+  - changed-files:
+      - any-glob-to-any-file: 'charts/**'
+
+github:
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'
+
+contracts:
+  - changed-files:
+      - any-glob-to-any-file: 'tools/contracts/**'
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '*.html'
+          - '*.css'
+          - '*.js'
+          - 'assets/**'
+
+benchmarks:
+  - changed-files:
+      - any-glob-to-any-file: 'tools/benchmarks/**'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,7 +1,8 @@
 name: Labeler
 
 on:
-  pull_request_target:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
### Motivation
- Provide explicit path-to-label mappings so the repository can auto-label PRs by area (API gateway, charts, contracts, etc.).
- Reduce security risk by avoiding elevated `pull_request_target` execution for a labeling-only workflow.
- Keep workflow permissions minimal (`contents: read`, `pull-requests: write`) and avoid shell steps that build commands from PR context.

### Description
- Added `.github/labeler.yml` with path-to-label rules for `api_gateway/**`, `charts/**`, `.github/**`, `tools/contracts/**`, and additional groups for `docs`, `frontend`, and `benchmarks`.
- Updated `.github/workflows/label.yml` to trigger on `pull_request` with types `[opened, synchronize, reopened, ready_for_review]` instead of `pull_request_target`.
- Preserved least-privilege permissions in the workflow (`contents: read`, `pull-requests: write`) and retained the use of the pinned `actions/labeler` action without introducing shell steps.

### Testing
- Validated YAML syntax for both changed files with `python3` YAML load, which succeeded.
- Ran `npm run lint` in the repo as part of validation, which failed due to the repository using ESLint v9 flat-config expectations (`eslint.config.*` missing) and is unrelated to the labeler changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d778b2c1788320ad8e6fc9dc012a02)