### PR TITLE
[ci] Split AKS image build and gated deploy workflows

### DIFF
--- a/.github/workflows/azure-kubernetes-service-helm-build.yml
+++ b/.github/workflows/azure-kubernetes-service-helm-build.yml
@@ -1,0 +1,67 @@
+name: Build AKS deployment image artifact
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AZURE_CONTAINER_REGISTRY: "your-azure-container-registry"
+  CONTAINER_NAME: "your-container-name"
+  RESOURCE_GROUP: "your-resource-group"
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    if: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Azure login
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Build and push image to ACR
+        run: |
+          az acr build \
+            --image ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }} \
+            --registry ${{ env.AZURE_CONTAINER_REGISTRY }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            .
+
+      - name: Resolve immutable digest
+        id: digest
+        run: |
+          digest=$(az acr manifest show-metadata \
+            --name ${{ env.CONTAINER_NAME }}:${{ github.sha }} \
+            --registry ${{ env.AZURE_CONTAINER_REGISTRY }} \
+            --query digest -o tsv)
+          if [ -z "$digest" ]; then
+            echo "Failed to resolve image digest" >&2
+            exit 1
+          fi
+          printf '%s\n' "$digest" > image-digest.txt
+          cat > image-release.json <<EOF
+          {
+            "image": "${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}@${digest}",
+            "digest": "${digest}",
+            "commit": "${{ github.sha }}"
+          }
+          EOF
+
+      - name: Upload image metadata artifact
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+        with:
+          name: aks-image-release
+          path: |
+            image-digest.txt
+            image-release.json
+          if-no-files-found: error

--- a/.github/workflows/azure-kubernetes-service-helm.yml
+++ b/.github/workflows/azure-kubernetes-service-helm.yml
@@ -1,11 +1,38 @@
-name: Build and deploy an app to AKS with Helm
+name: Deploy app to AKS with Helm
 
 on:
+  workflow_call:
+    inputs:
+      deployment_environment:
+        description: Target environment (dev, staging, prod)
+        required: true
+        type: string
+      image_digest:
+        description: OCI image digest that has already passed promotion gates (sha256:...)
+        required: true
+        type: string
+      gate_passed:
+        description: Gate assertion from upstream workflow
+        required: true
+        type: boolean
   workflow_dispatch:
-
-concurrency:
-  group: aks-helm-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    inputs:
+      deployment_environment:
+        description: Target environment
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
+      image_digest:
+        description: OCI image digest that has already passed promotion gates (sha256:...)
+        required: true
+        type: string
+      gate_passed:
+        description: Confirm that this digest passed required gates
+        required: true
+        type: boolean
 
 permissions:
   contents: read
@@ -20,29 +47,16 @@ env:
   CHART_OVERRIDE_PATH: "your-chart-override-path"
 
 jobs:
-  build-image:
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    if: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Azure login
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Build and push image to ACR
-        run: |
-          az acr build --image ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }} --registry ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} .
-
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: [build-image]
-    if: ${{ needs.build-image.result == 'success' }}
+    if: ${{ (inputs.gate_passed || github.event.inputs.gate_passed == 'true') && (inputs.image_digest || github.event.inputs.image_digest) != '' && secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' }}
+    environment:
+      name: ${{ inputs.deployment_environment || github.event.inputs.deployment_environment }}
+    concurrency:
+      group: deploy-${{ inputs.deployment_environment || github.event.inputs.deployment_environment }}
+      cancel-in-progress: false
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -83,4 +97,4 @@ jobs:
           action: deploy
           manifests: ${{ steps.bake.outputs.manifestsBundle }}
           images: |
-            ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
+            ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}@${{ inputs.image_digest || github.event.inputs.image_digest }}


### PR DESCRIPTION
### Motivation
- Separate image build from deployment so deploys only consume promoted, immutable artifacts and cannot accidentally deploy mutable tags.
- Enforce environment-scoped deployment controls and serialized deploys per environment (`dev`, `staging`, `prod`) to reduce cross-environment collisions.
- Require an explicit gate assertion and an immutable `image_digest` for deploys to ensure only vetted images reach clusters.

### Description
- Converted `.github/workflows/azure-kubernetes-service-helm.yml` into a deploy-only workflow that accepts `deployment_environment`, `image_digest`, and `gate_passed` via `workflow_call` and `workflow_dispatch`.
- Added job-level `environment` binding and environment-scoped `concurrency` group `deploy-<environment>` to serialize deploys per environment.
- Enforced deploy preconditions so the job only runs when `gate_passed` is true and an `image_digest` is provided, and switched image references to immutable digest form `repo@sha256:...`.
- Added a new build workflow at `.github/workflows/azure-kubernetes-service-helm-build.yml` that builds/pushes the image to ACR, resolves the immutable digest, and uploads an `aks-image-release` artifact containing `image-digest.txt` and `image-release.json` for downstream promotion and gating.

### Testing
- Ran `npm run lint`, which failed due to the repository ESLint v9 configuration requiring an `eslint.config.*` file; this failure is unrelated to the workflow YAML changes.
- No other automated test suites (e.g., `pytest` or contract checks) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77b0261fc8320ad9b3abd66d5c651)