### PR TITLE
[github] Add Security Scorecards workflow with least-privilege permissions

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -4,5 +4,7 @@ Enable branch protection (or rulesets) for the default primary branch in use (`m
 
 - **Require a pull request before merging**
 - **Require review from Code Owners**
+- **Require status checks to pass before merging**
+  - Add `OSSF Scorecards` from workflow `Security Scorecards` as a required check on `main`
 
-This setting makes the `CODEOWNERS` rules mandatory before merge for protected branches.
+This setting makes the `CODEOWNERS` rules mandatory before merge for protected branches and enforces security workflow health gates.

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,9 @@
+name: Aetherium CodeQL Config
+
+paths-ignore:
+  - '**/*.md'
+  - 'tools/benchmarks/**'
+
+query-filters:
+  - exclude:
+      id: js/unused-local-variable

--- a/.github/workflows/security-scorecards.yml
+++ b/.github/workflows/security-scorecards.yml
@@ -1,0 +1,41 @@
+name: Security Scorecards
+
+on:
+  schedule:
+    - cron: '17 3 * * 1'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**'
+  pull_request:
+    paths:
+      - '.github/**'
+
+permissions:
+  contents: read
+
+jobs:
+  scorecards:
+    name: OSSF Scorecards
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run OpenSSF Scorecards
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
### Motivation
- Improve repository security posture by adding automated OpenSSF Scorecards runs on a regular schedule and when GitHub workflow files change. 
- Limit blast radius by scoping triggers to changes under `.github/**` and applying least-privilege permissions for workflow execution and SARIF publishing. 

### Description
- Add a new GitHub Actions workflow at ` .github/workflows/security-scorecards.yml` that triggers on a weekly `schedule` and on `push`/`pull_request` events that affect `.github/**` (with `push` limited to `main`).
- Configure global workflow permissions to `contents: read` and elevate permissions at the job level only for the `scorecards` job (`actions: read`, `contents: read`, `id-token: write`, `security-events: write`).
- Run the OpenSSF Scorecards action (`ossf/scorecard-action@v2.4.0`) and publish SARIF results, then upload SARIF to the GitHub Security tab using `github/codeql-action/upload-sarif@v3`.
- Add a baseline CodeQL config at `.github/codeql/codeql-config.yml` and update `.github/branch-protection.md` to recommend adding `OSSF Scorecards` as a required status check on `main`.

### Testing
- Ran `npm run lint`, which failed due to a missing `eslint.config.(js|mjs|cjs)` for the repository's ESLint v9 configuration and is unrelated to the workflow-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77d5f081083209caeab28e9a3611f)