### PR TITLE
[github] Expand Dependabot coverage and grouped update strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,35 +1,272 @@
 version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/api_gateway"
+
+multi-ecosystem-groups:
+  infra:
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: weekly
+      day: monday
       time: "03:00"
-      timezone: "Etc/UTC"
+      timezone: Etc/UTC
     labels:
-      - "dependencies"
-      - "python"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      - dependencies
+      - infra
+    assignees:
+      - CNR-CRN
+  app-runtime:
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: weekly
+      day: monday
       time: "03:30"
-      timezone: "Etc/UTC"
+      timezone: Etc/UTC
     labels:
-      - "dependencies"
-      - "github_actions"
+      - dependencies
+      - runtime
+    assignees:
+      - CNR-CRN
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-      timezone: "Etc/UTC"
+updates:
+  # -----------------------------
+  # App/runtime ecosystems
+  # -----------------------------
+  - package-ecosystem: npm
+    directory: /
+    multi-ecosystem-group: app-runtime
+    open-pull-requests-limit: 10
     labels:
-      - "dependencies"
-      - "docker"
+      - dependencies
+      - javascript
+      - runtime
+    assignees:
+      - CNR-CRN
+    schedule:
+      interval: daily
+      time: "01:30"
+      timezone: Etc/UTC
+    groups:
+      app-runtime-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      app-runtime-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /api_gateway
+    multi-ecosystem-group: app-runtime
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - python
+      - runtime
+    assignees:
+      - CNR-CRN
+    schedule:
+      interval: daily
+      time: "01:40"
+      timezone: Etc/UTC
+    groups:
+      app-runtime-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      app-runtime-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /governor
+    multi-ecosystem-group: app-runtime
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - python
+      - runtime
+    assignees:
+      - CNR-CRN
+    schedule:
+      interval: daily
+      time: "01:50"
+      timezone: Etc/UTC
+    groups:
+      app-runtime-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      app-runtime-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /ws_gateway
+    multi-ecosystem-group: app-runtime
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - python
+      - runtime
+    assignees:
+      - CNR-CRN
+    schedule:
+      interval: daily
+      time: "02:00"
+      timezone: Etc/UTC
+    groups:
+      app-runtime-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      app-runtime-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  # -----------------------------
+  # Infra ecosystems
+  # -----------------------------
+  - package-ecosystem: github-actions
+    directory: /
+    multi-ecosystem-group: infra
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github_actions
+      - infra
+    assignees:
+      - CNR-CRN
+    schedule:
+      interval: daily
+      time: "02:30"
+      timezone: Etc/UTC
+    groups:
+      infra-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      infra-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    multi-ecosystem-group: infra
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker
+      - infra
+    assignees:
+      - CNR-CRN
+    schedule:
+      interval: daily
+      time: "02:40"
+      timezone: Etc/UTC
+    groups:
+      infra-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      infra-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /api_gateway
+    multi-ecosystem-group: infra
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker
+      - infra
+    assignees:
+      - CNR-CRN
+    schedule:
+      interval: daily
+      time: "02:45"
+      timezone: Etc/UTC
+    groups:
+      infra-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      infra-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /governor
+    multi-ecosystem-group: infra
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker
+      - infra
+    assignees:
+      - CNR-CRN
+    schedule:
+      interval: daily
+      time: "02:50"
+      timezone: Etc/UTC
+    groups:
+      infra-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      infra-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /ws_gateway
+    multi-ecosystem-group: infra
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker
+      - infra
+    assignees:
+      - CNR-CRN
+    schedule:
+      interval: daily
+      time: "02:55"
+      timezone: Etc/UTC
+    groups:
+      infra-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      infra-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: terraform
+    directory: /
+    multi-ecosystem-group: infra
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - terraform
+      - infra
+    assignees:
+      - CNR-CRN
+    schedule:
+      interval: daily
+      time: "03:10"
+      timezone: Etc/UTC
+    groups:
+      infra-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      infra-version:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
### Motivation
- Ensure Dependabot covers all actual ecosystems present in the repository by aligning automation with detected lockfiles/manifests and Dockerfiles.
- Introduce a clear grouping strategy to separate infra-focused updates from app/runtime updates for manageable cadence and labeling.
- Make PR metadata (labels, assignees, `open-pull-requests-limit`) explicit so generated PRs are routed consistently.
- Split update intent between `security-updates` and `version-updates` to allow more frequent security scans while keeping grouped weekly version cadence.

### Description
- Rewrote ` .github/dependabot.yml` to add `multi-ecosystem-groups` with two groups: `infra` and `app-runtime`, and set group-level schedules.
- Added update entries for detected ecosystems and directories including `npm` (root), `pip` for `/api_gateway`, `/governor`, and `/ws_gateway`, `docker` for `/`, `/api_gateway`, `/governor`, and `/ws_gateway`, `github-actions` (root), and `terraform` (root).
- Configured per-entry `open-pull-requests-limit` (`10` for app/runtime, `5` for infra), labels, and assignees (`CNR-CRN`), and per-ecosystem daily scan schedules while keeping weekly group cadence.
- Added `groups` rules for `app-runtime-security` / `app-runtime-version` and `infra-security` / `infra-version` using `applies-to: security-updates` and `applies-to: version-updates` to separate intents.

### Testing
- Loaded the YAML with `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` and it succeeded.
- Ran `npm run lint` and it failed due to the repository using a legacy ESLint config while ESLint v9 expects `eslint.config.*` (this is an existing repo issue and not caused by the Dependabot config change).
- Verified the file was committed successfully with the message `[github] expand dependabot ecosystems and grouped cadence`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7829f37988320ac1666f03d4930d9)