### PR TITLE
[docs] Redefine Aetherium as Light-native Creative OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 Aetherium Manifest is a contract-first runtime for visualizing AI cognitive state as deterministic light/particle behavior, with a FastAPI gateway and WebSocket state sync.
 
+## Product definition (April 11, 2026)
+
+**Aetherium = Light-native Creative OS**
+
+Aetherium Manifest is now positioned as a creative operating surface where users do not ask for "effects"; they "converse with light" to produce tangible design outputs:
+
+- poster
+- brand visual
+- UI concept
+- diagram
+- ambient scene
+- concept art
+- motion identity
+- document visual
+
+Core embodiment remains unchanged from the current prototype: **full-screen light body + bottom composer**, with existing interaction grammar preserved (`standby light`, `touch burst`, `fade`, and `tilt sensor`).
+
 ## What's updated (April 2026)
 
 - `index.html` is now a fully runnable **runtime console** that works end-to-end with:

--- a/docs/00_PURPOSE_AND_SCOPE.md
+++ b/docs/00_PURPOSE_AND_SCOPE.md
@@ -7,7 +7,18 @@
 - ทำให้ผู้ใช้รับรู้ว่า latency ใกล้ศูนย์
 
 ## Product Re-definition (April 11, 2026)
-Aetherium Manifest ถูกนิยามใหม่เป็น **Aetherium = Light-native Creative OS** โดยผู้ใช้ไม่ได้สั่ง "เอฟเฟกต์" แต่ "คุยกับแสง" เพื่อสร้างงาน เช่น poster, brand visual, UI concept, diagram, ambient scene, concept art, motion identity และ document visual พร้อมคงบุคลิกเดิมของระบบไว้: **ร่างกายของแสงเต็มจอ + composer ด้านล่าง** (standby light, touch burst, fade, tilt sensor)
+Aetherium Manifest ถูกนิยามใหม่เป็น **Aetherium = Light-native Creative OS** โดยผู้ใช้ไม่ได้สั่ง "เอฟเฟกต์" แต่ "คุยกับแสง" เพื่อสร้างงาน เช่น:
+
+- poster
+- brand visual
+- UI concept
+- diagram
+- ambient scene
+- concept art
+- motion identity
+- document visual
+
+พร้อมคงบุคลิกเดิมของระบบไว้: **ร่างกายของแสงเต็มจอ + composer ด้านล่าง** (standby light, touch burst, fade, tilt sensor)
 
 ## Scope
 

--- a/docs/00_PURPOSE_AND_SCOPE.md
+++ b/docs/00_PURPOSE_AND_SCOPE.md
@@ -6,6 +6,9 @@
 - เปลี่ยนจาก command-response เป็น intent-manifestation
 - ทำให้ผู้ใช้รับรู้ว่า latency ใกล้ศูนย์
 
+## Product Re-definition (April 11, 2026)
+Aetherium Manifest ถูกนิยามใหม่เป็น **Aetherium = Light-native Creative OS** โดยผู้ใช้ไม่ได้สั่ง "เอฟเฟกต์" แต่ "คุยกับแสง" เพื่อสร้างงาน เช่น poster, brand visual, UI concept, diagram, ambient scene, concept art, motion identity และ document visual พร้อมคงบุคลิกเดิมของระบบไว้: **ร่างกายของแสงเต็มจอ + composer ด้านล่าง** (standby light, touch burst, fade, tilt sensor)
+
 ## Scope
 
 ### In-Scope

--- a/docs/runtime_console.md
+++ b/docs/runtime_console.md
@@ -17,7 +17,7 @@ The runtime keeps the same embodiment grammar from the current prototype:
 - fade
 - tilt sensor
 
-Operational responsibilities:
+### Operational responsibilities
 
 - intent capture (text, file, voice-mock)
 - deterministic local particle rendering fallback

--- a/docs/runtime_console.md
+++ b/docs/runtime_console.md
@@ -12,10 +12,10 @@ The runtime keeps the same embodiment grammar from the current prototype:
 
 - full-screen light body
 - bottom composer
-- standby light baseline
-- touch burst interaction
-- fade transition behavior
-- tilt sensor response
+- standby light
+- touch burst
+- fade
+- tilt sensor
 
 Operational responsibilities:
 

--- a/docs/runtime_console.md
+++ b/docs/runtime_console.md
@@ -6,7 +6,7 @@ This document describes the production-safe baseline behavior of the single-file
 
 `index.html` is the zero-build operational console for **Aetherium = Light-native Creative OS**.
 
-Users do not command visual "effects" directly. They converse with light to shape outputs such as posters, brand visuals, UI concepts, diagrams, ambient scenes, concept art, motion identity, and document visuals.
+Users do not command visual "effects" directly. They converse with light to shape outputs such as poster, brand visual, UI concept, diagram, ambient scene, concept art, motion identity, and document visual.
 
 The runtime keeps the same embodiment grammar from the current prototype:
 

--- a/docs/runtime_console.md
+++ b/docs/runtime_console.md
@@ -4,7 +4,20 @@ This document describes the production-safe baseline behavior of the single-file
 
 ## Purpose
 
-`index.html` is the zero-build operational console for:
+`index.html` is the zero-build operational console for **Aetherium = Light-native Creative OS**.
+
+Users do not command visual "effects" directly. They converse with light to shape outputs such as posters, brand visuals, UI concepts, diagrams, ambient scenes, concept art, motion identity, and document visuals.
+
+The runtime keeps the same embodiment grammar from the current prototype:
+
+- full-screen light body
+- bottom composer
+- standby light baseline
+- touch burst interaction
+- fade transition behavior
+- tilt sensor response
+
+Operational responsibilities:
 
 - intent capture (text, file, voice-mock)
 - deterministic local particle rendering fallback


### PR DESCRIPTION
### Motivation
- Clarify product positioning by redefining Aetherium Manifest as a creative operating surface: "Aetherium = Light-native Creative OS" where users "converse with light" to produce tangible design outputs rather than request raw effects. 
- Surface the canonical set of target outputs (poster, brand visual, UI concept, diagram, ambient scene, concept art, motion identity, document visual) and lock the intended embodiment grammar used by the runtime. 

### Description
- Added a new `Product definition (April 11, 2026)` section to `README.md` that states the new positioning and lists the supported creative output categories. 
- Updated `docs/runtime_console.md` Purpose to reflect the new positioning, enumerate the preserved embodiment grammar (full-screen light body + bottom composer, standby light, touch burst, fade, tilt sensor), and preserve operational responsibilities. 
- Inserted a `Product Re-definition (April 11, 2026)` paragraph into `docs/00_PURPOSE_AND_SCOPE.md` (Thai) to record the new definition in the project scope document. 
- Contract/safety impact: documentation-only change with no schema, API, governor, or runtime policy modifications and no ABI impact; compatibility remains backward-compatible. 

### Testing
- Ran `npm run lint` which failed due to missing project ESLint config for ESLint v9 (`eslint.config.(js|mjs|cjs)` not present). 
- Ran `cd api_gateway && pytest -q` which failed during collection because the testing environment is missing the `httpx` dependency. 
- Ran `python3 tools/contracts/contract_checker.py` which also failed due to the same missing `httpx` dependency required by `api_gateway/main.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9bd7e422c8320a264953b7d7a9cf6)