### PR TITLE
Add Aetherium docs: Investor One-Pager, PRD v1, and RFC for Contract/Governor/Replay

### DIFF
--- a/docs/Investor_Enterprise_OnePager.md
+++ b/docs/Investor_Enterprise_OnePager.md
@@ -1,0 +1,86 @@
+# Aetherium — Investor / Enterprise One-Pager
+
+- **Version:** 1.0  
+- **Date:** 2026-04-11
+
+## Positioning
+**Aetherium is a governed, light-native creative platform** where AI interprets intent and manifests design through luminous motion—observable, replayable, and enterprise-safe by design.
+
+## The Problem
+Current AI creative stacks are fast but fragile:
+- weak brand continuity,
+- little auditability,
+- minimal collaboration controls,
+- insufficient policy/safety boundaries for enterprise adoption.
+
+## The Product
+Aetherium turns intent into governed manifestation across 8 pillars:
+1. Brand Memory
+2. Creative Modes
+3. Live Variations
+4. Premium Export
+5. Session Replay
+6. Team Rooms
+7. Safety Profiles
+8. Observability HUD
+
+## Why We Win (Moat)
+1. **Governor-first runtime boundary**: AI cannot directly execute renderer commands.
+2. **Persistent Brand Memory**: branded outputs improve over time as reusable assets.
+3. **Deterministic Replay + Lineage**: every decision and export is traceable.
+4. **Light-native interaction model**: dynamic creative interface beyond static prompt UX.
+5. **Observability as product surface**: operational trust baked into user experience.
+
+## Enterprise Value
+- Faster creative approval cycles (lower TTAM)
+- Higher brand consistency
+- Reduced governance/compliance risk
+- Better cross-functional collaboration in shared rooms
+- Stronger operational confidence via HUD telemetry
+
+## Target Segments
+- Enterprise brand teams
+- Design systems organizations
+- Innovation labs / AI transformation programs
+- Regulated creative environments needing audit trails
+
+## Roadmap
+### Phase 1 — Product Core
+Contracts + Governor + Renderer-core
+
+### Phase 2 — Manifest Studio
+Studio UX + continuity-driven variations
+
+### Phase 3 — Premium Memory
+Projects + profiles + lineage + replay
+
+### Phase 4 — Team / Enterprise
+Shared rooms + audit + telemetry + persistence
+
+### Phase 5 — Plugin Ecosystem
+Renderer APIs for cinematic, diagrammatic, sacred-light, brand-motion
+
+## KPI Framework
+- **North Star:** TTAM (Time-to-Approved-Manifest)
+- Variation Acceptance Rate
+- Brand Consistency Score
+- Governor Intervention Rate
+- Export Completion Rate
+- Enterprise Expansion (seats/workspaces)
+
+## Risk Posture
+- Policy drift managed by governor stages and deny-by-default gates.
+- Runtime anomalies surfaced through HUD warnings and decision logs.
+- Contract versioning ensures controlled evolution.
+
+## Call to Action
+Aetherium is positioned to become the **creative control plane for governed AI design** in enterprise environments.
+
+## Kickoff Template (Owner / Due Date / Status)
+| Initiative | Outcome | Owner | Due Date | Status | Commercial Impact |
+|---|---|---|---|---|---|
+| Design Partner Program | 3 lighthouse pilots | TBD | YYYY-MM-DD | Not Started | referenceable case studies |
+| Enterprise Safety Pack | profile + audit baseline | TBD | YYYY-MM-DD | Not Started | procurement readiness |
+| Studio GA Plan | v1 launch milestone | TBD | YYYY-MM-DD | Not Started | revenue conversion path |
+| GTM Narrative | category + messaging | TBD | YYYY-MM-DD | Not Started | clearer positioning |
+| Metrics Ops | TTAM instrumentation | TBD | YYYY-MM-DD | Not Started | measurable value proof |

--- a/docs/PRD_v1.md
+++ b/docs/PRD_v1.md
@@ -60,13 +60,13 @@ Creative teams still work with fragmented prompt loops: low continuity, weak bra
 ## 9) Visual Runtime States
 - IDLE
 - LISTENING
-- INTERPRETING
-- MANIFESTING
-- REFINING
-- EXPORTING
+- THINKING
+- GENERATING
+- RESPONDING
 - WARNING
 - ERROR
 - NIRODHA
+- SENSOR_ACTIVE
 
 ## 10) Functional Requirements
 ### FR-1 Brand Memory

--- a/docs/PRD_v1.md
+++ b/docs/PRD_v1.md
@@ -1,0 +1,150 @@
+# Aetherium Manifest Studio — PRD v1
+
+- **Version:** 1.0  
+- **Date:** 2026-04-11  
+- **Owner:** Product Lead  
+- **Status:** Draft for kickoff
+
+## 1) Problem Statement
+Creative teams still work with fragmented prompt loops: low continuity, weak brand consistency, limited replayability, and insufficient enterprise controls (safety/audit/collaboration/export).
+
+## 2) Vision
+**Aetherium is a light-native creative platform** where AI interprets intent and manifests form through luminous motion, governed by a runtime boundary that is safe, testable, and enterprise-ready.
+
+## 3) Goals (v1)
+1. Reduce time from first intent to approved output.
+2. Preserve cross-session brand consistency.
+3. Enforce policy-first safety via Governor.
+4. Provide replay/audit/export paths for real production workflows.
+
+## 4) Non-Goals (v1)
+- Full plugin marketplace.
+- Full enterprise IAM/SSO suite.
+- Advanced BI-grade telemetry warehousing.
+
+## 5) Users & Jobs-to-be-Done
+### Primary Roles
+- **Designer:** Explore and refine branches with continuity.
+- **Brand Lead:** Approve outputs against profile/rules.
+- **Strategist:** Tune intent toward business outcomes.
+- **Operator:** Monitor runtime state, risk, and telemetry.
+
+### JTBD
+"When creating branded assets, I need the system to start from persistent brand memory and maintain continuity across refinements so approved deliverables can be exported immediately."
+
+## 6) Product Pillars
+1. Brand Memory  
+2. Creative Modes  
+3. Live Variations  
+4. Premium Export  
+5. Session Replay  
+6. Team Rooms  
+7. Safety Profiles  
+8. Observability HUD
+
+## 7) Experience Architecture (Manifest Studio)
+- **Left:** Intent / Brand / Mode
+- **Center:** Light Canvas
+- **Right:** Variations / Layers / History / Rules
+- **Bottom:** Multimodal Composer
+
+## 8) Core Flow
+1. User types/speaks intent.
+2. Runtime enters LISTENING → INTERPRETING.
+3. Generate first light sketch (MANIFESTING).
+4. Auto-branch into 4–8 variations.
+5. User selects a branch and refines in-place.
+6. Lock version.
+7. Export / Share / Replay.
+
+## 9) Visual Runtime States
+- IDLE
+- LISTENING
+- INTERPRETING
+- MANIFESTING
+- REFINING
+- EXPORTING
+- WARNING
+- ERROR
+- NIRODHA
+
+## 10) Functional Requirements
+### FR-1 Brand Memory
+- Persist: primary/secondary colors, fonts, mood, composition rules, negative rules, approved references, profile archetype.
+- Auto-apply memory when a brand profile is selected.
+
+### FR-2 Creative Modes
+- Required modes: `poster`, `brand`, `UI`, `concept`, `diagram`, `ambient`.
+- Mode controls constraints, variation defaults, and export presets.
+
+### FR-3 Live Variations
+- Every sketch must branch 4–8 options.
+- Branch presets include: `calm`, `luxury`, `sacred`, `enterprise`, `minimal`, `cinematic`.
+- Refinement continues from selected branch (no context reset).
+
+### FR-4 Premium Export
+- Must support: PNG, SVG, MP4, layer package, prompt lineage, manifest JSON.
+- Every export references session/replay lineage.
+
+### FR-5 Session Replay
+- Persist: prompt sequence, state transitions, visual decisions, selected variations, export history.
+- Replay must run step-by-step deterministically.
+
+### FR-6 Team Rooms
+- Shared field collaboration with role presence.
+- Role-specific visibility/actions: designer, brand lead, strategist, operator.
+
+### FR-7 Safety Profiles
+- Profiles: `brand-safe`, `enterprise-safe`, `sacred-safe`.
+- All contracts must pass Governor before renderer execution.
+
+### FR-8 Observability HUD
+- Show: latency, drift, confidence, warnings, active mode, replay state, collaboration presence.
+
+## 11) Non-Functional Requirements
+- Predictable behavior via contract-first runtime.
+- Deterministic replay for auditability.
+- Low latency for first sketch and branch generation.
+- Deny-by-default policy posture.
+
+## 12) Success Metrics
+### North Star
+- **TTAM (Time-to-Approved-Manifest)**
+
+### Supporting
+- Variation Acceptance Rate
+- Brand Consistency Score
+- Governor Intervention Rate
+- Replay Reopen Rate
+- Export Completion Rate
+
+## 13) Delivery Phases
+### Phase 1 — Product Core
+Contracts + Governor + Renderer-core
+
+### Phase 2 — Manifest Studio
+Studio UX and continuity-driven branching
+
+### Phase 3 — Premium Memory
+Projects, brand profiles, asset lineage, replay
+
+### Phase 4 — Team / Enterprise
+Shared rooms, telemetry, audit, persistence
+
+### Phase 5 — Plugin Ecosystem
+Renderer API for cinematic/diagrammatic/sacred-light/brand-motion
+
+## 14) Risks & Mitigations
+- **Model drift** → schema validation + clamp + fallback.
+- **Latency under branching load** → staged quality tiers.
+- **Brand inconsistency** → profile constraints + policy blocking.
+
+## 15) Kickoff Template (Owner / Due Date / Status)
+| Workstream | Deliverable | Owner | Due Date | Status | Notes |
+|---|---|---|---|---|---|
+| Product | PRD sign-off | TBD | YYYY-MM-DD | Not Started | Scope freeze |
+| Design | Studio IA + state map | TBD | YYYY-MM-DD | Not Started | Left/Center/Right/Bottom |
+| Engineering | Contract schemas v1 | TBD | YYYY-MM-DD | Not Started | intent + manifest + replay |
+| AI Safety | Governor policy baseline | TBD | YYYY-MM-DD | Not Started | brand-safe/enterprise-safe/sacred-safe |
+| Platform | Telemetry + replay pipeline | TBD | YYYY-MM-DD | Not Started | deterministic log order |
+| GTM | Positioning + pilot list | TBD | YYYY-MM-DD | Not Started | enterprise readiness narrative |

--- a/docs/RFC_0001_contract_governor_replay.md
+++ b/docs/RFC_0001_contract_governor_replay.md
@@ -1,0 +1,171 @@
+# RFC-0001: Contracts + Governor + Replay Schemas
+
+- **Status:** Proposed  
+- **Version:** 1.0  
+- **Date:** 2026-04-11  
+- **Authors:** Platform Eng, AI Safety, Product
+
+## 1) Summary
+Define a contract-first runtime where AI emits structured intent/contracts and **cannot invoke renderer directly**. The Governor is the canonical execution boundary.
+
+## 2) Scope
+- Creative Intent schema
+- Manifest Contract schema
+- Governor decision pipeline and log schema
+- Session Replay schema
+- Versioning + compatibility rules
+
+## 3) Architecture (5 Layers)
+1. Creative Intent Layer
+2. Manifestation Contract Layer
+3. Runtime Governor Layer
+4. Renderer / Formation Engine Layer
+5. Memory / Team / Replay / Telemetry Layer
+
+## 4) Normative Requirements
+- Renderer MUST only consume governor-approved contracts.
+- Unknown fields/modes/profiles MUST default to deny or safe fallback.
+- Replay timeline MUST be deterministic and immutable.
+- Contract evolution MUST follow semantic versioning.
+
+## 5) Schemas (v1)
+
+## 5.1 `creative_intent.v1`
+```json
+{
+  "schema_version": "creative_intent.v1",
+  "intent_id": "uuid",
+  "timestamp": "ISO-8601",
+  "prompt_text": "string",
+  "goal_type": "poster|brand|UI|concept|diagram|ambient",
+  "emotional_valence": {
+    "energy": 0.0,
+    "serenity": 0.0,
+    "gravity": 0.0
+  },
+  "semantic_concepts": ["string"],
+  "output_constraints": {
+    "format_targets": ["png", "svg", "mp4", "manifest_json"],
+    "aspect_ratio": "1:1|4:5|16:9|custom",
+    "quality_tier": "draft|standard|high"
+  },
+  "brand_profile_id": "string|null",
+  "safety_profile": "brand-safe|enterprise-safe|sacred-safe",
+  "session_id": "uuid",
+  "room_id": "uuid|null"
+}
+```
+
+## 5.2 `manifest_contract.v1`
+```json
+{
+  "schema_version": "manifest_contract.v1",
+  "manifest_id": "uuid",
+  "state": "IDLE|LISTENING|INTERPRETING|MANIFESTING|REFINING|EXPORTING|WARNING|ERROR|NIRODHA",
+  "shape": "sphere|vortex|bloom|lattice|shell|void|custom",
+  "palette_mode": "brand|cool|warm|sacred|enterprise|minimal|cinematic",
+  "particle_density": 0.0,
+  "turbulence": 0.0,
+  "glow_intensity": 0.0,
+  "cohesion": 0.0,
+  "flicker": 0.0,
+  "flow_direction": "inward|outward|clockwise|counterclockwise|adaptive",
+  "attractor_points": [{"x": 0.0, "y": 0.0, "z": 0.0, "weight": 0.0}],
+  "composition_hint": "string",
+  "typography_hint": "string",
+  "variation_branch": "base|calm|luxury|sacred|enterprise|minimal|cinematic",
+  "lineage_parent_id": "uuid|null"
+}
+```
+
+## 5.3 `governor_decision_log.v1`
+```json
+{
+  "schema_version": "governor_decision_log.v1",
+  "decision_id": "uuid",
+  "intent_id": "uuid",
+  "manifest_id": "uuid",
+  "pipeline": [
+    "validate",
+    "transition",
+    "profile_map",
+    "clamp",
+    "fallback",
+    "policy_block",
+    "capability_gate",
+    "telemetry_log"
+  ],
+  "result": "allow|modify|deny|fallback",
+  "violations": ["string"],
+  "modifications": [{"field": "string", "from": "any", "to": "any", "reason": "string"}],
+  "confidence": 0.0,
+  "latency_ms": 0,
+  "timestamp": "ISO-8601"
+}
+```
+
+## 5.4 `session_replay.v1`
+```json
+{
+  "schema_version": "session_replay.v1",
+  "replay_id": "uuid",
+  "session_id": "uuid",
+  "timeline": [
+    {
+      "seq": 1,
+      "timestamp": "ISO-8601",
+      "event_type": "intent|state_transition|variation_select|export",
+      "payload_ref": "uri-or-id"
+    }
+  ],
+  "selected_variation": "string|null",
+  "export_history": [{"format": "png", "artifact_id": "string", "timestamp": "ISO-8601"}],
+  "room_activity": [{"user_id": "string", "action": "string", "timestamp": "ISO-8601"}]
+}
+```
+
+## 6) Governor Pipeline Semantics
+1. **validate**: schema/range/type checks
+2. **transition**: legal state transitions only
+3. **profile_map**: apply brand + safety profile constraints
+4. **clamp**: normalize risky numeric fields to safe bounds
+5. **fallback**: safe preset on invalid/partial contracts
+6. **policy_block**: hard deny for policy violations
+7. **capability_gate**: permission checks (room/export/features)
+8. **telemetry_log**: persist decision metadata before render
+
+## 7) State Machine (Minimum)
+- IDLE → LISTENING
+- LISTENING → INTERPRETING
+- INTERPRETING → MANIFESTING | WARNING
+- MANIFESTING → REFINING | ERROR
+- REFINING → MANIFESTING | EXPORTING
+- EXPORTING → IDLE | WARNING
+- ANY → NIRODHA (explicit safe settle)
+
+## 8) Compatibility & Versioning
+- Additive fields = minor version bump.
+- Breaking type/semantic changes = major bump.
+- Support deprecation windows with dual-read strategy.
+
+## 9) Test Strategy
+- Contract validation unit tests
+- Governor allow/modify/deny/fallback behavior tests
+- Replay determinism tests
+- Variation lineage continuity tests
+- Export lineage integrity tests
+
+## 10) Rollout Plan
+- Stage A: Shadow-mode governor logging
+- Stage B: Non-prod hard enforcement
+- Stage C: Production hard enforcement + alerting thresholds
+
+## 11) Kickoff Template (Owner / Due Date / Status)
+| Track | Task | Owner | Due Date | Status | Exit Criteria |
+|---|---|---|---|---|---|
+| Schema | Finalize v1 envelopes | TBD | YYYY-MM-DD | Not Started | JSON Schema artifacts merged |
+| Governor | Implement pipeline stages | TBD | YYYY-MM-DD | Not Started | all 8 stages wired |
+| Replay | Immutable timeline log | TBD | YYYY-MM-DD | Not Started | deterministic playback passes tests |
+| Renderer | Contract-only input gateway | TBD | YYYY-MM-DD | Not Started | direct AI → renderer path removed |
+| QA | Contract/governor/replay suites | TBD | YYYY-MM-DD | Not Started | CI green on required tests |
+| Ops | Telemetry dashboards | TBD | YYYY-MM-DD | Not Started | latency/confidence/warnings visible |

--- a/docs/RFC_0001_contract_governor_replay.md
+++ b/docs/RFC_0001_contract_governor_replay.md
@@ -61,7 +61,7 @@ Define a contract-first runtime where AI emits structured intent/contracts and *
 {
   "schema_version": "manifest_contract.v1",
   "manifest_id": "uuid",
-  "state": "IDLE|LISTENING|INTERPRETING|MANIFESTING|REFINING|EXPORTING|WARNING|ERROR|NIRODHA",
+  "state": "IDLE|LISTENING|THINKING|GENERATING|RESPONDING|WARNING|ERROR|NIRODHA|SENSOR_ACTIVE",
   "shape": "NEBULA_CLOUD|SPHERE|SPIRAL_VORTEX|CRACKED_SHELL|CUBE|STREAM|SHELL|FRACTURE|custom",
   "palette": {"mode": "CALM_IDLE|ACTIVE_LISTENING|DEEP_REASONING|CO_CREATION|WARNING_OVERLOAD|ERROR_POLICY|NIRODHA_DORMANT|CUSTOM", "primary": "hex", "secondary": "hex"},
   "particle_density": 0.0,

--- a/docs/RFC_0001_contract_governor_replay.md
+++ b/docs/RFC_0001_contract_governor_replay.md
@@ -63,7 +63,7 @@ Define a contract-first runtime where AI emits structured intent/contracts and *
   "manifest_id": "uuid",
   "state": "IDLE|LISTENING|INTERPRETING|MANIFESTING|REFINING|EXPORTING|WARNING|ERROR|NIRODHA",
   "shape": "NEBULA_CLOUD|SPHERE|SPIRAL_VORTEX|CRACKED_SHELL|CUBE|STREAM|SHELL|FRACTURE|custom",
-  "palette_mode": "brand|cool|warm|sacred|enterprise|minimal|cinematic",
+  "palette": {"mode": "CALM_IDLE|ACTIVE_LISTENING|DEEP_REASONING|CO_CREATION|WARNING_OVERLOAD|ERROR_POLICY|NIRODHA_DORMANT|CUSTOM", "primary": "hex", "secondary": "hex"},
   "particle_density": 0.0,
   "turbulence": 0.0,
   "glow_intensity": 0.0,

--- a/docs/RFC_0001_contract_governor_replay.md
+++ b/docs/RFC_0001_contract_governor_replay.md
@@ -85,12 +85,13 @@ Define a contract-first runtime where AI emits structured intent/contracts and *
   "decision_id": "uuid",
   "intent_id": "uuid",
   "manifest_id": "uuid",
-  "pipeline": [
     "validate",
     "transition",
     "profile_map",
     "clamp",
     "fallback",
+    "psycho_safety_gate",
+    "validate_schema",
     "policy_block",
     "capability_gate",
     "telemetry_log"

--- a/docs/RFC_0001_contract_governor_replay.md
+++ b/docs/RFC_0001_contract_governor_replay.md
@@ -70,7 +70,7 @@ Define a contract-first runtime where AI emits structured intent/contracts and *
   "cohesion": 0.0,
   "flicker": 0.0,
   "flow_direction": "inward|outward|clockwise|counterclockwise|adaptive",
-  "attractor_points": [{"x": 0.0, "y": 0.0, "z": 0.0, "weight": 0.0}],
+  "attractor": {"x": 0.0, "y": 0.0},
   "composition_hint": "string",
   "typography_hint": "string",
   "variation_branch": "base|calm|luxury|sacred|enterprise|minimal|cinematic",

--- a/docs/RFC_0001_contract_governor_replay.md
+++ b/docs/RFC_0001_contract_governor_replay.md
@@ -62,7 +62,7 @@ Define a contract-first runtime where AI emits structured intent/contracts and *
   "schema_version": "manifest_contract.v1",
   "manifest_id": "uuid",
   "state": "IDLE|LISTENING|INTERPRETING|MANIFESTING|REFINING|EXPORTING|WARNING|ERROR|NIRODHA",
-  "shape": "sphere|vortex|bloom|lattice|shell|void|custom",
+  "shape": "NEBULA_CLOUD|SPHERE|SPIRAL_VORTEX|CRACKED_SHELL|CUBE|STREAM|SHELL|FRACTURE|custom",
   "palette_mode": "brand|cool|warm|sacred|enterprise|minimal|cinematic",
   "particle_density": 0.0,
   "turbulence": 0.0,


### PR DESCRIPTION
### Motivation
- Provide unified product positioning, requirements, and governance guidance for the Aetherium Manifest Studio to align product, engineering, safety, and GTM efforts.
- Capture a contract-first runtime and governor-driven execution model with deterministic replay and enterprise controls to guide implementation and pilot rollouts.

### Description
- Add the investor/enterprise one-pager at `docs/Investor_Enterprise_OnePager.md` covering positioning, problem, product pillars, roadmap, KPIs, risks, and a kickoff template.
- Add the product requirements document at `docs/PRD_v1.md` containing vision, v1 goals/non-goals, user roles and JTBD, experience architecture, core flows, visual runtime states, functional and non-functional requirements, success metrics, and delivery phases.
- Add the RFC at `docs/RFC_0001_contract_governor_replay.md` defining v1 schemas (`creative_intent.v1`, `manifest_contract.v1`, `governor_decision_log.v1`, `session_replay.v1`), governor pipeline semantics, state machine, compatibility/versioning rules, test strategy, and rollout plan.

### Testing
- No automated tests were required or run for these documentation-only additions (no code changes; CI linting was not invoked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c00aeaa483208d0cb2e4ab93c028)