### PR TITLE
[contracts] Add ai_particle_control_contract_v2 intent-layer and adapter compatibility

### DIFF
--- a/docs/schemas/ai_particle_control_contract_v2.json
+++ b/docs/schemas/ai_particle_control_contract_v2.json
@@ -1,0 +1,319 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aetherium.dev/schemas/ai_particle_control_contract_v2.json",
+  "title": "AIParticleControlContractV2",
+  "description": "Canonical AI particle control contract with intent-layer controls for creative objective, safety, and output constraints.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "intent_state",
+    "renderer_controls"
+  ],
+  "properties": {
+    "intent_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "state_entered_at",
+        "shape",
+        "particle_density",
+        "velocity",
+        "turbulence",
+        "cohesion",
+        "flow_direction",
+        "glow_intensity",
+        "flicker",
+        "attractor",
+        "palette",
+        "state_duration_ms",
+        "transition_reason",
+        "goal_type",
+        "brand_profile_id",
+        "safety_profile",
+        "output_constraints"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "IDLE",
+            "LISTENING",
+            "INTERPRETING",
+            "GENERATING",
+            "THINKING",
+            "CONFIRMING",
+            "RESPONDING",
+            "WARNING",
+            "ERROR",
+            "STABILIZED",
+            "NIRODHA",
+            "SENSOR_PENDING_PERMISSION",
+            "SENSOR_ACTIVE",
+            "SENSOR_UNAVAILABLE"
+          ]
+        },
+        "shape": {
+          "type": "string",
+          "enum": [
+            "ring",
+            "helix",
+            "spiral_vortex",
+            "sphere",
+            "stream",
+            "burst",
+            "lattice",
+            "nebula_cloud"
+          ]
+        },
+        "particle_density": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "velocity": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "turbulence": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "cohesion": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "flow_direction": {
+          "type": "string",
+          "enum": [
+            "clockwise",
+            "counterclockwise",
+            "inward",
+            "outward",
+            "centripetal",
+            "centrifugal",
+            "bidirectional",
+            "still",
+            "adaptive"
+          ]
+        },
+        "glow_intensity": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "flicker": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "attractor": {
+          "type": "string",
+          "enum": [
+            "core",
+            "halo",
+            "axis",
+            "orbit",
+            "mesh",
+            "none"
+          ]
+        },
+        "palette": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode",
+            "primary",
+            "secondary"
+          ],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "adaptive",
+                "dual_tone",
+                "thermal",
+                "spectral",
+                "monochrome",
+                "DEEP_REASONING",
+                "ACTIVE_LISTENING",
+                "WARNING_OVERLOAD",
+                "ERROR_POLICY"
+              ]
+            },
+            "primary": {
+              "type": "string",
+              "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+            },
+            "secondary": {
+              "type": "string",
+              "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+            },
+            "accent": {
+              "type": "string",
+              "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+            }
+          }
+        },
+        "state_entered_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "state_duration_ms": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "transition_reason": {
+          "type": "string"
+        },
+        "goal_type": {
+          "type": "string",
+          "enum": ["poster", "brand", "UI", "concept", "diagram", "ambient"]
+        },
+        "brand_profile_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "safety_profile": {
+          "type": "string",
+          "enum": ["brand-safe", "enterprise-safe", "sacred-safe"]
+        },
+        "output_constraints": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["target_format", "size", "quality_tier"],
+          "properties": {
+            "target_format": {
+              "type": "string",
+              "enum": ["runtime", "png", "jpg", "svg", "webp", "mp4", "gif"]
+            },
+            "size": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["width", "height"],
+              "properties": {
+                "width": {"type": "integer", "minimum": 1},
+                "height": {"type": "integer", "minimum": 1}
+              }
+            },
+            "quality_tier": {
+              "type": "string",
+              "enum": ["draft", "balanced", "high", "ultra"]
+            },
+            "max_latency_ms": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "semantic_concepts": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "emotional_valence": {
+          "type": "number",
+          "minimum": -1.0,
+          "maximum": 1.0
+        },
+        "scholar": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "renderer_controls": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "base_shape",
+        "chromatic_mode",
+        "particle_count",
+        "flow_field",
+        "shader_uniforms",
+        "runtime_profile"
+      ],
+      "properties": {
+        "base_shape": {
+          "type": "string",
+          "enum": [
+            "ring",
+            "helix",
+            "spiral_vortex",
+            "sphere",
+            "stream",
+            "burst",
+            "lattice"
+          ]
+        },
+        "chromatic_mode": {
+          "type": "string",
+          "enum": [
+            "adaptive",
+            "dual_tone",
+            "thermal",
+            "spectral",
+            "monochrome"
+          ]
+        },
+        "particle_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 50000
+        },
+        "flow_field": {
+          "type": "string",
+          "enum": [
+            "clockwise",
+            "counterclockwise",
+            "inward",
+            "outward",
+            "centripetal",
+            "centrifugal",
+            "bidirectional",
+            "still"
+          ]
+        },
+        "shader_uniforms": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {"type": "number"},
+              {"type": "string"},
+              {"type": "boolean"}
+            ]
+          },
+          "required": [
+            "glow_intensity",
+            "flicker",
+            "cohesion"
+          ]
+        },
+        "runtime_profile": {
+          "type": "string",
+          "enum": [
+            "deterministic",
+            "adaptive",
+            "low_power",
+            "cinematic"
+          ]
+        },
+        "intent_layer": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  },
+  "x-field-evolution": {
+    "introduced_in": "ai_particle_control_contract_v2",
+    "supersedes": "ai_particle_control_contract_v1",
+    "compatibility_adapter": "tools.contracts.particle_control_adapter",
+    "required_evolution_sections": [
+      "intent_state",
+      "renderer_controls"
+    ]
+  }
+}

--- a/tools/contracts/contract_checker.py
+++ b/tools/contracts/contract_checker.py
@@ -29,6 +29,10 @@ CHECKS = {
         "schema": SCHEMA_DIR / "ai_particle_control_contract_v1.json",
         "payload": PAYLOAD_DIR / "ai_particle_control_contract_v1.payload.json",
     },
+    "ai_particle_control_contract_v2": {
+        "schema": SCHEMA_DIR / "ai_particle_control_contract_v2.json",
+        "payload": PAYLOAD_DIR / "ai_particle_control_contract_v2.payload.json",
+    },
     "embodiment_v1": {
         "schema": SCHEMA_DIR / "embodiment_v1.json",
         "payload": PAYLOAD_DIR / "embodiment_v1.payload.json",

--- a/tools/contracts/particle_control_adapter.py
+++ b/tools/contracts/particle_control_adapter.py
@@ -15,6 +15,8 @@ FLOW_DIRECTIONS = {
 
 SHAPES = {"ring", "helix", "spiral_vortex", "sphere", "stream", "burst", "lattice"}
 PALETTE_MODES = {"adaptive", "dual_tone", "thermal", "spectral", "monochrome"}
+GOAL_TYPES = {"poster", "brand", "UI", "concept", "diagram", "ambient"}
+SAFETY_PROFILES = {"brand-safe", "enterprise-safe", "sacred-safe"}
 
 
 def _clamp_float(value: Any, minimum: float = 0.0, maximum: float = 1.0, default: float = 0.0) -> float:
@@ -46,6 +48,9 @@ def to_renderer_controls(particle_control: dict[str, Any]) -> dict[str, Any]:
     cohesion = _clamp_float(intent.get("cohesion"), default=0.5)
     velocity = _clamp_float(intent.get("velocity"), default=0.3)
     turbulence = _clamp_float(intent.get("turbulence"), default=0.0)
+    semantic_concepts = intent.get("semantic_concepts")
+    if not isinstance(semantic_concepts, list):
+        semantic_concepts = []
 
     return {
         "base_shape": shape,
@@ -62,6 +67,21 @@ def to_renderer_controls(particle_control: dict[str, Any]) -> dict[str, Any]:
             "secondary_color": palette.get("secondary", "#FFFFFF"),
             "attractor": str(intent.get("attractor", "core")),
             "state": str(intent.get("state", "idle")),
+            "goal_type": _coerce_enum(intent.get("goal_type"), GOAL_TYPES, "ambient"),
+            "safety_profile": _coerce_enum(intent.get("safety_profile"), SAFETY_PROFILES, "brand-safe"),
+            "brand_profile_id": str(intent.get("brand_profile_id", "default")),
+            "output_target_format": str(intent.get("output_constraints", {}).get("target_format", "runtime")),
+            "quality_tier": str(intent.get("output_constraints", {}).get("quality_tier", "balanced")),
+        },
+        "intent_layer": {
+            "goal_type": _coerce_enum(intent.get("goal_type"), GOAL_TYPES, "ambient"),
+            "brand_profile_id": str(intent.get("brand_profile_id", "default")),
+            "safety_profile": _coerce_enum(intent.get("safety_profile"), SAFETY_PROFILES, "brand-safe"),
+            "output_constraints": intent.get("output_constraints", {}),
+            "semantic_concepts": [str(item) for item in semantic_concepts],
+            "emotional_valence": (
+                None if intent.get("emotional_valence") is None else _clamp_float(intent.get("emotional_valence"), minimum=-1.0, maximum=1.0, default=0.0)
+            ),
         },
         "runtime_profile": "cinematic" if density >= 0.75 else "adaptive" if velocity >= 0.6 else "deterministic",
     }
@@ -93,5 +113,8 @@ def to_visual_manifestation(particle_control: dict[str, Any], transition_type: s
             "cohesion": _clamp_float(uniforms.get("cohesion"), default=0.5),
             "flicker": _clamp_float(uniforms.get("flicker"), default=0.0),
             "velocity": _clamp_float(uniforms.get("velocity"), default=0.3),
+            "goal_type": _coerce_enum(uniforms.get("goal_type"), GOAL_TYPES, "ambient"),
+            "safety_profile": _coerce_enum(uniforms.get("safety_profile"), SAFETY_PROFILES, "brand-safe"),
+            "brand_profile_id": str(uniforms.get("brand_profile_id", "default")),
         },
     }

--- a/tools/contracts/payloads/ai_particle_control_contract_v2.payload.json
+++ b/tools/contracts/payloads/ai_particle_control_contract_v2.payload.json
@@ -1,0 +1,80 @@
+{
+  "intent_state": {
+    "state": "RESPONDING",
+    "state_entered_at": "2026-04-11T12:00:00Z",
+    "shape": "spiral_vortex",
+    "particle_density": 0.5,
+    "velocity": 0.5,
+    "turbulence": 0.5,
+    "cohesion": 0.5,
+    "flow_direction": "outward",
+    "glow_intensity": 0.5,
+    "flicker": 0.1,
+    "attractor": "core",
+    "palette": {
+      "mode": "DEEP_REASONING",
+      "primary": "#4169E1",
+      "secondary": "#B0C4DE"
+    },
+    "state_duration_ms": 5000,
+    "transition_reason": "testing scholar agent",
+    "goal_type": "brand",
+    "brand_profile_id": "brand-core-01",
+    "safety_profile": "enterprise-safe",
+    "output_constraints": {
+      "target_format": "png",
+      "size": {
+        "width": 1920,
+        "height": 1080
+      },
+      "quality_tier": "high",
+      "max_latency_ms": 1200
+    },
+    "semantic_concepts": [
+      "clarity",
+      "trust",
+      "precision"
+    ],
+    "emotional_valence": 0.35,
+    "scholar": {
+      "summary": "This is a test summary.",
+      "visual_interpretation": "ripple pattern",
+      "language": "en-US",
+      "tone": "formal"
+    }
+  },
+  "renderer_controls": {
+    "base_shape": "spiral_vortex",
+    "chromatic_mode": "adaptive",
+    "particle_count": 5000,
+    "flow_field": "outward",
+    "shader_uniforms": {
+      "glow_intensity": 0.5,
+      "flicker": 0.1,
+      "cohesion": 0.5,
+      "goal_type": "brand",
+      "safety_profile": "enterprise-safe",
+      "brand_profile_id": "brand-core-01"
+    },
+    "intent_layer": {
+      "goal_type": "brand",
+      "brand_profile_id": "brand-core-01",
+      "safety_profile": "enterprise-safe",
+      "output_constraints": {
+        "target_format": "png",
+        "size": {
+          "width": 1920,
+          "height": 1080
+        },
+        "quality_tier": "high"
+      },
+      "semantic_concepts": [
+        "clarity",
+        "trust",
+        "precision"
+      ],
+      "emotional_valence": 0.35
+    },
+    "runtime_profile": "cinematic"
+  }
+}

--- a/tools/contracts/test_particle_control_adapter.py
+++ b/tools/contracts/test_particle_control_adapter.py
@@ -61,3 +61,39 @@ def test_to_visual_manifestation_uses_compiled_renderer_controls() -> None:
     assert visual["particle_physics"]["particle_count"] == 10000
     assert visual["chromatic_mode"] == "adaptive"
     assert visual["device_tier"] == 3
+
+
+def test_to_renderer_controls_maps_intent_layer_fields() -> None:
+    payload = {
+        "intent_state": {
+            "goal_type": "brand",
+            "brand_profile_id": "brand-core-01",
+            "safety_profile": "enterprise-safe",
+            "output_constraints": {
+                "target_format": "png",
+                "quality_tier": "high",
+                "size": {"width": 1920, "height": 1080},
+            },
+            "semantic_concepts": ["clarity", "trust"],
+            "emotional_valence": 0.2,
+        }
+    }
+
+    renderer = to_renderer_controls(payload)
+
+    assert renderer["shader_uniforms"]["goal_type"] == "brand"
+    assert renderer["shader_uniforms"]["brand_profile_id"] == "brand-core-01"
+    assert renderer["shader_uniforms"]["safety_profile"] == "enterprise-safe"
+    assert renderer["intent_layer"]["semantic_concepts"] == ["clarity", "trust"]
+    assert renderer["intent_layer"]["emotional_valence"] == 0.2
+
+
+def test_to_renderer_controls_intent_layer_is_backward_compatible() -> None:
+    renderer = to_renderer_controls({"intent_state": {}})
+
+    assert renderer["shader_uniforms"]["goal_type"] == "ambient"
+    assert renderer["shader_uniforms"]["brand_profile_id"] == "default"
+    assert renderer["shader_uniforms"]["safety_profile"] == "brand-safe"
+    assert renderer["intent_layer"]["output_constraints"] == {}
+    assert renderer["intent_layer"]["semantic_concepts"] == []
+    assert renderer["intent_layer"]["emotional_valence"] is None


### PR DESCRIPTION
### Motivation
- Introduce an intent-layer to the AI particle control contract to express creative objective, brand/safety profiles, and output constraints for richer runtime behavior and governance.
- Keep the evolution additive and backward-compatible so existing v1 integrations and adapter flows continue to work without breaking ABI.

### Description
- Add a new schema `docs/schemas/ai_particle_control_contract_v2.json` that introduces `goal_type`, `brand_profile_id`, `safety_profile`, `output_constraints`, and optional `semantic_concepts` and `emotional_valence` in `intent_state` and an `intent_layer` container in `renderer_controls`.
- Update `tools/contracts/particle_control_adapter.py` to map and normalize new intent-layer fields into `shader_uniforms` and a new `intent_layer` structure while providing safe defaults when fields are absent.
- Add a v2 example payload at `tools/contracts/payloads/ai_particle_control_contract_v2.payload.json` covering the new fields.
- Extend tests in `tools/contracts/test_particle_control_adapter.py` to validate mapping of the new intent-layer fields and backward-compatible defaults.
- Register the new v2 check in `tools/contracts/contract_checker.py` so the checker exercises the v2 schema/payload.

### Testing
- Ran the adapter unit tests with `PYTHONPATH=. pytest -q tools/contracts/test_particle_control_adapter.py`, which passed (`4 passed`).
- Validated the new schema against the v2 payload using `Draft202012Validator` in a short Python run, which produced zero validation errors.
- Executing `python3 tools/contracts/contract_checker.py` in this environment failed due to a missing runtime dependency (`httpx`) pulled in by `api_gateway/main.py`, so full checker end-to-end could not complete here.
- `npm run lint` failed in this environment because ESLint v9 expects an `eslint.config.*` file that is not present in the repository, so frontend lint was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9daad66883208af0b6d0a089c381)