### PR TITLE
[frontend+api] Add lineage-aware variation generator set flow

### DIFF
--- a/api_gateway/README.md
+++ b/api_gateway/README.md
@@ -6,6 +6,7 @@
 
 - `POST /api/v1/cognitive/emit`
 - `POST /api/v1/cognitive/validate`
+- `POST /api/v1/cognitive/variations/generate` (generate 4–8 variation branches with lineage metadata)
 - `GET /health`
 - `WS /ws/cognitive-stream`
 

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -12,6 +12,7 @@ from enum import Enum
 
 from fastapi import FastAPI, HTTPException, Header, BackgroundTasks, Request
 from .scholar_router import router as scholar_router
+from .variation_service import generate_variation_set
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 import redis.asyncio as redis
@@ -320,6 +321,16 @@ async def generate_cognitive_dsl(
     if request.get("model") == "unknown-model":
         raise HTTPException(status_code=400, detail="Unsupported model")
     return {"status": "success"}
+
+
+@app.post("/api/v1/cognitive/variations/generate")
+async def generate_variations(
+    request: Dict[str, Any],
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+) -> dict[str, Any]:
+    _ensure_api_key(x_api_key)
+    payload = generate_variation_set(request)
+    return {"status": "success", "data": payload}
 
 @app.get("/api/v1/reliability/temporal-morphogenesis")
 async def temporal_morphogenesis(

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -64,6 +64,31 @@ def test_generate_rejects_unsupported_model_with_400(client: TestClient) -> None
     assert "Unsupported model" in response.text
 
 
+def test_generate_variations_returns_branch_metadata(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/cognitive/variations/generate",
+        headers={"X-API-Key": "test-key"},
+        json={
+            "goal_type": "image",
+            "brand_profile": {"palette_lock": True},
+            "safety_profile": {"strict_mode": True, "max_branches": 6},
+            "lineage": {"active_context_id": "n7"},
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["goal_type"] == "image"
+    assert payload["parent_id"] == "n7"
+    assert 4 <= payload["count"] <= 8
+    assert payload["count"] == len(payload["variations"])
+    for variation in payload["variations"]:
+        assert variation["parent_id"] == "n7"
+        assert variation["variation_id"]
+        assert variation["preset"]
+        assert isinstance(variation["constraints_delta"], dict)
+        assert variation["constraints_delta"].get("palette_lock") is True
+
+
 def test_proxy_fetch_rejects_urls_with_credentials(client: TestClient) -> None:
     response = client.get(
         "/api/v1/proxy/fetch",

--- a/api_gateway/variation_service.py
+++ b/api_gateway/variation_service.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from typing import Any
+
+GOAL_PRESETS: dict[str, list[dict[str, Any]]] = {
+    "pure_light": [
+        {"name": "CALM", "constraints_delta": {"particle_bias": -0.12, "luma_bias": 0.08}},
+        {"name": "DEEP_FOCUS", "constraints_delta": {"particle_bias": 0.06, "cohesion_bias": 0.16}},
+        {"name": "AETHER_WAVE", "constraints_delta": {"motion_bias": 0.2, "flicker_limit": 0.18}},
+        {"name": "SACRED_MINIMAL", "constraints_delta": {"particle_bias": -0.24, "symmetry": "radial"}},
+        {"name": "AURORA_PULSE", "constraints_delta": {"hue_shift": 18, "flow_bias": "spiral"}},
+    ],
+    "image": [
+        {"name": "EDITORIAL", "constraints_delta": {"contrast": 0.2, "grain": 0.05}},
+        {"name": "CINEMATIC", "constraints_delta": {"contrast": 0.28, "bloom": 0.15}},
+        {"name": "MINIMAL", "constraints_delta": {"saturation": -0.18, "space": 0.24}},
+        {"name": "BRAND_STRICT", "constraints_delta": {"palette_lock": True, "typography": "precise"}},
+        {"name": "STORYBOARD", "constraints_delta": {"panel_rhythm": "3-act", "camera_bias": "wide"}},
+        {"name": "POSTER_GLOW", "constraints_delta": {"rim_light": 0.3, "particle_bias": 0.08}},
+    ],
+    "video": [
+        {"name": "KINETIC", "constraints_delta": {"motion_blur": 0.25, "flow_bias": "vortex"}},
+        {"name": "MEDITATIVE", "constraints_delta": {"tempo": "slow", "cohesion_bias": 0.2}},
+        {"name": "MUSIC_SYNC", "constraints_delta": {"beat_sync": True, "flicker_limit": 0.22}},
+        {"name": "NARRATIVE", "constraints_delta": {"scene_arcs": 4, "camera_bias": "dolly"}},
+        {"name": "SAFETY_SOFT", "constraints_delta": {"flash_cap_hz": 2, "luma_cap": 0.72}},
+        {"name": "TRAIL_CORE", "constraints_delta": {"trail_length": 0.33, "particle_bias": 0.1}},
+        {"name": "AETHER_CUT", "constraints_delta": {"cut_rhythm": "adaptive", "energy_bias": 0.18}},
+    ],
+    "search": [
+        {"name": "SCHOLAR_SUMMARY", "constraints_delta": {"citation_density": "high", "verbosity": "low"}},
+        {"name": "COMPARATIVE", "constraints_delta": {"cross_reference": True, "table_view": True}},
+        {"name": "TIMELINE", "constraints_delta": {"time_axis": "strict", "recency_bias": 0.3}},
+        {"name": "RISK_SCAN", "constraints_delta": {"risk_tags": True, "confidence_floor": 0.62}},
+    ],
+}
+
+
+def _stable_suffix(value: str) -> str:
+    return hashlib.sha1(value.encode("utf-8")).hexdigest()[:8]
+
+
+def generate_variation_set(request: dict[str, Any]) -> dict[str, Any]:
+    goal_type = str(request.get("goal_type") or "pure_light")
+    brand_profile = request.get("brand_profile") or {}
+    safety_profile = request.get("safety_profile") or {}
+    lineage = request.get("lineage") or {}
+
+    presets = GOAL_PRESETS.get(goal_type, GOAL_PRESETS["pure_light"])
+    strict_mode = bool(safety_profile.get("strict_mode", False))
+    max_branches = int(safety_profile.get("max_branches") or (4 if strict_mode else 8))
+    bounded_branches = max(4, min(8, max_branches))
+    selected_presets = presets[:bounded_branches]
+
+    palette_lock = brand_profile.get("palette_lock")
+    set_id = f"vset_{uuid.uuid4().hex[:10]}"
+    parent_id = str(lineage.get("active_context_id") or "genesis")
+
+    variations: list[dict[str, Any]] = []
+    for idx, preset in enumerate(selected_presets, start=1):
+        variation_id = f"var_{_stable_suffix(f'{set_id}:{parent_id}:{preset['name']}:{idx}')}_{idx}"
+        constraints_delta = dict(preset.get("constraints_delta") or {})
+        if palette_lock:
+            constraints_delta["palette_lock"] = True
+        if strict_mode:
+            constraints_delta["flash_cap_hz"] = min(float(constraints_delta.get("flash_cap_hz", 2.0)), 2.0)
+
+        variations.append(
+            {
+                "variation_id": variation_id,
+                "parent_id": parent_id,
+                "preset": preset["name"],
+                "constraints_delta": constraints_delta,
+                "rank": idx,
+            }
+        )
+
+    return {
+        "set_id": set_id,
+        "goal_type": goal_type,
+        "parent_id": parent_id,
+        "count": len(variations),
+        "variations": variations,
+    }

--- a/index.html
+++ b/index.html
@@ -174,19 +174,19 @@
                 <span class="state-chip rounded-full border border-white/15 px-2 py-1" data-state="NIRODHA">NIRODHA</span>
             </div>
 
-            <section id="branch-panel" class="mb-4 opacity-0 pointer-events-none grid grid-cols-2 md:grid-cols-4 gap-2">
-                <button class="branch-btn rounded-xl px-3 py-4 font-mono text-xs text-blue-100" onclick="selectBranch('calm')">CALM</button>
-                <button class="branch-btn rounded-xl px-3 py-4 font-mono text-xs text-orange-100" onclick="selectBranch('cinematic')">CINEMATIC</button>
-                <button class="branch-btn rounded-xl px-3 py-4 font-mono text-xs text-emerald-100" onclick="selectBranch('minimal')">MINIMAL</button>
-                <button class="branch-btn rounded-xl px-3 py-4 font-mono text-xs text-purple-100" onclick="selectBranch('sacred')">SACRED</button>
+            <section id="branch-panel" class="mb-4 opacity-0 pointer-events-none">
+                <div id="branch-buttons" class="grid grid-cols-1 md:grid-cols-2 gap-2"></div>
             </section>
 
             <section id="terminal-logs" class="glass-panel rounded-xl p-3 h-52 overflow-y-auto font-mono text-[10px] text-blue-100 mb-3"></section>
 
             <section class="glass-panel rounded-xl p-4 min-h-[17rem] overflow-y-auto mb-3">
-                <div class="font-mono text-xs text-cyan-200 mb-3 border-b border-white/10 pb-2 flex justify-between">
+                <div class="font-mono text-xs text-cyan-200 mb-3 border-b border-white/10 pb-2 flex justify-between items-center">
                     <span><i class="fas fa-code-branch mr-2"></i>DESIGN LINEAGE</span>
-                    <span id="lineage-count" class="text-white/45">1 node</span>
+                    <div class="flex items-center gap-2">
+                        <span id="lineage-count" class="text-white/45">1 node</span>
+                        <button class="text-[10px] px-2 py-1 rounded border border-cyan-300/40 hover:bg-cyan-400/10" onclick="exportManifest()">EXPORT</button>
+                    </div>
                 </div>
                 <div id="lineage-container" class="space-y-2"></div>
             </section>
@@ -281,6 +281,8 @@
         let ui_surface_mode = 'clean';
         let lineageCounter = 0;
         const nodes = [{ id: 'genesis', label: 'Genesis Root', deleted: false }];
+        const variationRegistry = {};
+        const variationSets = [];
         let branchContext = 'genesis';
 
         function setUiSurfaceMode(mode) {
@@ -373,6 +375,75 @@
             return 'pure_light';
         }
 
+        function mapGoalType(mode) {
+            if (mode === 'video') return 'video';
+            if (mode === 'image') return 'image';
+            if (mode === 'search') return 'search';
+            return 'pure_light';
+        }
+
+        async function requestVariationSet(intent, mode) {
+            const payload = {
+                goal_type: mapGoalType(mode),
+                brand_profile: { palette_lock: mode === 'image' },
+                safety_profile: { strict_mode: mode === 'video', max_branches: mode === 'search' ? 4 : 6 },
+                lineage: { active_context_id: branchContext, intent },
+            };
+            try {
+                const response = await fetch('/api/v1/cognitive/variations/generate', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-API-Key': 'dev-local-key',
+                    },
+                    body: JSON.stringify(payload),
+                });
+                if (!response.ok) throw new Error(`variation endpoint ${response.status}`);
+                const body = await response.json();
+                return body.data;
+            } catch (error) {
+                logTerminal(`[BRANCH] Variation API unavailable (${error.message}), fallback local set.`, 'warn');
+                const fallback = ['CALM', 'CINEMATIC', 'MINIMAL', 'SACRED'];
+                return {
+                    set_id: `local_${Date.now()}`,
+                    parent_id: branchContext,
+                    variations: fallback.map((preset, idx) => ({
+                        variation_id: `local_${branchContext}_${idx + 1}`,
+                        parent_id: branchContext,
+                        preset,
+                        constraints_delta: { fallback: true },
+                    })),
+                };
+            }
+        }
+
+        function renderBranchPanel(variationSet) {
+            variationSets.push(variationSet);
+            variationSet.variations.forEach((variation) => {
+                variationRegistry[variation.variation_id] = variation;
+            });
+
+            const branchPanel = document.getElementById('branch-panel');
+            const buttons = document.getElementById('branch-buttons');
+            buttons.innerHTML = '';
+            variationSet.variations.forEach((variation) => {
+                const button = document.createElement('button');
+                button.className = 'branch-btn rounded-xl px-3 py-3 font-mono text-xs text-blue-100 text-left';
+                button.onclick = () => selectBranch(variation.variation_id);
+                button.innerHTML = `
+                    <div class="font-bold">${variation.preset}</div>
+                    <div class="text-[10px] text-white/70 mt-1">${variation.variation_id}</div>
+                    <div class="text-[10px] text-white/55 mt-1">Δ ${Object.keys(variation.constraints_delta || {}).join(', ') || 'none'}</div>
+                `;
+                buttons.appendChild(button);
+            });
+
+            if (ui_surface_mode === 'studio') {
+                branchPanel.classList.remove('opacity-0', 'pointer-events-none');
+            }
+            logTerminal(`[BRANCH] Generated ${variationSet.variations.length} branches from ${variationSet.parent_id}.`, 'system');
+        }
+
         function emitIntent() {
             if (isProcessing) return;
             const input = document.getElementById('intent-input');
@@ -401,17 +472,12 @@
             }, 950);
         }
 
-        function runManifest(intent, mode) {
+        async function runManifest(intent, mode) {
             setRuntimeState(mode === 'video' ? 'STREAMING' : mode === 'search' ? 'SEARCHING' : 'MANIFESTING');
             setFlowState('CONVERGING');
             createLineageNode(intent, mode);
-
-            const branchPanel = document.getElementById('branch-panel');
-            if (ui_surface_mode === 'studio') {
-                branchPanel.classList.remove('opacity-0', 'pointer-events-none');
-            } else {
-                branchPanel.classList.add('opacity-0', 'pointer-events-none');
-            }
+            const variationSet = await requestVariationSet(intent, mode);
+            renderBranchPanel(variationSet);
 
             if (mode === 'search') {
                 renderScholar(intent);
@@ -446,7 +512,7 @@
         function createLineageNode(intent, mode) {
             lineageCounter += 1;
             const id = `n${lineageCounter}`;
-            nodes.push({ id, label: intent, mode, parent: branchContext, deleted: false });
+            nodes.push({ id, label: intent, mode, parent: branchContext, deleted: false, manifest_context: branchContext });
             branchContext = id;
             renderLineage();
         }
@@ -484,10 +550,30 @@
             renderLineage();
         }
 
-        function selectBranch(style) {
+        function selectBranch(variationId) {
+            const selected = variationRegistry[variationId];
+            if (!selected) return;
+            branchContext = selected.variation_id;
             document.getElementById('branch-panel').classList.add('opacity-0', 'pointer-events-none');
             setFlowState('REFINING');
-            logTerminal(`[BRANCH] Selected variation: ${style}.`, 'success');
+            logTerminal(`[BRANCH] Selected ${selected.preset} (${selected.variation_id}), context anchored to parent ${selected.parent_id}.`, 'success');
+        }
+
+        function exportManifest() {
+            const payload = {
+                exported_at: new Date().toISOString(),
+                replay_context: branchContext,
+                lineage_nodes: nodes,
+                variation_sets: variationSets,
+            };
+            const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const anchor = document.createElement('a');
+            anchor.href = url;
+            anchor.download = `aetherium_manifest_${Date.now()}.json`;
+            anchor.click();
+            URL.revokeObjectURL(url);
+            logTerminal(`[EXPORT] Manifest exported with replay context ${branchContext}.`, 'system');
         }
 
         function updateTargetsByState() {


### PR DESCRIPTION
### Motivation
- Provide a frontend + API variation generation layer that produces 4–8 branches per intent so users can refine from consistent branch context rather than hard-coded options. 
- Preserve lineage and replay/export continuity by attaching branch metadata to the manifest/export payload.

### Description
- Added `api_gateway/variation_service.py` implementing `generate_variation_set` which emits branch metadata (`variation_id`, `parent_id`, `preset`, `constraints_delta`) using `goal_type`, `brand_profile`, and `safety_profile` and bounds branches to 4–8. 
- Exposed new endpoint `POST /api/v1/cognitive/variations/generate` wired to `generate_variation_set` in `api_gateway/main.py`. 
- Reworked `index.html` to remove hard-coded branch buttons, request the variation set from the new endpoint (with a local fallback), render dynamic branch UI, and anchor `branchContext` to the chosen `variation_id`; lineage nodes include `manifest_context` and `exportManifest()` now includes `variation_sets` and `replay_context`. 
- Added `api_gateway/test_api.py` test for the variations endpoint and updated `api_gateway/README.md` to document the new endpoint.

### Testing
- `python -m py_compile api_gateway/main.py api_gateway/variation_service.py` ran successfully. 
- `pytest -q api_gateway/test_api.py` attempted but failed during collection due to missing test runtime dependency `httpx` (so tests could not fully run). 
- `npm run lint` was attempted and flagged a repository configuration issue for ESLint v9 (missing `eslint.config.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca15a53a08320b0633155ce4be746)