### PR TITLE
[api_gateway] Add export domain endpoints, schemas, and audit history

### DIFF
--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -56,6 +56,35 @@ class TelemetryPoint(BaseModel):
 class TelemetryIngestRequest(BaseModel):
     points: list[TelemetryPoint]
 
+class ExportArtifactType(str, Enum):
+    PNG = "PNG"
+    SVG = "SVG"
+    MP4 = "MP4"
+    LAYER_PACKAGE = "layer_package"
+    MANIFEST_JSON = "manifest_json"
+    PROMPT_LINEAGE_BUNDLE = "prompt_lineage_bundle"
+
+class ExportRequest(BaseModel):
+    session_id: str = Field(..., min_length=1)
+    lineage_id: str = Field(..., min_length=1)
+    selected_variation_id: str = Field(..., min_length=1)
+    artifact_type: ExportArtifactType
+    options: Dict[str, Any] = Field(default_factory=dict)
+    requested_by: Optional[str] = None
+
+class ExportResponse(BaseModel):
+    export_id: str
+    session_id: str
+    lineage_id: str
+    selected_variation_id: str
+    artifact_type: ExportArtifactType
+    status: Literal["accepted"]
+    audit_trail_id: str
+    replay_key: str
+    review_status: Literal["ready_for_enterprise_review"]
+    created_at: datetime
+    options: Dict[str, Any] = Field(default_factory=dict)
+
 # --- Validation ---
 
 class FirmaValidator:
@@ -87,6 +116,7 @@ r: Optional[redis.Redis] = None
 nc: Optional[nats.NATS] = None
 NONCE_CACHE: Dict[str, bool] = {}
 RUNTIME_GOVERNOR = RuntimeGovernor()
+EXPORT_AUDIT_TRAIL: List[Dict[str, Any]] = []
 REQUIRED_PIPELINE_ORDER = [
     "validate",
     "transition",
@@ -357,6 +387,62 @@ async def ingest_telemetry(
                 await r.lpush("telemetry:queue", json.dumps(point.model_dump(mode="json")))
         except Exception: pass
     return {"status": "success", "inserted": len(request.points)}
+
+@app.post("/api/v1/export/request", response_model=ExportResponse)
+async def request_export(
+    request: ExportRequest,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+) -> ExportResponse:
+    _ensure_api_key(x_api_key)
+    created_at = datetime.now(timezone.utc)
+    export_id = f"exp_{uuid.uuid4().hex}"
+    audit_trail_id = f"audit_{uuid.uuid4().hex}"
+    replay_key = f"{request.session_id}:{request.lineage_id}:{request.selected_variation_id}:{export_id}"
+    audit_record: Dict[str, Any] = {
+        "audit_trail_id": audit_trail_id,
+        "event_type": "export_requested",
+        "created_at": created_at.isoformat(),
+        "export_id": export_id,
+        "session_id": request.session_id,
+        "lineage_id": request.lineage_id,
+        "selected_variation_id": request.selected_variation_id,
+        "artifact_type": request.artifact_type.value,
+        "requested_by": request.requested_by or "unknown",
+        "replay_key": replay_key,
+        "review_status": "ready_for_enterprise_review",
+        "options": request.options,
+    }
+    EXPORT_AUDIT_TRAIL.insert(0, audit_record)
+    return ExportResponse(
+        export_id=export_id,
+        session_id=request.session_id,
+        lineage_id=request.lineage_id,
+        selected_variation_id=request.selected_variation_id,
+        artifact_type=request.artifact_type,
+        status="accepted",
+        audit_trail_id=audit_trail_id,
+        replay_key=replay_key,
+        review_status="ready_for_enterprise_review",
+        created_at=created_at,
+        options=request.options,
+    )
+
+@app.get("/api/v1/export/history")
+async def export_history(
+    session_id: Optional[str] = None,
+    lineage_id: Optional[str] = None,
+    selected_variation_id: Optional[str] = None,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+) -> Dict[str, Any]:
+    _ensure_api_key(x_api_key)
+    records = EXPORT_AUDIT_TRAIL
+    if session_id:
+        records = [record for record in records if record["session_id"] == session_id]
+    if lineage_id:
+        records = [record for record in records if record["lineage_id"] == lineage_id]
+    if selected_variation_id:
+        records = [record for record in records if record["selected_variation_id"] == selected_variation_id]
+    return {"status": "success", "count": len(records), "history": records}
 
 @app.get("/api/v1/proxy/fetch")
 async def proxy_fetch(

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 import pytest
 from fastapi.testclient import TestClient
 
-from .main import app, _proxy_request_signature
+from .main import EXPORT_AUDIT_TRAIL, app, _proxy_request_signature
 
 
 @pytest.fixture
@@ -303,3 +303,73 @@ def test_emit_accepts_valid_api_key(client: TestClient, monkeypatch: pytest.Monk
         },
     )
     assert response.status_code == 200
+
+
+def test_export_request_supports_all_artifact_types(client: TestClient) -> None:
+    EXPORT_AUDIT_TRAIL.clear()
+    artifact_types = ["PNG", "SVG", "MP4", "layer_package", "manifest_json", "prompt_lineage_bundle"]
+    for artifact_type in artifact_types:
+        response = client.post(
+            "/api/v1/export/request",
+            headers={"X-API-Key": "test-key"},
+            json={
+                "session_id": "sess-export-1",
+                "lineage_id": "lin-1",
+                "selected_variation_id": "var-1",
+                "artifact_type": artifact_type,
+                "options": {"quality": "high"},
+                "requested_by": "qa-user",
+            },
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["artifact_type"] == artifact_type
+        assert payload["session_id"] == "sess-export-1"
+        assert payload["lineage_id"] == "lin-1"
+        assert payload["selected_variation_id"] == "var-1"
+        assert payload["review_status"] == "ready_for_enterprise_review"
+        assert payload["replay_key"].startswith("sess-export-1:lin-1:var-1:")
+
+
+def test_export_request_requires_replay_identifiers(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/export/request",
+        headers={"X-API-Key": "test-key"},
+        json={
+            "session_id": "sess-export-2",
+            "lineage_id": "lin-2",
+            "artifact_type": "PNG",
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_export_history_supports_replay_filters(client: TestClient) -> None:
+    EXPORT_AUDIT_TRAIL.clear()
+    seed_payload = {
+        "session_id": "sess-export-3",
+        "lineage_id": "lin-3",
+        "selected_variation_id": "var-3",
+        "artifact_type": "manifest_json",
+    }
+    client.post("/api/v1/export/request", headers={"X-API-Key": "test-key"}, json=seed_payload)
+    client.post(
+        "/api/v1/export/request",
+        headers={"X-API-Key": "test-key"},
+        json={**seed_payload, "selected_variation_id": "var-4", "artifact_type": "layer_package"},
+    )
+
+    response = client.get(
+        "/api/v1/export/history",
+        headers={"X-API-Key": "test-key"},
+        params={
+            "session_id": "sess-export-3",
+            "lineage_id": "lin-3",
+            "selected_variation_id": "var-3",
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert payload["history"][0]["selected_variation_id"] == "var-3"
+    assert payload["history"][0]["artifact_type"] == "manifest_json"

--- a/docs/04_DATA_SCHEMAS.md
+++ b/docs/04_DATA_SCHEMAS.md
@@ -90,3 +90,13 @@ This sub-schema defines the structure for knowledge-heavy outputs from ScholarAg
 - `tone` — Affects the visual emotional bias (formal, casual, creative).
 
 Reasoning: Ensures that knowledge manifestations are structured, governable, and can be localized or cited properly within the Manifest HUD.
+
+## Export Domain V1
+Canonical contract files:
+- `docs/schemas/export_request_v1.json`
+- `docs/schemas/export_response_v1.json`
+
+Export ABI constraints:
+- Every request MUST include `session_id`, `lineage_id`, and `selected_variation_id` for deterministic replay lineage.
+- `artifact_type` supports: `PNG`, `SVG`, `MP4`, `layer_package`, `manifest_json`, `prompt_lineage_bundle`.
+- Response includes `audit_trail_id`, `replay_key`, and `review_status` so export history can be reviewed in enterprise governance flows.

--- a/docs/schemas/export_request_v1.json
+++ b/docs/schemas/export_request_v1.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aetherium.dev/schemas/export_request_v1.json",
+  "title": "Aetherium Export Request v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "session_id",
+    "lineage_id",
+    "selected_variation_id",
+    "artifact_type"
+  ],
+  "properties": {
+    "session_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "selected_variation_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_type": {
+      "type": "string",
+      "enum": [
+        "PNG",
+        "SVG",
+        "MP4",
+        "layer_package",
+        "manifest_json",
+        "prompt_lineage_bundle"
+      ]
+    },
+    "options": {
+      "type": "object",
+      "default": {}
+    },
+    "requested_by": {
+      "type": "string"
+    }
+  }
+}

--- a/docs/schemas/export_response_v1.json
+++ b/docs/schemas/export_response_v1.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aetherium.dev/schemas/export_response_v1.json",
+  "title": "Aetherium Export Response v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "export_id",
+    "session_id",
+    "lineage_id",
+    "selected_variation_id",
+    "artifact_type",
+    "status",
+    "audit_trail_id",
+    "replay_key",
+    "review_status",
+    "created_at"
+  ],
+  "properties": {
+    "export_id": {
+      "type": "string",
+      "pattern": "^exp_[a-f0-9]+$"
+    },
+    "session_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "selected_variation_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_type": {
+      "type": "string",
+      "enum": [
+        "PNG",
+        "SVG",
+        "MP4",
+        "layer_package",
+        "manifest_json",
+        "prompt_lineage_bundle"
+      ]
+    },
+    "status": {
+      "type": "string",
+      "const": "accepted"
+    },
+    "audit_trail_id": {
+      "type": "string",
+      "pattern": "^audit_[a-f0-9]+$"
+    },
+    "replay_key": {
+      "type": "string",
+      "minLength": 1
+    },
+    "review_status": {
+      "type": "string",
+      "const": "ready_for_enterprise_review"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "options": {
+      "type": "object",
+      "default": {}
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a contract-first export domain so rendered artifacts and metadata can be deterministically replayed and reviewed by enterprise workflows.
- Support requested artifact outputs (`PNG`, `SVG`, `MP4`, `layer_package`, `manifest_json`, `prompt_lineage_bundle`) while requiring replay identity (`session_id`, `lineage_id`, `selected_variation_id`).
- Record export audit information to enable replay, governance review, and downstream enterprise review workflows.

### Description
- Added export models and types: `ExportArtifactType`, `ExportRequest`, and `ExportResponse` to `api_gateway/main.py` to validate export payloads and responses.
- Implemented new endpoints: `POST /api/v1/export/request` to create an export job and `GET /api/v1/export/history` to query the in-memory audit trail filtered by `session_id`, `lineage_id`, and `selected_variation_id`.
- Added an in-memory audit trail `EXPORT_AUDIT_TRAIL` to store `audit_trail_id`, `replay_key`, `export_id`, metadata, and `review_status` for each request and returned `audit_trail_id`, `replay_key`, and `review_status` in responses.
- Added JSON Schema files under `docs/schemas/` (`export_request_v1.json` and `export_response_v1.json`) and documented the Export Domain in `docs/04_DATA_SCHEMAS.md`.
- Added tests in `api_gateway/test_api.py` to exercise artifact type acceptance, required replay identifiers, and history filtering.

### Testing
- Ran `cd api_gateway && pytest -q test_api.py` but test collection was blocked by an existing `IndentationError` in `governor/runtime_governor.py`, so the new tests could not complete execution.
- Ran `npm run lint` which failed in the current repository due to missing ESLint config required by ESLint v9, so frontend linting was not completed.
- Created and committed JSON schema files under `docs/schemas/` and added unit tests; these tests are ready to run once the repository-level import errors and linter configuration issues are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca38bf5ec8320a260736f7e8a840e)