### PR TITLE
[ws_gateway] Expand room event model with presence, approvals, and conflict policy

### DIFF
--- a/docs/runtime_console.md
+++ b/docs/runtime_console.md
@@ -92,3 +92,14 @@ Single intent is classified into one route and rendered accordingly:
 - `video` => streaming flow field
 - `search` => scholar panel synthesis path
 - `pure_light` => chroma/field modulation
+
+## WS room event contract (state-sync)
+
+State sync now uses `room_event.v1` envelopes (`ws_gateway/room-events.schema.json`) with explicit event families:
+
+- `presence` actions: `join`, `leave`, `active_role`, `cursor_or_focus`
+- `action` events with role-scoped `scope` checks (`state.visual`, `state.semantic`, etc.)
+- `approval` events for `brand_lead` and `operator`
+- `conflict_resolution` audit events for stale `base_stream_id` during concurrent edits
+
+Conflict policy is deterministic and replayable: optimistic concurrency with **last write wins** and explicit conflict event emission before accepting the stale write.

--- a/ws_gateway/main.py
+++ b/ws_gateway/main.py
@@ -15,6 +15,25 @@ STATE_SYNC_STREAM_MAXLEN = int(os.getenv("STATE_SYNC_STREAM_MAXLEN", "1000"))
 REPLAY_BATCH_LIMIT = int(os.getenv("STATE_SYNC_REPLAY_BATCH_LIMIT", "256"))
 r: Optional[redis.Redis] = None
 
+SCHEMA_VERSION = "room_event.v1"
+CONFLICT_POLICY = {
+    "policy_id": "state-sync-conflict.v1",
+    "strategy": "optimistic_concurrency_last_write_wins",
+    "description": "accept write, emit deterministic conflict event when base_stream_id is stale",
+}
+
+ROLE_ACTION_SCOPES: dict[str, set[str]] = {
+    "viewer": {"presence.read"},
+    "designer": {"presence.read", "presence.write", "state.visual"},
+    "strategist": {"presence.read", "presence.write", "state.semantic"},
+    "brand_lead": {"presence.read", "presence.write", "state.semantic", "approval.manage"},
+    "operator": {"presence.read", "presence.write", "state.visual", "state.semantic", "approval.manage", "system.ops"},
+}
+
+PRESENCE_ACTIONS = {"join", "leave", "active_role", "cursor_or_focus"}
+APPROVAL_ACTIONS = {"request", "approve", "reject"}
+ROOM_LAST_STREAM_ID: dict[str, str] = {}
+
 
 @app.on_event("startup")
 async def startup() -> None:
@@ -32,6 +51,7 @@ async def _authorize(websocket: WebSocket, api_key: Optional[str], x_api_key: Op
         return False
 
     import hmac
+
     expected_key = os.getenv("AETHERIUM_API_KEY")
     if expected_key and not hmac.compare_digest(key, expected_key):
         await websocket.close(code=1008)
@@ -44,16 +64,103 @@ def _stream_key(room_id: str) -> str:
     return f"state-sync:{room_id}"
 
 
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _permission_denied(reason: str, room_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "error",
+        "error": "permission_denied",
+        "reason": reason,
+        "room_id": room_id,
+        "payload": payload,
+        "updated_at": _now_iso(),
+    }
+
+
+def _has_scope(role: str, scope: str) -> bool:
+    return scope in ROLE_ACTION_SCOPES.get(role, set())
+
+
+def _resolve_scope(event_type: str, payload: dict[str, Any]) -> str | None:
+    if event_type == "presence":
+        return "presence.write"
+    if event_type == "approval":
+        return "approval.manage"
+    if event_type == "action":
+        scope = payload.get("scope")
+        return scope if isinstance(scope, str) else None
+    return None
+
+
+def _build_room_event(room_id: str, payload: dict[str, Any]) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    event_type = payload.get("type", "action")
+    actor_id = payload.get("actor_id")
+    role = payload.get("role")
+    action = payload.get("action")
+
+    if not isinstance(actor_id, str) or not actor_id:
+        return None, {"type": "error", "error": "invalid_actor", "detail": "actor_id is required"}
+    if not isinstance(role, str) or role not in ROLE_ACTION_SCOPES:
+        return None, {"type": "error", "error": "invalid_role", "detail": "role is required and must be supported"}
+
+    scope = _resolve_scope(event_type, payload)
+    if not scope:
+        return None, {
+            "type": "error",
+            "error": "invalid_scope",
+            "detail": f"scope is required for event type '{event_type}'",
+        }
+
+    if not _has_scope(role, scope):
+        return None, _permission_denied(f"role '{role}' cannot perform scope '{scope}'", room_id, payload)
+
+    if event_type == "presence" and action not in PRESENCE_ACTIONS:
+        return None, {"type": "error", "error": "invalid_presence_action", "detail": "unsupported presence action"}
+
+    if event_type == "approval":
+        if action not in APPROVAL_ACTIONS:
+            return None, {"type": "error", "error": "invalid_approval_action", "detail": "unsupported approval action"}
+        target_event_id = payload.get("target_event_id")
+        if not isinstance(target_event_id, str) or not target_event_id:
+            return None, {"type": "error", "error": "invalid_target_event_id", "detail": "target_event_id is required"}
+
+    base_stream_id = payload.get("base_stream_id")
+    if base_stream_id is not None and not isinstance(base_stream_id, str):
+        return None, {"type": "error", "error": "invalid_base_stream_id", "detail": "base_stream_id must be a string"}
+
+    event = {
+        "schema_version": SCHEMA_VERSION,
+        "type": event_type,
+        "room_id": room_id,
+        "actor_id": actor_id,
+        "role": role,
+        "scope": scope,
+        "action": action,
+        "payload": payload.get("payload", {}),
+        "cursor_or_focus": payload.get("cursor_or_focus"),
+        "target_event_id": payload.get("target_event_id"),
+        "base_stream_id": base_stream_id,
+        "conflict_policy": CONFLICT_POLICY,
+        "updated_at": _now_iso(),
+    }
+    return event, None
+
+
 async def _append_room_event(room_id: str, event: dict[str, Any]) -> str | None:
     if not r:
         return None
     try:
-        return await r.xadd(
+        stream_id = await r.xadd(
             _stream_key(room_id),
             {"payload": json.dumps(event)},
             maxlen=STATE_SYNC_STREAM_MAXLEN,
             approximate=True,
         )
+        if stream_id:
+            ROOM_LAST_STREAM_ID[room_id] = stream_id
+        return stream_id
     except Exception:
         logger.exception("failed to append room event")
         return None
@@ -104,7 +211,7 @@ async def cognitive_stream(
     try:
         while True:
             event = await websocket.receive_json()
-            envelope = {"received_at": datetime.now(timezone.utc).isoformat(), "event": event}
+            envelope = {"received_at": _now_iso(), "event": event}
             stream_id = await _append_room_event("cognitive", envelope)
             await websocket.send_json({"status": "accepted", "stream_id": stream_id})
     except WebSocketDisconnect:
@@ -125,14 +232,37 @@ async def state_sync_stream(
     await _replay_events(websocket, room_id, last_event_id)
     try:
         while True:
-            delta = await websocket.receive_json()
-            event = {
-                "type": "state_delta",
-                "room_id": room_id,
-                "delta": delta,
-                "updated_at": datetime.now(timezone.utc).isoformat(),
-            }
+            raw_event = await websocket.receive_json()
+            event, err = _build_room_event(room_id, raw_event)
+            if err:
+                await websocket.send_json({"status": "rejected", "room_id": room_id, "error": err})
+                continue
+
+            assert event is not None
+            latest_stream_id = ROOM_LAST_STREAM_ID.get(room_id)
+            base_stream_id = event.get("base_stream_id")
+            conflict_stream_id = None
+            if base_stream_id and latest_stream_id and base_stream_id != latest_stream_id:
+                conflict_event = {
+                    "schema_version": SCHEMA_VERSION,
+                    "type": "conflict_resolution",
+                    "room_id": room_id,
+                    "conflict_policy": CONFLICT_POLICY,
+                    "winning_stream_id": latest_stream_id,
+                    "stale_base_stream_id": base_stream_id,
+                    "incoming_actor_id": event.get("actor_id"),
+                    "updated_at": _now_iso(),
+                }
+                conflict_stream_id = await _append_room_event(room_id, conflict_event)
+
             stream_id = await _append_room_event(room_id, event)
-            await websocket.send_json({"status": "accepted", "room_id": room_id, "stream_id": stream_id})
+            await websocket.send_json(
+                {
+                    "status": "accepted",
+                    "room_id": room_id,
+                    "stream_id": stream_id,
+                    "conflict_stream_id": conflict_stream_id,
+                }
+            )
     except WebSocketDisconnect:
         pass

--- a/ws_gateway/room-events.schema.json
+++ b/ws_gateway/room-events.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aetherium.dev/schemas/room-events.schema.json",
+  "title": "Aetherium Room Events",
+  "description": "Contract for state-sync room events including presence, scoped actions, approvals, and conflict resolution.",
+  "type": "object",
+  "required": ["schema_version", "type", "room_id", "updated_at"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "room_event.v1"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["presence", "action", "approval", "conflict_resolution"]
+    },
+    "room_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "actor_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "role": {
+      "type": "string",
+      "enum": ["viewer", "designer", "strategist", "brand_lead", "operator"]
+    },
+    "scope": {
+      "type": "string",
+      "enum": ["presence.read", "presence.write", "state.visual", "state.semantic", "approval.manage", "system.ops"]
+    },
+    "action": {
+      "type": ["string", "null"]
+    },
+    "payload": {
+      "type": "object"
+    },
+    "cursor_or_focus": {
+      "type": ["object", "null"]
+    },
+    "target_event_id": {
+      "type": ["string", "null"]
+    },
+    "base_stream_id": {
+      "type": ["string", "null"]
+    },
+    "conflict_policy": {
+      "type": "object",
+      "required": ["policy_id", "strategy"],
+      "properties": {
+        "policy_id": {"type": "string"},
+        "strategy": {"type": "string"},
+        "description": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "winning_stream_id": {
+      "type": "string"
+    },
+    "stale_base_stream_id": {
+      "type": "string"
+    },
+    "incoming_actor_id": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"type": {"const": "presence"}}},
+      "then": {
+        "required": ["actor_id", "role", "scope", "action"],
+        "properties": {
+          "scope": {"const": "presence.write"},
+          "action": {"enum": ["join", "leave", "active_role", "cursor_or_focus"]}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"type": {"const": "approval"}}},
+      "then": {
+        "required": ["actor_id", "role", "scope", "action", "target_event_id"],
+        "properties": {
+          "scope": {"const": "approval.manage"},
+          "action": {"enum": ["request", "approve", "reject"]}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"type": {"const": "conflict_resolution"}}},
+      "then": {
+        "required": ["conflict_policy", "winning_stream_id", "stale_base_stream_id", "incoming_actor_id"]
+      }
+    }
+  ],
+  "additionalProperties": true
+}

--- a/ws_gateway/test_ws_gateway.py
+++ b/ws_gateway/test_ws_gateway.py
@@ -1,14 +1,41 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
+from . import main
 from .main import app
+
+
+class InMemoryRedis:
+    def __init__(self) -> None:
+        self.streams: dict[str, list[tuple[str, dict[str, str]]]] = {}
+        self.counter = 0
+
+    async def xadd(self, stream: str, fields: dict[str, str], maxlen: int | None = None, approximate: bool = True) -> str:
+        self.counter += 1
+        stream_id = f"1-{self.counter}"
+        self.streams.setdefault(stream, []).append((stream_id, fields))
+        if maxlen and len(self.streams[stream]) > maxlen:
+            self.streams[stream] = self.streams[stream][-maxlen:]
+        return stream_id
+
+    async def xrange(self, stream: str, min: str, max: str, count: int) -> list[tuple[str, dict[str, str]]]:
+        events = self.streams.get(stream, [])
+        start_exclusive = "0-0"
+        if min.startswith("("):
+            start_exclusive = min[1:]
+        filtered = [item for item in events if item[0] > start_exclusive]
+        return filtered[:count]
 
 
 @pytest.fixture
 def client() -> TestClient:
+    main.r = InMemoryRedis()  # type: ignore[assignment]
+    main.ROOM_LAST_STREAM_ID.clear()
     return TestClient(app)
 
 
@@ -29,3 +56,102 @@ def test_state_sync_websocket_requires_api_key(client: TestClient) -> None:
     with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect('/ws/state-sync/demo-room'):
             pass
+
+
+def test_state_sync_presence_event_and_role_scope_permissions(client: TestClient) -> None:
+    with client.websocket_connect('/ws/state-sync/room-a?api_key=test-key') as websocket:
+        websocket.send_json(
+            {
+                'type': 'presence',
+                'action': 'join',
+                'actor_id': 'u-designer',
+                'role': 'designer',
+                'payload': {'device': 'desktop'},
+            }
+        )
+        accepted = websocket.receive_json()
+        assert accepted['status'] == 'accepted'
+
+        websocket.send_json(
+            {
+                'type': 'approval',
+                'action': 'approve',
+                'actor_id': 'u-designer',
+                'role': 'designer',
+                'target_event_id': accepted['stream_id'],
+            }
+        )
+        rejected = websocket.receive_json()
+        assert rejected['status'] == 'rejected'
+        assert rejected['error']['error'] == 'permission_denied'
+
+
+def test_state_sync_approval_event_for_brand_lead_and_operator(client: TestClient) -> None:
+    with client.websocket_connect('/ws/state-sync/room-b?api_key=test-key') as websocket:
+        websocket.send_json(
+            {
+                'type': 'approval',
+                'action': 'approve',
+                'actor_id': 'u-brand',
+                'role': 'brand_lead',
+                'target_event_id': '1-1',
+                'payload': {'comment': 'on-brand'},
+            }
+        )
+        brand_resp = websocket.receive_json()
+        assert brand_resp['status'] == 'accepted'
+
+        websocket.send_json(
+            {
+                'type': 'approval',
+                'action': 'reject',
+                'actor_id': 'u-ops',
+                'role': 'operator',
+                'target_event_id': '1-1',
+                'payload': {'comment': 'policy block'},
+            }
+        )
+        op_resp = websocket.receive_json()
+        assert op_resp['status'] == 'accepted'
+
+
+def test_replay_consistency_and_conflict_resolution_for_concurrent_edits(client: TestClient) -> None:
+    with client.websocket_connect('/ws/state-sync/room-c?api_key=test-key') as websocket:
+        websocket.send_json(
+            {
+                'type': 'action',
+                'action': 'edit_layer',
+                'scope': 'state.visual',
+                'actor_id': 'u1',
+                'role': 'designer',
+                'payload': {'layer': 'hero', 'value': '#fff'},
+            }
+        )
+        first = websocket.receive_json()
+        assert first['status'] == 'accepted'
+
+        websocket.send_json(
+            {
+                'type': 'action',
+                'action': 'edit_layer',
+                'scope': 'state.visual',
+                'actor_id': 'u2',
+                'role': 'designer',
+                'base_stream_id': '1-0',
+                'payload': {'layer': 'hero', 'value': '#000'},
+            }
+        )
+        second = websocket.receive_json()
+        assert second['status'] == 'accepted'
+        assert second['conflict_stream_id'] is not None
+
+    with client.websocket_connect('/ws/state-sync/room-c?api_key=test-key&last_event_id=0-0') as replay_socket:
+        replay_events = [replay_socket.receive_json() for _ in range(3)]
+
+    assert [event['event']['type'] for event in replay_events] == ['action', 'conflict_resolution', 'action']
+    assert replay_events[1]['event']['conflict_policy']['strategy'] == 'optimistic_concurrency_last_write_wins'
+    assert replay_events[2]['event']['base_stream_id'] == '1-0'
+
+    redis_stream = main.r.streams['state-sync:room-c']  # type: ignore[union-attr]
+    persisted_types = [json.loads(entry[1]['payload'])['type'] for entry in redis_stream]
+    assert persisted_types == ['action', 'conflict_resolution', 'action']


### PR DESCRIPTION
### Motivation
- Introduce a structured, contract-first room event model for state-sync to support presence, role-scoped actions, approvals, and deterministic conflict resolution for concurrent edits.
- Make conflict detection and resolution replayable and auditable so clients can rely on deterministic ordering and last-write-wins semantics for operational recovery.

### Description
- Reworked `ws_gateway/main.py` to emit and validate `room_event.v1` envelopes and added `SCHEMA_VERSION`, `CONFLICT_POLICY`, `ROLE_ACTION_SCOPES`, `PRESENCE_ACTIONS`, `APPROVAL_ACTIONS`, and `ROOM_LAST_STREAM_ID` runtime state.
- Added helper functions `/_now_iso`, `/_permission_denied`, `/_has_scope`, `/_resolve_scope`, and `/_build_room_event` to validate actor/role/scope and to construct typed room events prior to persistence.
- Updated `state_sync_stream` to accept typed room events, enforce role-to-scope permissions (deny-by-default), validate approval targets, detect stale `base_stream_id` and emit a `conflict_resolution` event before persisting the incoming write.
- Added `ws_gateway/room-events.schema.json` describing `room_event.v1` (families: `presence`, `action`, `approval`, `conflict_resolution`) with per-type `allOf` validation rules.
- Extended `ws_gateway/test_ws_gateway.py` with an `InMemoryRedis` test double and tests covering presence/role permission checks, brand-lead/operator approval flows, and replay consistency + conflict ordering for concurrent edits.
- Updated `docs/runtime_console.md` to document the `room_event.v1` contract and the deterministic conflict policy.

### Testing
- Ran `python3 -m py_compile ws_gateway/main.py ws_gateway/test_ws_gateway.py` which succeeded and ensured the modified Python files compile.
- Ran `pytest -q ws_gateway/test_ws_gateway.py` which failed during test collection due to the environment missing the `httpx` dependency required by `fastapi.testclient` (error: `ModuleNotFoundError: No module named 'httpx'`).
- Ran `npm run lint` which failed in this environment because ESLint v9 expects a flat `eslint.config.js` (project currently lacks that config), so JS lint could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca4f705f083209062261306431f6e)