### PR TITLE
[ci] Add ESLint v9 flat config and ws_gateway test deps

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -76,6 +76,40 @@ jobs:
       - name: Run governor psycho-safety parity test
         run: npx --yes tsx --test test_runtime_governor_psycho_safety.test.ts
 
+  frontend-lint:
+    name: Frontend Lint (ESLint)
+    needs: lint-and-typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Install Node dependencies
+        run: npm ci
+      - name: Run frontend lint
+        run: npm run lint
+
+  ws-gateway-tests:
+    name: WS Gateway Tests
+    needs: lint-and-typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: pip
+          cache-dependency-path: ws_gateway/requirements-dev.txt
+      - name: Install ws_gateway test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r ws_gateway/requirements-dev.txt
+      - name: Run ws_gateway pytest module
+        run: pytest -q ws_gateway/test_ws_gateway.py
+
   frontend-js-tests:
     name: Frontend JS Tests
     if: ${{ !inputs.fast-gate }}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,37 @@
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: ["dist", "coverage", ".vite", "node_modules"],
+  },
+  {
+    files: ["**/*.{ts,tsx}"],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+    ],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
+    },
+  }
+);

--- a/ws_gateway/requirements-dev.txt
+++ b/ws_gateway/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8.2.0
+httpx>=0.27,<1


### PR DESCRIPTION
### Motivation
- ESLint v9 in the repository requires a flat config file so `eslint` can load and run under the flat-config resolution model. 
- The `ws_gateway` test suite requires test-only dependencies (`pytest`, `httpx`) which must be separated from runtime requirements to avoid CI failures in clean environments. 
- CI workflows should reflect real project steps for frontend lint and Python ws_gateway tests so PR checks run reliably in a clean environment. 

### Description
- Add root `eslint.config.js` implementing the exact ESLint v9 flat config with TypeScript and React Hooks/Refresh plugin settings. 
- Add `ws_gateway/requirements-dev.txt` with `-r requirements.txt`, `pytest>=8.2.0`, and `httpx>=0.27,<1` to separate test-only packages from runtime deps. 
- Update `.github/workflows/reusable-ci.yml` to add a `frontend-lint` job that runs `npm ci` and `npm run lint`, and a `ws-gateway-tests` job that installs `ws_gateway/requirements-dev.txt` and runs `pytest -q ws_gateway/test_ws_gateway.py`. 
- No application runtime code was modified and `package.json` was intentionally left unchanged. 

### Testing
- Ran `npm ci` successfully which installed Node dependencies. 
- Ran `npm run lint` which now loads the flat ESLint config but reports pre-existing TypeScript lint violations (lint executed successfully but returned errors). 
- Ran `python -m pip install -r ws_gateway/requirements-dev.txt` successfully which installed `pytest` and `httpx`. 
- Ran `pytest -q ws_gateway/test_ws_gateway.py` which passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca90a170c8320bcc8da8deddb96b5)