### PR TITLE
[ci] Gate frontend ESLint job until lint baseline is cleared

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: boolean
         default: false
+      run-frontend-lint:
+        description: Enable frontend ESLint job (disabled until baseline lint backlog is resolved)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -78,6 +83,7 @@ jobs:
 
   frontend-lint:
     name: Frontend Lint (ESLint)
+    if: ${{ inputs.run-frontend-lint }}
     needs: lint-and-typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
### Motivation
- The unconditional `npm run lint` added to the reusable CI caused unrelated PRs to fail because existing TypeScript files trigger ESLint errors, so the frontend lint job must be opt-in until the baseline backlog is fixed.

### Description
- Add a `workflow_call` boolean input `run-frontend-lint` (default `false`) and apply `if: ${{ inputs.run-frontend-lint }}` to the `frontend-lint` job in `.github/workflows/reusable-ci.yml` so ESLint runs only when explicitly enabled.

### Testing
- Verified the workflow update with an automated content assertion using `python3 - <<'PY' ...` to confirm both `run-frontend-lint` and `if: ${{ inputs.run-frontend-lint }}` are present in `.github/workflows/reusable-ci.yml`, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcaabd56a4832096ca526856288b59)