### PR TITLE
[frontend] Configure Vite for GitHub Pages project-site base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+
+export default defineConfig({
+  plugins: [react()],
+  base: process.env.GITHUB_PAGES === "true" ? "/Aetherium-Manifest/" : "/",
+});


### PR DESCRIPTION
### Motivation
- Ensure built assets and asset URLs resolve correctly when deploying the frontend as a GitHub Pages project site at `/Aetherium-Manifest/` while preserving local/dev behavior.

### Description
- Add `vite.config.ts` that imports `@vitejs/plugin-react-swc` and sets `base: process.env.GITHUB_PAGES === "true" ? "/Aetherium-Manifest/" : "/"` as the only frontend build configuration change.

### Testing
- Ran `npm run lint`, which failed due to existing unrelated TypeScript/ESLint errors in repository files (15 errors), so lint did not pass. 
- Ran `npm run build`, which failed because `tsconfig.json` is not present in this environment and `tsc -b` could not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb83f2b148320a18ddee8606b4383)