### PR TITLE
[governor] Fix runtime ABI schema resolution fallback order

### DIFF
--- a/governor.ts
+++ b/governor.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import {
@@ -1256,7 +1256,14 @@ let CACHED_RUNTIME_ABI_VALIDATOR: RuntimeGovernorOptions["schemaValidator"] | nu
 function loadRuntimeAbiSchemaValidator(): RuntimeGovernorOptions["schemaValidator"] | undefined {
   if (CACHED_RUNTIME_ABI_VALIDATOR !== undefined) return CACHED_RUNTIME_ABI_VALIDATOR ?? undefined;
   try {
-    const schemaPath = process.env.PARTICLE_CONTROL_SCHEMA_PATH ?? resolve(process.cwd(), "governor", "particle-control.schema.json");
+    const schemaCandidates = process.env.PARTICLE_CONTROL_SCHEMA_PATH
+      ? [process.env.PARTICLE_CONTROL_SCHEMA_PATH]
+      : [resolve(process.cwd(), "particle-control.schema.json"), resolve(process.cwd(), "governor", "particle-control.schema.json")];
+    const schemaPath = schemaCandidates.find((candidate) => existsSync(candidate));
+    if (!schemaPath) {
+      CACHED_RUNTIME_ABI_VALIDATOR = null;
+      return undefined;
+    }
     const raw = readFileSync(schemaPath, "utf-8");
     const schema = JSON.parse(raw) as JsonSchema;
     CACHED_RUNTIME_ABI_VALIDATOR = makeNaiveRuntimeAbiValidator(schema);


### PR DESCRIPTION
### Motivation
- The TypeScript `RuntimeGovernor` could load the Python-governor schema at `governor/particle-control.schema.json` by default, causing spurious schema validation failures and unexpected safe-contract substitutions.
- The intent is to make the TS runtime prefer the repository-root ABI schema and avoid accidental ABI mismatches that mask real runtime behavior.

### Description
- Prefer the repository-root `particle-control.schema.json` when resolving the runtime ABI schema by trying `process.env.PARTICLE_CONTROL_SCHEMA_PATH`, then `./particle-control.schema.json`, then `./governor/particle-control.schema.json` as a fallback, using `existsSync` to select an existing candidate.
- If no schema file is found the loader now returns `undefined` (disables the naive validator) instead of attempting to load a potentially incompatible schema, preventing false-positive validation failures.
- Kept existing override behavior via `PARTICLE_CONTROL_SCHEMA_PATH` intact and implemented a safe fast-path when no schema is present.

### Testing
- Ran the TypeScript parity tests with `npx --yes tsx --test test_runtime_governor_psycho_safety.test.ts` and all tests passed (5/5) ✅.
- Ran `npm run lint` which still fails due to pre-existing TypeScript lint issues in unrelated files (reported but not changed) ⚠️.
- Ran `python3 tools/contracts/contract_checker.py` which could not run in this environment due to a missing Python dependency (`httpx`) unrelated to this change ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcbb4685e083208fa05465a9b5afe4)