### PR TITLE
[ci] Harden security gates and remove duplicate PR checks

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -8,3 +8,5 @@ Enable branch protection (or rulesets) for the default primary branch in use (`m
   - Add `OSSF Scorecards` from workflow `Security Scorecards` as a required check on `main`
 
 This setting makes the `CODEOWNERS` rules mandatory before merge for protected branches and enforces security workflow health gates.
+
+- `Security Scorecards` now runs on all pull requests, so it can be safely configured as a required status check.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,38 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: ["main", "master", "develop"]
+  pull_request:
+    branches: ["**"]
+  schedule:
+    - cron: "31 2 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python", "javascript-typescript"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   codex:
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
     runs-on: ubuntu-latest
     outputs:
       final_message: ${{ steps.run_codex.outputs.final-message }}
@@ -37,7 +38,7 @@ jobs:
   post-feedback:
     runs-on: ubuntu-latest
     needs: codex
-    if: needs.codex.outputs.final_message != ''
+    if: ${{ needs.codex.result == 'success' && needs.codex.outputs.final_message != '' }}
     steps:
       - name: Post Codex feedback
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/contract-and-runtime-checks.yml
+++ b/.github/workflows/contract-and-runtime-checks.yml
@@ -1,8 +1,6 @@
 name: Contract and Runtime Quality Checks
 
 on:
-  pull_request:
-    branches: ["**"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/sdlc-automation.yml
+++ b/.github/workflows/sdlc-automation.yml
@@ -37,7 +37,7 @@ jobs:
     with:
       fast-gate: false
       check-pr-body: false
-      run-full-contracts: false
+      run-full-contracts: ${{ github.ref_name == 'main' || github.ref_name == 'develop' }}
 
   nightly-heavy:
     if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_full_nightly) }}

--- a/.github/workflows/security-scorecards.yml
+++ b/.github/workflows/security-scorecards.yml
@@ -6,11 +6,8 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '.github/**'
   pull_request:
-    paths:
-      - '.github/**'
+    branches: ["**"]
 
 permissions:
   contents: read
@@ -26,16 +23,16 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run OpenSSF Scorecards
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
### Motivation
- Strengthen repository security by pinning third-party GitHub Actions in the Scorecards workflow and expanding its PR coverage so it can be used as a reliable required status check.
- Prevent unnecessary CI failures and accidental runs of the Codex reviewer when `OPENAI_API_KEY` is not configured.
- Eliminate duplicated PR compute by removing overlapping automatic triggers and restore CodeQL scanning coverage using the repo config.

### Description
- Updated `.github/workflows/security-scorecards.yml` to pin actions to full commit SHAs and change the `pull_request` trigger to `branches: ["**"]` so Scorecards runs for all PRs.
- Modified `.github/workflows/codex-review.yml` to guard the `codex` job with `if: ${{ secrets.OPENAI_API_KEY != '' }}` and tightened the `post-feedback` condition to require a successful `codex` job result.
- Added a new `.github/workflows/codeql-analysis.yml` workflow that uses the existing `.github/codeql/codeql-config.yml` and pinned CodeQL actions to SHAs so CodeQL scans run on push/PR/schedule.
- Removed the `pull_request` trigger from `contract-and-runtime-checks.yml` and adjusted `.github/workflows/sdlc-automation.yml` to run full contract/fuzz coverage on pushes to `main`/`develop`; updated `.github/branch-protection.md` to reflect Scorecards now running on all PRs.

### Testing
- Ran `npm run lint`, which failed with ESLint errors reported in multiple TypeScript files (15 problems), indicating a pre-existing lint backlog unrelated to the workflow changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcdc19323c8320a8f53faed2b8be9c)