### PR TITLE
[api-gateway] Fix dependency and queue/runtime governor regressions

### DIFF
--- a/api_gateway/requirements.txt
+++ b/api_gateway/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.111.0
 uvicorn[standard]>=0.30.0
 msgspec>=0.18.6
 nats-py>=2.8.0
+httpx>=0.27.0

--- a/api_gateway/ws_scaling.py
+++ b/api_gateway/ws_scaling.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 import hashlib
+import math
 from typing import Any
 
 
@@ -60,7 +61,7 @@ class BackpressureQueue:
 
     def __init__(self, max_items: int = 128) -> None:
         self.max_items = max_items
-        self._items: collections.deque[OutboundMessage] = collections.deque()
+        self._items: list[OutboundMessage] = []
         self.dropped = 0
 
     def __len__(self) -> int:
@@ -73,7 +74,7 @@ class BackpressureQueue:
     def pop(self) -> OutboundMessage | None:
         if not self._items:
             return None
-        return self._items.popleft()
+        return self._items.pop(0)
 
     def _trim_if_needed(self) -> None:
         while len(self._items) > self.max_items:

--- a/governor/runtime_governor.py
+++ b/governor/runtime_governor.py
@@ -895,12 +895,9 @@ class RuntimeGovernor:
                 unverified = False
                 trusted_domains = ["wikipedia.org", "github.com", "aetherium.dev", "nasa.gov", "arxiv.org", "nature.com", "sciencedirect.com", "scholar.google.com", "npmjs.com", "developer.mozilla.org", "stackoverflow.com", "reuters.com"]
                 for url in scholar["cited_sources"]:
-                for url in scholar["cited_sources"]:
                     # Extract hostname for secure validation
                     hostname = url.split("://")[-1].split("/")[0].split("?")[0].split(":")[0]
                     if not any(hostname == domain or hostname.endswith("." + domain) for domain in trusted_domains):
-                        unverified = True
-                        violations.append(f"unverified source detected: {url}")
                         unverified = True
                         violations.append(f"unverified source detected: {url}")
                 scholar["unverified_source_detected"] = unverified


### PR DESCRIPTION
### Motivation
- Restore runtime import and safety-validation paths that were failing test collection and causing runtime errors by fixing a missing runtime dependency, an indentation/duplicate-line regression in the governor, and regressions in the WebSocket scaling queue implementation.

### Description
- Add `httpx` to `api_gateway/requirements.txt` so runtime imports used by `api_gateway/main.py` and related tools are available outside dev-only requirements. 
- Fix scholar cited-source validation in `governor/runtime_governor.py` by removing the duplicated `for url in scholar["cited_sources"]:` line and duplicate violation appends to eliminate the `IndentationError` and duplicated diagnostics. 
- Repair `api_gateway/ws_scaling.py` by adding the `math` import and switching `BackpressureQueue` internal storage to an indexable `list` with `pop(drop_index)`/`pop(0)` semantics so eviction by priority and `recommended_nodes` math calculations work deterministically.

### Testing
- Ran `pytest -q api_gateway/test_ws_scaling.py` and all tests passed (`5 passed`).
- Ran `python3 -m py_compile governor/runtime_governor.py` and compilation succeeded with no syntax errors.
- Ran `npm run lint` and `cd api_gateway && pytest -q` as wider checks and those revealed pre-existing issues unrelated to this patch (TypeScript lint errors and multiple failing `test_runtime_quality.py` cases), so they remain failing and were not changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf44f4f008320a7efddec6563e460)