### PR TITLE
[tools] Harden tiny reasoning light safety clamps

### DIFF
--- a/docs/08_TEST_PLAN.md
+++ b/docs/08_TEST_PLAN.md
@@ -20,6 +20,7 @@
 - ghost path ห้าม commit โดยไม่มี confirmation
 - rollback correctness ภายใต้ mismatch หนัก
 - malformed envelope / replay / invalid rkey tests
+- tiny reasoning light model ต้อง clamp ค่าความปลอดภัยที่ผิดช่วง (fps/brightness/flicker cap) และใช้ block glyph สำหรับอักขระที่ไม่รองรับ
 
 ## 5) GunUI Experience
 - Gate ปิดแล้วต้องไม่เกิด visual spam

--- a/tests/test_tiny_reasoning_light_model.py
+++ b/tests/test_tiny_reasoning_light_model.py
@@ -35,8 +35,22 @@ def test_light_frame_output_respects_safety_profile() -> None:
     assert len(frames) == 2
     assert frames[0]["frame_duration_ms"] == 125
     assert frames[0]["brightness"] == 0.4
+    assert frames[0]["flicker_hz_cap"] == 1.0
     assert frames[0]["mode"] == "no_flicker"
     assert len(frames[0]["matrix_5x7"]) == 7
+
+
+def test_light_frame_output_clamps_invalid_safety_values_and_unknown_glyph() -> None:
+    model = TinyReasoningLightModel(
+        safety=SafetyProfile(mode="low_sensory", max_fps=120, max_brightness=-0.2, flicker_hz_cap=-3.0)
+    )
+    model.fit([SpecializedSample("fallback", "fallback", "X")])
+    frames = model.render_light_frames("?")
+
+    assert frames[0]["frame_duration_ms"] == 41
+    assert frames[0]["brightness"] == 0.05
+    assert frames[0]["flicker_hz_cap"] == 0.0
+    assert frames[0]["matrix_5x7"] == ["11111", "11111", "11111", "11111", "11111", "11111", "11111"]
 
 
 def test_bootstrap_demo_model_end_to_end() -> None:

--- a/tools/tiny_reasoning_light_model.py
+++ b/tools/tiny_reasoning_light_model.py
@@ -56,9 +56,9 @@ class TinyReasoningLightModel:
         term_counts = self._intent_term_counts.get(intent, {})
         if not tokens:
             return 0.0
-        numer = sum(term_counts.get(t, 0) for t in tokens)
+        numerator = sum(term_counts.get(t, 0) for t in tokens)
         denom = math.sqrt(sum(v * v for v in term_counts.values())) or 1.0
-        return numer / denom
+        return numerator / denom
 
     def infer_intent(self, user_query: str) -> str:
         if not self._intent_term_counts:
@@ -78,7 +78,7 @@ class TinyReasoningLightModel:
 
     @staticmethod
     def _char_to_matrix(char: str) -> list[str]:
-        # 5x7 subset for high-readability projection. Unknown chars fallback to block.
+        # 5x7 subset for high-readability projection. Unknown chars fall back to a block.
         font = {
             "A": ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
             "B": ["11110", "10001", "10001", "11110", "10001", "10001", "11110"],
@@ -96,13 +96,14 @@ class TinyReasoningLightModel:
             "Y": ["10001", "10001", "01010", "00100", "00100", "00100", "00100"],
             " ": ["00000", "00000", "00000", "00000", "00000", "00000", "00000"],
         }
-        return font.get(char.upper(), ["11111", "10001", "00100", "00100", "00100", "00000", "00100"])
+        return font.get(char.upper(), ["11111", "11111", "11111", "11111", "11111", "11111", "11111"])
 
     def render_light_frames(self, text: str) -> list[dict[str, object]]:
         """Render deterministic frame list to display text using light pixels."""
         frames: list[dict[str, object]] = []
         safe_fps = min(max(self.safety.max_fps, 1), 24)
         safe_brightness = min(max(self.safety.max_brightness, 0.05), 1.0)
+        safe_flicker_hz_cap = min(max(self.safety.flicker_hz_cap, 0.0), 60.0)
         for char in text:
             frames.append(
                 {
@@ -110,7 +111,7 @@ class TinyReasoningLightModel:
                     "matrix_5x7": self._char_to_matrix(char),
                     "frame_duration_ms": int(1000 / safe_fps),
                     "brightness": safe_brightness,
-                    "flicker_hz_cap": self.safety.flicker_hz_cap,
+                    "flicker_hz_cap": safe_flicker_hz_cap,
                     "mode": self.safety.mode,
                 }
             )


### PR DESCRIPTION
### Motivation
- Ensure the tiny reasoning light utility emits bounded, safe frame payloads when given out-of-range safety values.
- Align the implementation with its comment that unknown glyphs should fallback to a block glyph.
- Improve clarity of a small comment and internal variable naming for readability.

### Description
- Clamp `flicker_hz_cap` into a safe range with `safe_flicker_hz_cap = min(max(self.safety.flicker_hz_cap, 0.0), 60.0)` and emit that value instead of raw input.
- Change unknown glyph fallback to a full 5x7 filled block matrix to match the documented behavior in `_char_to_matrix`.
- Rename local variable `numer` to `numerator` in `_score_intent` and reword a comment for grammar/clarity.
- Add unit assertions and a new test `test_light_frame_output_clamps_invalid_safety_values_and_unknown_glyph` in `tests/test_tiny_reasoning_light_model.py` to validate clamping and glyph fallback, and add an assertion for `flicker_hz_cap` in the existing safety-profile test.
- Update `docs/08_TEST_PLAN.md` to call out the new safety expectation for the tiny reasoning light model.

### Testing
- Ran `pytest -q tests/test_tiny_reasoning_light_model.py` which passed (`4 passed`).
- Ran `npm run lint` which failed due to pre-existing TypeScript lint errors outside the modified Python files.
- Ran `python3 tools/contracts/contract_checker.py` which could not complete in this environment due to a missing dependency (`httpx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0805f3f88320b914e708db82a81b)