### PR TITLE
[ws_gateway] Add sharded Go WebSocket runtime gateway

### DIFF
--- a/docs/14_WEBSOCKET_RUNTIME_GATEWAY_TH.md
+++ b/docs/14_WEBSOCKET_RUNTIME_GATEWAY_TH.md
@@ -1,0 +1,77 @@
+# WebSocket Runtime Gateway (Go) สำหรับโหลดสูง
+
+เอกสารนี้เพิ่ม utility สาธารณะ `ws_gateway/` สำหรับ real-time fanout โดยออกแบบให้รองรับระดับ ~50k connections ต่อ node (ขึ้นกับเครื่องและ tuning จริง)
+
+## Design key
+
+- ใช้ Go netpoll (epoll/kqueue ผ่าน Go runtime) + goroutine model
+- 1 connection = 1 reader goroutine + 1 writer goroutine
+- มี connection registry กลาง
+- มี room sharding เพื่อลด lock contention
+- มี message fanout ต่อ room
+- มี backpressure control (drop/disconnect slow consumer)
+- มี heartbeat (ping/pong + read deadline)
+- รองรับ hook event bus ผ่าน interface (`BusPublisher`) เพื่อเชื่อม NATS/Kafka ได้
+
+## โครงสร้างไฟล์
+
+- `ws_gateway/main.go`:
+  - bootstrap server
+  - WebSocket upgrade (`/ws?room=<roomId>`)
+  - graceful shutdown
+  - env config (`WS_LISTEN_ADDR`, `WS_ROOM_SHARDS`)
+- `ws_gateway/server.go`:
+  - connection manager
+  - shard registry
+  - register/unregister/broadcast loop
+  - read pump / write pump
+  - event bus hooks (`PublishToBus`, `HandleAIEvent`)
+- `ws_gateway/id.go`:
+  - generator สำหรับ connection ID
+
+## วิธีรัน
+
+```bash
+cd ws_gateway
+go mod tidy
+go run .
+```
+
+ค่า default:
+
+- listen addr: `:8080`
+- room shards: `32`
+- endpoint: `ws://localhost:8080/ws?room=default`
+
+## Event Bus integration
+
+เชื่อม NATS/Kafka ด้วยการ implement interface:
+
+```go
+type BusPublisher interface {
+    Publish(msg Message) error
+}
+```
+
+จากนั้น inject ด้วย `server.SetPublisher(...)`
+
+## OS/Runtime tuning (production baseline)
+
+> ใช้ตาม policy infra ของทีมและทดสอบร่วมกับ load test ก่อนใช้จริง
+
+```bash
+ulimit -n 200000
+sysctl -w net.core.somaxconn=65535
+sysctl -w net.ipv4.tcp_tw_reuse=1
+```
+
+```bash
+GOMAXPROCS=auto
+GOGC=100
+```
+
+## Notes
+
+- ตัวเลข 50k/node เป็น target เชิงสถาปัตยกรรม ไม่ใช่ SLA ตายตัว
+- ควรทำ load test ตาม workload จริง (จำนวน rooms, fanout ratio, payload size, burst pattern)
+- แนะนำเก็บ metrics เพิ่ม: queue depth, disconnect reason, p95/p99 write latency, dropped message count

--- a/ws_gateway/go.mod
+++ b/ws_gateway/go.mod
@@ -1,0 +1,5 @@
+module aetherium/ws_gateway
+
+go 1.22
+
+require github.com/gorilla/websocket v1.5.3

--- a/ws_gateway/go.sum
+++ b/ws_gateway/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/ws_gateway/id.go
+++ b/ws_gateway/id.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+var idCounter atomic.Uint64
+
+func generateID() string {
+	next := idCounter.Add(1)
+	return fmt.Sprintf("c-%d-%d", time.Now().UnixNano(), next)
+}

--- a/ws_gateway/main.go
+++ b/ws_gateway/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin:     func(_ *http.Request) bool { return true },
+}
+
+func main() {
+	cfg := loadConfig()
+	server := NewServer(cfg)
+
+	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			log.Printf("upgrade error: %v", err)
+			return
+		}
+
+		room := r.URL.Query().Get("room")
+		if room == "" {
+			room = "default"
+		}
+
+		server.HandleConnection(conn, room)
+	})
+
+	httpServer := &http.Server{
+		Addr:         cfg.ListenAddr,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	go server.Run()
+
+	go func() {
+		log.Printf("WebSocket server running on %s", cfg.ListenAddr)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("http server error: %v", err)
+		}
+	}()
+
+	shutdownCh := make(chan os.Signal, 1)
+	signal.Notify(shutdownCh, syscall.SIGINT, syscall.SIGTERM)
+	<-shutdownCh
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := httpServer.Shutdown(ctx); err != nil {
+		log.Printf("shutdown error: %v", err)
+	}
+
+	server.Stop()
+}
+
+type Config struct {
+	ListenAddr string
+	Shards     int
+}
+
+func loadConfig() Config {
+	listenAddr := getenv("WS_LISTEN_ADDR", ":8080")
+	shards := getenvInt("WS_ROOM_SHARDS", 32)
+	if shards <= 0 {
+		shards = 32
+	}
+
+	return Config{ListenAddr: listenAddr, Shards: shards}
+}
+
+func getenv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+func getenvInt(key string, fallback int) int {
+	if value, ok := os.LookupEnv(key); ok {
+		parsed, err := strconv.Atoi(value)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}

--- a/ws_gateway/server.go
+++ b/ws_gateway/server.go
@@ -231,7 +231,7 @@ func (s *Server) broadcastToRoom(msg Message) {
 		case client.send <- msg.Data:
 		default:
 			// backpressure policy: disconnect slow consumer
-			s.unregister <- client
+			_ = client.conn.Close()
 		}
 	}
 }

--- a/ws_gateway/server.go
+++ b/ws_gateway/server.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"errors"
+	"hash/fnv"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	writeWait      = 10 * time.Second
+	pongWait       = 60 * time.Second
+	pingPeriod     = 30 * time.Second
+	maxMessageSize = 1024
+	sendBufferSize = 256
+)
+
+type Message struct {
+	Room string
+	Data []byte
+}
+
+type Client struct {
+	id   string
+	room string
+	conn *websocket.Conn
+	send chan []byte
+
+	lastSeen atomic.Int64
+}
+
+type BusPublisher interface {
+	Publish(msg Message) error
+}
+
+type RoomShard struct {
+	mu    sync.RWMutex
+	rooms map[string]map[string]*Client
+}
+
+type Server struct {
+	clientsMu sync.RWMutex
+	clients   map[string]*Client
+
+	shards []RoomShard
+
+	register   chan *Client
+	unregister chan *Client
+	broadcast  chan Message
+
+	quit      chan struct{}
+	closeOnce sync.Once
+
+	publisher BusPublisher
+}
+
+func NewServer(cfg Config) *Server {
+	shards := make([]RoomShard, cfg.Shards)
+	for i := range shards {
+		shards[i] = RoomShard{rooms: make(map[string]map[string]*Client)}
+	}
+
+	return &Server{
+		clients:    make(map[string]*Client),
+		shards:     shards,
+		register:   make(chan *Client, 1_000),
+		unregister: make(chan *Client, 1_000),
+		broadcast:  make(chan Message, 10_000),
+		quit:       make(chan struct{}),
+	}
+}
+
+func (s *Server) SetPublisher(publisher BusPublisher) {
+	s.publisher = publisher
+}
+
+func (s *Server) Run() {
+	for {
+		select {
+		case <-s.quit:
+			return
+		case client := <-s.register:
+			s.addClient(client)
+		case client := <-s.unregister:
+			s.removeClient(client)
+		case msg := <-s.broadcast:
+			s.broadcastToRoom(msg)
+			if err := s.PublishToBus(msg); err != nil {
+				log.Printf("event bus publish error: %v", err)
+			}
+		}
+	}
+}
+
+func (s *Server) Stop() {
+	s.closeOnce.Do(func() {
+		close(s.quit)
+		s.clientsMu.Lock()
+		defer s.clientsMu.Unlock()
+		for _, client := range s.clients {
+			close(client.send)
+			_ = client.conn.Close()
+		}
+	})
+}
+
+func (s *Server) HandleConnection(conn *websocket.Conn, room string) {
+	client := &Client{
+		id:   generateID(),
+		room: room,
+		conn: conn,
+		send: make(chan []byte, sendBufferSize),
+	}
+	client.lastSeen.Store(time.Now().Unix())
+
+	s.register <- client
+
+	go s.readPump(client)
+	go s.writePump(client)
+}
+
+func (s *Server) readPump(c *Client) {
+	defer func() {
+		s.unregister <- c
+		_ = c.conn.Close()
+	}()
+
+	c.conn.SetReadLimit(maxMessageSize)
+	_ = c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	c.conn.SetPongHandler(func(_ string) error {
+		c.lastSeen.Store(time.Now().Unix())
+		return c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	})
+
+	for {
+		_, message, err := c.conn.ReadMessage()
+		if err != nil {
+			break
+		}
+
+		c.lastSeen.Store(time.Now().Unix())
+		s.broadcast <- Message{Room: c.room, Data: message}
+	}
+}
+
+func (s *Server) writePump(c *Client) {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		_ = c.conn.Close()
+	}()
+
+	for {
+		select {
+		case msg, ok := <-c.send:
+			_ = c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				_ = c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+			if err := c.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+				return
+			}
+		case <-ticker.C:
+			_ = c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (s *Server) addClient(c *Client) {
+	s.clientsMu.Lock()
+	s.clients[c.id] = c
+	s.clientsMu.Unlock()
+
+	shard := s.shardForRoom(c.room)
+	shard.mu.Lock()
+	if _, ok := shard.rooms[c.room]; !ok {
+		shard.rooms[c.room] = make(map[string]*Client)
+	}
+	shard.rooms[c.room][c.id] = c
+	shard.mu.Unlock()
+}
+
+func (s *Server) removeClient(c *Client) {
+	s.clientsMu.Lock()
+	if _, exists := s.clients[c.id]; !exists {
+		s.clientsMu.Unlock()
+		return
+	}
+	delete(s.clients, c.id)
+	s.clientsMu.Unlock()
+
+	shard := s.shardForRoom(c.room)
+	shard.mu.Lock()
+	if roomClients, ok := shard.rooms[c.room]; ok {
+		delete(roomClients, c.id)
+		if len(roomClients) == 0 {
+			delete(shard.rooms, c.room)
+		}
+	}
+	shard.mu.Unlock()
+
+	close(c.send)
+}
+
+func (s *Server) broadcastToRoom(msg Message) {
+	shard := s.shardForRoom(msg.Room)
+
+	shard.mu.RLock()
+	roomClients, ok := shard.rooms[msg.Room]
+	if !ok || len(roomClients) == 0 {
+		shard.mu.RUnlock()
+		return
+	}
+
+	clients := make([]*Client, 0, len(roomClients))
+	for _, client := range roomClients {
+		clients = append(clients, client)
+	}
+	shard.mu.RUnlock()
+
+	for _, client := range clients {
+		select {
+		case client.send <- msg.Data:
+		default:
+			// backpressure policy: disconnect slow consumer
+			s.unregister <- client
+		}
+	}
+}
+
+func (s *Server) PublishToBus(msg Message) error {
+	if s.publisher == nil {
+		return nil
+	}
+	return s.publisher.Publish(msg)
+}
+
+func (s *Server) HandleAIEvent(event []byte, room string) error {
+	select {
+	case s.broadcast <- Message{Room: room, Data: event}:
+		return nil
+	default:
+		return errors.New("broadcast queue is saturated")
+	}
+}
+
+func (s *Server) shardForRoom(room string) *RoomShard {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(room))
+	index := h.Sum32() % uint32(len(s.shards))
+	return &s.shards[index]
+}

--- a/ws_gateway/server.go
+++ b/ws_gateway/server.go
@@ -59,10 +59,10 @@ type Server struct {
 }
 
 func NewServer(cfg Config) *Server {
-	shards := make([]RoomShard, cfg.Shards)
-	for i := range shards {
-		shards[i] = RoomShard{rooms: make(map[string]map[string]*Client)}
+	if cfg.Shards <= 0 {
+		cfg.Shards = 32
 	}
+	shards := make([]RoomShard, cfg.Shards)
 
 	return &Server{
 		clients:    make(map[string]*Client),

--- a/ws_gateway/server.go
+++ b/ws_gateway/server.go
@@ -207,7 +207,7 @@ func (s *Server) removeClient(c *Client) {
 	}
 	shard.mu.Unlock()
 
-	close(c.send)
+	c.close()
 }
 
 func (s *Server) broadcastToRoom(msg Message) {


### PR DESCRIPTION
### Motivation

- Provide a scalable low-latency WebSocket fanout runtime capable of handling very large connection counts (~50k/node) using the Go netpoll/goroutine model. 
- Reduce lock contention and improve fanout throughput via room sharding, while enforcing backpressure and heartbeat-based liveness to keep the runtime stable. 
- Expose event-bus hooks so AI-originated events can be injected or published to messaging backends (NATS/Kafka) for integration with the Aetherium runtime.

### Description

- Add a new `ws_gateway/` Go module containing `main.go`, `server.go`, `id.go`, `go.mod`, and `go.sum`. 
- Implement a sharded room registry and central connection registry with `register`/`unregister`/`broadcast` event loop and `shardForRoom` hashing. 
- Implement per-connection `readPump` and `writePump` with ping/pong heartbeats, read/write deadlines, bounded `send` buffers, and backpressure policy that disconnects slow consumers. 
- Add `BusPublisher` interface plus `PublishToBus` and `HandleAIEvent` for event-bus integration and AI event injection, and add `docs/14_WEBSOCKET_RUNTIME_GATEWAY_TH.md` documenting run instructions and production tuning (`WS_LISTEN_ADDR`, `WS_ROOM_SHARDS`).

### Testing

- Ran `cd ws_gateway && go test ./...` which passed (package contains no test files). 
- Ran `npm run lint` which failed due to pre-existing TypeScript lint errors in unrelated files (`governor.ts`, `light-control-language.ts`, `perceptual-feedback.ts`, `shape-compiler.ts`). 
- Ran `cd api_gateway && pytest -q` which failed in this environment because the `httpx` Python dependency is missing. 
- Ran `python3 tools/contracts/contract_checker.py` which also failed for the same missing `httpx` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd6179b5b48320b1343e6227cf79e7)