### PR TITLE
[runtime] Harden startup orchestration and readiness probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,29 @@ uvicorn main:app --host 0.0.0.0 --port 8090 --reload
 
 > Default local ports are `8080` (API) and `8090` (WS) to avoid bind conflicts. Set **API Base** and **WS Base** in the UI panel accordingly.
 
+### 4) One-command local stack startup (hardened)
+
+```bash
+# optional, recommended:
+python3 -m venv .venv && source .venv/bin/activate
+
+# starts API + WS (background) and frontend static host (foreground)
+./start_services.sh
+```
+
+Runtime knobs (environment variables):
+
+- `API_HOST`, `API_PORT`, `API_WORKERS`
+- `WS_HOST`, `WS_PORT`, `START_WS_GATEWAY=0|1`
+- `FRONTEND_HOST`, `FRONTEND_PORT`
+- `LOG_DIR` (default: `./.logs`)
+- `REQUIRE_REDIS_FOR_READINESS=0|1`, `REQUIRE_NATS_FOR_READINESS=0|1`
+
+Health and readiness probes:
+
+- API gateway: `GET /health`, `GET /readyz`
+- WS gateway: `GET /health`, `GET /readyz`
+
 ## Recommended verification
 
 ```bash

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -110,6 +110,8 @@ app.add_middleware(
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 NATS_URL = os.getenv("NATS_URL", "nats://localhost:4222")
 GOVERNOR_SERVICE_URL = os.getenv("GOVERNOR_SERVICE_URL", "http://governor.aetherium.svc.cluster.local")
+REQUIRE_REDIS_FOR_READINESS = os.getenv("REQUIRE_REDIS_FOR_READINESS", "0") == "1"
+REQUIRE_NATS_FOR_READINESS = os.getenv("REQUIRE_NATS_FOR_READINESS", "0") == "1"
 
 # External Clients
 r: Optional[redis.Redis] = None
@@ -491,3 +493,26 @@ def health_check() -> dict[str, Any]:
             "nats": "connected" if nc and nc.is_connected else "disconnected",
         },
     }
+
+
+@app.get("/readyz")
+def readiness_check() -> dict[str, Any]:
+    components = {
+        "redis": "connected" if r else "disconnected",
+        "nats": "connected" if nc and nc.is_connected else "disconnected",
+    }
+    readiness_failures: list[str] = []
+    if REQUIRE_REDIS_FOR_READINESS and components["redis"] != "connected":
+        readiness_failures.append("redis")
+    if REQUIRE_NATS_FOR_READINESS and components["nats"] != "connected":
+        readiness_failures.append("nats")
+    if readiness_failures:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "status": "not_ready",
+                "required_components_unavailable": readiness_failures,
+                "components": components,
+            },
+        )
+    return {"status": "ready", "components": components}

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -20,6 +20,22 @@ def test_health_check(client: TestClient) -> None:
     assert response.json()["status"] == "healthy"
 
 
+def test_readiness_check_default_is_ready_without_brokers(client: TestClient) -> None:
+    response = client.get("/readyz")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ready"
+
+
+def test_readiness_check_respects_required_brokers(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("api_gateway.main.REQUIRE_REDIS_FOR_READINESS", True)
+    monkeypatch.setattr("api_gateway.main.REQUIRE_NATS_FOR_READINESS", True)
+    response = client.get("/readyz")
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["detail"]["status"] == "not_ready"
+    assert set(payload["detail"]["required_components_unavailable"]) == {"redis", "nats"}
+
+
 def test_emit_missing_api_key(client: TestClient) -> None:
     response = client.post("/api/v1/cognitive/emit", json={})
     assert response.status_code == 401

--- a/start_services.sh
+++ b/start_services.sh
@@ -1,7 +1,53 @@
-#!/bin/bash
-echo "Installing dependencies for api-gateway..."
-pip install -r api_gateway/requirements.txt
-echo "Starting api-gateway in the background..."
-uvicorn api_gateway.main:app --host 0.0.0.0 --port 8080 --workers 4 &
-echo "Starting frontend server in the foreground..."
-python3 -m http.server 4173
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+API_HOST="${API_HOST:-0.0.0.0}"
+API_PORT="${API_PORT:-8080}"
+WS_HOST="${WS_HOST:-0.0.0.0}"
+WS_PORT="${WS_PORT:-8090}"
+FRONTEND_HOST="${FRONTEND_HOST:-0.0.0.0}"
+FRONTEND_PORT="${FRONTEND_PORT:-4173}"
+API_WORKERS="${API_WORKERS:-2}"
+START_WS_GATEWAY="${START_WS_GATEWAY:-1}"
+LOG_DIR="${LOG_DIR:-${ROOT_DIR}/.logs}"
+
+mkdir -p "${LOG_DIR}"
+
+if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+  python -m pip install -r "${ROOT_DIR}/api_gateway/requirements.txt" -r "${ROOT_DIR}/ws_gateway/requirements.txt"
+else
+  echo "WARNING: no virtualenv active. Installing dependencies into current interpreter." >&2
+  python3 -m pip install -r "${ROOT_DIR}/api_gateway/requirements.txt" -r "${ROOT_DIR}/ws_gateway/requirements.txt"
+fi
+
+echo "Starting api-gateway on ${API_HOST}:${API_PORT} (${API_WORKERS} workers)"
+uvicorn api_gateway.main:app \
+  --host "${API_HOST}" \
+  --port "${API_PORT}" \
+  --workers "${API_WORKERS}" \
+  > "${LOG_DIR}/api_gateway.log" 2>&1 &
+API_PID=$!
+
+WS_PID=""
+if [[ "${START_WS_GATEWAY}" == "1" ]]; then
+  echo "Starting ws-gateway on ${WS_HOST}:${WS_PORT}"
+  uvicorn ws_gateway.main:app \
+    --host "${WS_HOST}" \
+    --port "${WS_PORT}" \
+    > "${LOG_DIR}/ws_gateway.log" 2>&1 &
+  WS_PID=$!
+fi
+
+cleanup() {
+  echo "Shutting down services..."
+  kill "${API_PID}" 2>/dev/null || true
+  if [[ -n "${WS_PID}" ]]; then
+    kill "${WS_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+echo "Starting frontend static server on ${FRONTEND_HOST}:${FRONTEND_PORT}"
+python3 -m http.server "${FRONTEND_PORT}" --bind "${FRONTEND_HOST}"

--- a/ws_gateway/main.py
+++ b/ws_gateway/main.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from fastapi import FastAPI, Header, Query, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Header, HTTPException, Query, WebSocket, WebSocketDisconnect
 import redis.asyncio as redis
 
 app = FastAPI(title="Aetherium WS Gateway")
@@ -13,6 +13,7 @@ logger = logging.getLogger("ws-gateway")
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 STATE_SYNC_STREAM_MAXLEN = int(os.getenv("STATE_SYNC_STREAM_MAXLEN", "1000"))
 REPLAY_BATCH_LIMIT = int(os.getenv("STATE_SYNC_REPLAY_BATCH_LIMIT", "256"))
+REQUIRE_REDIS_FOR_READINESS = os.getenv("REQUIRE_REDIS_FOR_READINESS", "1") == "1"
 r: Optional[redis.Redis] = None
 
 SCHEMA_VERSION = "room_event.v1"
@@ -42,6 +43,32 @@ async def startup() -> None:
         r = redis.from_url(REDIS_URL, decode_responses=True)
     except Exception:
         logger.exception("ws-gateway startup failed")
+
+
+@app.get("/health")
+def health_check() -> dict[str, Any]:
+    return {
+        "status": "healthy",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "components": {
+            "redis": "connected" if r else "disconnected",
+        },
+    }
+
+
+@app.get("/readyz")
+def readiness_check() -> dict[str, Any]:
+    components = {"redis": "connected" if r else "disconnected"}
+    if REQUIRE_REDIS_FOR_READINESS and components["redis"] != "connected":
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "status": "not_ready",
+                "required_components_unavailable": ["redis"],
+                "components": components,
+            },
+        )
+    return {"status": "ready", "components": components}
 
 
 async def _authorize(websocket: WebSocket, api_key: Optional[str], x_api_key: Optional[str]) -> bool:

--- a/ws_gateway/test_ws_gateway.py
+++ b/ws_gateway/test_ws_gateway.py
@@ -39,6 +39,27 @@ def client() -> TestClient:
     return TestClient(app)
 
 
+def test_health_endpoint(client: TestClient) -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+
+
+def test_readiness_endpoint_ready_when_redis_is_available(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("ws_gateway.main.REQUIRE_REDIS_FOR_READINESS", True)
+    response = client.get("/readyz")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ready"
+
+
+def test_readiness_endpoint_fails_when_redis_is_required_and_unavailable(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("ws_gateway.main.REQUIRE_REDIS_FOR_READINESS", True)
+    monkeypatch.setattr(main, "r", None)
+    response = client.get("/readyz")
+    assert response.status_code == 503
+    assert response.json()["detail"]["status"] == "not_ready"
+
+
 def test_websocket_stream_missing_key(client: TestClient) -> None:
     with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect('/ws/cognitive-stream'):


### PR DESCRIPTION
### Motivation

- Make the local developer "one-command" stack practical and robust with configurable hosts/ports, per-service logs and graceful shutdown. 
- Provide explicit readiness gates so probes can enforce broker dependency availability (Redis/NATS) before traffic is accepted. 

### Description

- Hardened `start_services.sh` with `set -euo pipefail`, environment knobs (`API_HOST`, `API_PORT`, `API_WORKERS`, `WS_HOST`, `WS_PORT`, `START_WS_GATEWAY`, `LOG_DIR`), per-service log files, optional WS startup, and cleanup trap to terminate background processes. 
- Added readiness endpoint to API gateway: `GET /readyz` and env-driven dependency requirements `REQUIRE_REDIS_FOR_READINESS` and `REQUIRE_NATS_FOR_READINESS`. 
- Added `GET /health` and `GET /readyz` to WS gateway with `REQUIRE_REDIS_FOR_READINESS` support and explicit HTTP 503 when required components are unavailable. 
- Updated tests (`api_gateway/test_api.py` and `ws_gateway/test_ws_gateway.py`) to cover health/readiness behaviors and updated README with a one-command local stack startup and runtime knobs. 

### Testing

- Ran `pytest -q api_gateway/test_api.py ws_gateway/test_ws_gateway.py` and the adapted gateway tests passed (31 passed). 
- Ran the full API suite with `cd api_gateway && pytest -q` which failed due to pre-existing runtime/contract-related test failures unrelated to these readiness/startup changes (12 failing tests reported). 
- Ran `python3 tools/contracts/contract_checker.py` which reported existing schema-vs-runtime drift failures. 
- Ran `npm run lint` which reported existing TypeScript lint errors in unrelated frontend files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfec3bb4d08320b5ec86dbbc1c01e6)