### PR TITLE
[api_gateway] Fix export audit trail bounded deque writes

### DIFF
--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -5,6 +5,7 @@ import uuid
 import logging
 import hmac
 import hashlib
+from collections import deque
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional, Union
 from enum import Enum
@@ -100,6 +101,11 @@ class TelemetryPoint(BaseModel):
 class TelemetryIngestRequest(BaseModel):
     points: list[TelemetryPoint]
 
+
+class ExportRequest(BaseModel):
+    session_id: str
+    reason: str | None = None
+
 # --- Validation ---
 
 class FirmaValidator:
@@ -133,6 +139,7 @@ GOVERNOR_SERVICE_URL = os.getenv("GOVERNOR_SERVICE_URL", "http://governor.aether
 r: Optional[redis.Redis] = None
 nc: Optional[nats.NATS] = None
 NONCE_CACHE: Dict[str, bool] = {}
+EXPORT_AUDIT_TRAIL: deque[dict[str, Any]] = deque(maxlen=1000)
 
 @app.on_event("startup")
 async def startup():
@@ -339,6 +346,26 @@ async def ingest_telemetry(
                 await r.lpush("telemetry:queue", json.dumps(point.model_dump(mode="json")))
         except Exception: pass
     return {"status": "success", "inserted": len(request.points)}
+
+
+@app.post("/api/v1/export/request")
+async def request_export(
+    request: ExportRequest,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+) -> dict[str, Any]:
+    _ensure_api_key(x_api_key)
+    audit_record = {
+        "export_id": str(uuid.uuid4()),
+        "session_id": request.session_id,
+        "reason": request.reason,
+        "requested_at": datetime.now(timezone.utc).isoformat(),
+    }
+    EXPORT_AUDIT_TRAIL.appendleft(audit_record)
+    return {
+        "status": "queued",
+        "data": audit_record,
+        "export_history_size": len(EXPORT_AUDIT_TRAIL),
+    }
 
 @app.get("/api/v1/proxy/fetch")
 async def proxy_fetch(


### PR DESCRIPTION
### Motivation
- Prevent export request handlers from failing with `IndexError` when the in-memory audit backlog is at capacity by using deque-native prepend semantics so capped retention evicts oldest entries without raising on write.

### Description
- Import `deque` and add an in-memory bounded audit trail `EXPORT_AUDIT_TRAIL: deque[dict[str, Any]] = deque(maxlen=1000)` to the gateway runtime.
- Add an `ExportRequest` Pydantic model and a new `POST /api/v1/export/request` endpoint which builds an `audit_record` and uses `EXPORT_AUDIT_TRAIL.appendleft(audit_record)` to safely prepend records while preserving newest-first ordering and automatic eviction.

### Testing
- Verified with a `TestClient` loop (run with `AETHERIUM_API_KEY=test-key`) that posting 1002 export requests succeeds and that `len(EXPORT_AUDIT_TRAIL) == 1000` with newest-first ordering.
- Ran `pytest -q api_gateway/test_api.py`, which showed failures unrelated to this change caused by the test environment not having `AETHERIUM_API_KEY` set to the expected value; `npm run lint` also fails in this environment due to a missing ESLint v9 flat config in the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e01760fa388320ac101e7c6828dca2)