### PR TITLE
Add export audit trail endpoints and in-memory audit deque

### DIFF
--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -362,7 +362,7 @@ async def request_export(
     }
     EXPORT_AUDIT_TRAIL.appendleft(audit_record)
     return {
-        "status": "queued",
+        "status": "recorded",
         "data": audit_record,
         "export_history_size": len(EXPORT_AUDIT_TRAIL),
     }

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -5,6 +5,7 @@ import uuid
 import logging
 import hmac
 import hashlib
+from collections import deque
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional, Union
 from enum import Enum
@@ -100,6 +101,11 @@ class TelemetryPoint(BaseModel):
 class TelemetryIngestRequest(BaseModel):
     points: list[TelemetryPoint]
 
+
+class ExportRequest(BaseModel):
+    session_id: str
+    reason: str | None = None
+
 # --- Validation ---
 
 class FirmaValidator:
@@ -133,6 +139,7 @@ GOVERNOR_SERVICE_URL = os.getenv("GOVERNOR_SERVICE_URL", "http://governor.aether
 r: Optional[redis.Redis] = None
 nc: Optional[nats.NATS] = None
 NONCE_CACHE: Dict[str, bool] = {}
+EXPORT_AUDIT_TRAIL: deque[dict[str, Any]] = deque(maxlen=1000)
 
 @app.on_event("startup")
 async def startup():
@@ -339,6 +346,42 @@ async def ingest_telemetry(
                 await r.lpush("telemetry:queue", json.dumps(point.model_dump(mode="json")))
         except Exception: pass
     return {"status": "success", "inserted": len(request.points)}
+
+
+@app.post("/api/v1/export/request")
+async def request_export(
+    request: ExportRequest,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+) -> dict[str, Any]:
+    _ensure_api_key(x_api_key)
+    audit_record = {
+        "export_id": str(uuid.uuid4()),
+        "session_id": request.session_id,
+        "reason": request.reason,
+        "requested_at": datetime.now(timezone.utc).isoformat(),
+    }
+    EXPORT_AUDIT_TRAIL.appendleft(audit_record)
+    return {
+        "status": "queued",
+        "data": audit_record,
+        "export_history_size": len(EXPORT_AUDIT_TRAIL),
+    }
+
+
+@app.get("/api/v1/export/history")
+async def get_export_history(
+    limit: int = 100,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+) -> dict[str, Any]:
+    _ensure_api_key(x_api_key)
+    safe_limit = max(1, min(limit, 1000))
+    history = list(EXPORT_AUDIT_TRAIL)[:safe_limit]
+    return {
+        "status": "success",
+        "data": history,
+        "count": len(history),
+        "total_history_size": len(EXPORT_AUDIT_TRAIL),
+    }
 
 @app.get("/api/v1/proxy/fetch")
 async def proxy_fetch(


### PR DESCRIPTION
### Motivation
- Provide a simple export-requesting API and an in-memory audit trail for tracking export requests and reasons.
- Enable lightweight querying of recent exports without depending on external storage for short-term history.
- Ensure requests are authenticated via the existing `X-API-Key` check.

### Description
- Added `ExportRequest` Pydantic model and imported `deque` to maintain an in-memory audit trail as `EXPORT_AUDIT_TRAIL = deque(maxlen=1000)`.
- Implemented POST `/api/v1/export/request` which validates the API key, records an `export_id`, `session_id`, `reason`, and timestamp, and appends the record to the audit deque.
- Implemented GET `/api/v1/export/history` which validates the API key and returns up to `limit` recent audit records along with counts and total history size.
- Kept existing authentication by calling `_ensure_api_key` in both endpoints and used `uuid.uuid4()` and `datetime.now(timezone.utc).isoformat()` for identifiers and timestamps.

### Testing
- No automated tests were added for the new endpoints as part of this change.
- No existing automated test suite was executed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e01760fa388320ac101e7c6828dca2)