### PR TITLE
Add export audit endpoints with in-memory audit trail

### DIFF
--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -350,21 +350,21 @@ async def ingest_telemetry(
 
 @app.post("/api/v1/export/request")
 async def request_export(
-    request: ExportRequest,
+    payload: ExportRequest,
     x_api_key: str | None = Header(default=None, alias="X-API-Key"),
 ) -> dict[str, Any]:
     _ensure_api_key(x_api_key)
     audit_record = {
         "export_id": str(uuid.uuid4()),
-        "session_id": request.session_id,
-        "reason": request.reason,
+        "session_id": payload.session_id,
+        "reason": payload.reason,
         "requested_at": datetime.now(timezone.utc).isoformat(),
     }
     EXPORT_AUDIT_TRAIL.appendleft(audit_record)
     return {
-        "status": "recorded",
+        "status": "success",
         "data": audit_record,
-        "export_history_size": len(EXPORT_AUDIT_TRAIL),
+        "total_history_size": len(EXPORT_AUDIT_TRAIL),
     }
 
 

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -5,6 +5,7 @@ import uuid
 import logging
 import hmac
 import hashlib
+from collections import deque
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional, Union
 from enum import Enum
@@ -100,6 +101,11 @@ class TelemetryPoint(BaseModel):
 class TelemetryIngestRequest(BaseModel):
     points: list[TelemetryPoint]
 
+
+class ExportRequest(BaseModel):
+    session_id: str
+    reason: str | None = None
+
 # --- Validation ---
 
 class FirmaValidator:
@@ -133,6 +139,7 @@ GOVERNOR_SERVICE_URL = os.getenv("GOVERNOR_SERVICE_URL", "http://governor.aether
 r: Optional[redis.Redis] = None
 nc: Optional[nats.NATS] = None
 NONCE_CACHE: Dict[str, bool] = {}
+EXPORT_AUDIT_TRAIL: deque[dict[str, Any]] = deque(maxlen=1000)
 
 @app.on_event("startup")
 async def startup():
@@ -339,6 +346,42 @@ async def ingest_telemetry(
                 await r.lpush("telemetry:queue", json.dumps(point.model_dump(mode="json")))
         except Exception: pass
     return {"status": "success", "inserted": len(request.points)}
+
+
+@app.post("/api/v1/export/request")
+async def request_export(
+    request: ExportRequest,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+) -> dict[str, Any]:
+    _ensure_api_key(x_api_key)
+    audit_record = {
+        "export_id": str(uuid.uuid4()),
+        "session_id": request.session_id,
+        "reason": request.reason,
+        "requested_at": datetime.now(timezone.utc).isoformat(),
+    }
+    EXPORT_AUDIT_TRAIL.appendleft(audit_record)
+    return {
+        "status": "recorded",
+        "data": audit_record,
+        "export_history_size": len(EXPORT_AUDIT_TRAIL),
+    }
+
+
+@app.get("/api/v1/export/history")
+async def get_export_history(
+    limit: int = 100,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+) -> dict[str, Any]:
+    _ensure_api_key(x_api_key)
+    safe_limit = max(1, min(limit, 1000))
+    history = list(EXPORT_AUDIT_TRAIL)[:safe_limit]
+    return {
+        "status": "success",
+        "data": history,
+        "count": len(history),
+        "total_history_size": len(EXPORT_AUDIT_TRAIL),
+    }
 
 @app.get("/api/v1/proxy/fetch")
 async def proxy_fetch(


### PR DESCRIPTION
### Motivation

- Provide a simple, auditable way to record and retrieve export requests linked to sessions for operational traceability.

### Description

- Added an `ExportRequest` Pydantic model and an in-memory `EXPORT_AUDIT_TRAIL` using `collections.deque` with `maxlen=1000` to store recent export records.
- Implemented `POST /api/v1/export/request` to record an export request and return an `export_id`, `session_id`, `reason`, and timestamp, and to prepend the record into `EXPORT_AUDIT_TRAIL`.
- Implemented `GET /api/v1/export/history` to return a paginated view of the most recent audit records with a `limit` parameter and bounds checking (`1..1000`).
- Added necessary imports and ensured both endpoints enforce API key validation via the existing `_ensure_api_key` check and use `uuid.uuid4()` and `datetime.now(timezone.utc)` for identifiers and timestamps.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e01760fa388320ac101e7c6828dca2)