### PR TITLE
[api_gateway] Replace deprecated startup hook and tighten README audit guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Aetherium Manifest is now positioned as a creative operating surface where users
 
 Core embodiment remains a **full-screen light body + bottom composer**, now expanded with governed manifestation states, replayable lineage controls, and multimodal input affordances.
 
-## What's updated (April 2026)
+## What’s updated (April 2026)
 
-- `index.html` is now a fully runnable **runtime console** that works end-to-end with:
+- `index.html` is now a fully runnable **runtime console** that runs end-to-end with:
   - `POST /api/v1/cognitive/emit`
   - `POST /api/v1/cognitive/validate`
   - `POST /api/v1/cognitive/generate`
@@ -30,11 +30,11 @@ Core embodiment remains a **full-screen light body + bottom composer**, now expa
   - `GET /api/v1/reliability/temporal-morphogenesis`
   - `WS /ws/state-sync/{room_id}` (via `ws_gateway`)
   - `WS /ws/cognitive-stream` (via `ws_gateway`)
-- Runtime HUD now exposes state/resonance/entropy with terminal-grade governor checkpoints.
+- The Runtime HUD now exposes state/resonance/entropy with terminal-grade governor checkpoints.
 - Composer now supports **Attach + Voice + EMIT** inside a glassmorphism shell for light-native interaction.
-- Governed manifestation loop is visible in UI (`Contract Proposed -> Governor Verification -> Manifest`).
+- The governed manifestation loop is visible in the UI (`Contract Proposed -> Governor Verification -> Manifest`).
 - Replayable **Design Lineage Tree** enables time-shift, branch pruning, and iterative exploration.
-- Scholar side panel (`AKASHIC SEARCH`) presents mock search summaries and source-trust status.
+- The Scholar side panel (`AKASHIC SEARCH`) presents mock search summaries and source-trust status.
 
 ## Architecture (current)
 
@@ -125,7 +125,8 @@ npm run lint
 - Active audit backlogs are maintained in:
   - `docs/CODEBASE_AUDIT_TASKS_EN.md`
   - `docs/CODEBASE_AUDIT_TASKS_TH.md`
-- Both files must keep **pending items only**. Completed recommendations should be removed to avoid mixing finished work with active tasks.
+- Both files must keep **pending items only**. Completed recommendations must be removed (in both English and Thai) to avoid mixing finished work with active tasks.
+- Current status: both backlog files report **no pending tasks** as of April 16, 2026.
 
 ## Notes on runtime security defaults
 

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -226,7 +226,7 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
-        if nc and nc.is_connected:
+        if nc:
             try:
                 await nc.close()
             except Exception:

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -10,6 +10,7 @@ import ipaddress
 from urllib.parse import urlparse
 from collections import deque
 from datetime import datetime, timezone
+from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Literal, Optional, Union
 from enum import Enum
 
@@ -208,9 +209,36 @@ class FirmaValidator:
 
 # --- App Initialization ---
 
-app = FastAPI(title="Aetherium API Gateway")
-app.include_router(scholar_router)
 logger = logging.getLogger("api-gateway")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global r, nc
+    if not os.getenv("AETHERIUM_API_KEY"):
+        logger.error("AETHERIUM_API_KEY is not configured; protected endpoints will fail closed")
+    try:
+        r = redis.from_url(REDIS_URL, decode_responses=True)
+        nc = await nats.connect(NATS_URL)
+        logger.info("Connected to Redis and NATS")
+    except Exception as e:
+        logger.error(f"Startup failed: {e}")
+
+    try:
+        yield
+    finally:
+        if nc and nc.is_connected:
+            try:
+                await nc.close()
+            except Exception:
+                logger.exception("Failed to close NATS connection cleanly")
+        if r:
+            try:
+                await r.aclose()
+            except Exception:
+                logger.exception("Failed to close Redis connection cleanly")
+
+app = FastAPI(title="Aetherium API Gateway", lifespan=lifespan)
+app.include_router(scholar_router)
 
 app.add_middleware(
     CORSMiddleware,
@@ -305,18 +333,6 @@ def _is_blocked_proxy_target(hostname: str) -> bool:
             return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved
         except Exception:
             return True
-
-@app.on_event("startup")
-async def startup():
-    global r, nc
-    if not os.getenv("AETHERIUM_API_KEY"):
-        logger.error("AETHERIUM_API_KEY is not configured; protected endpoints will fail closed")
-    try:
-        r = redis.from_url(REDIS_URL, decode_responses=True)
-        nc = await nats.connect(NATS_URL)
-        logger.info("Connected to Redis and NATS")
-    except Exception as e:
-        logger.error(f"Startup failed: {e}")
 
 # --- Helper Functions ---
 


### PR DESCRIPTION
### Motivation
- Remove a deprecated FastAPI startup pattern and eliminate associated deprecation warnings during test runs. 
- Ensure runtime clients (NATS/Redis) are closed cleanly on shutdown to avoid leaking connections. 
- Improve README clarity and explicitly state audit backlog hygiene for both English and Thai documents.

### Description
- Replaced the `@app.on_event("startup")` pattern in `api_gateway/main.py` with a FastAPI `lifespan` handler using `@asynccontextmanager` and added graceful shutdown cleanup for `nc` (NATS) and `r` (Redis). 
- Imported `asynccontextmanager` and adjusted `FastAPI(...)` initialization to pass `lifespan=lifespan` so startup/shutdown logic is modernized. 
- Removed the old `startup` function and preserved existing behavior such as API key fail-closed logging while improving operational resiliency. 
- Updated `README.md` wording for grammar/clarity and tightened audit backlog guidance to require pending-only items for both `docs/CODEBASE_AUDIT_TASKS_EN.md` and `docs/CODEBASE_AUDIT_TASKS_TH.md`, adding a current-status note.

### Testing
- Ran `cd api_gateway && pytest -q` and all tests passed (`68 passed`). 
- Ran `python3 tools/contracts/contract_checker.py` and schema/contract audits passed. 
- Ran `npm run lint` and the web lint step completed without warnings beyond an unrelated npm env notice.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09dcba4b483209dc6263abc9bc772)