### PR TITLE
docs: remove completed roadmap items and consolidate pending recommendations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Aetherium Manifest คือเลเยอร์แสดงผลฝั่ง 
 โฟลเดอร์ `api_gateway/` มีตัวอย่าง Cognitive DSL gateway พร้อม endpoint สำหรับ emit/validate/health/websocket
 
 ### แนวทางต่อยอด (ค้างดำเนินการ)
-- ย้าย mutable runtime state ไป Redis (metrics counters, telemetry cache และ WebSocket room membership) เพื่อรองรับหลาย worker ได้สม่ำเสมอ
+- ย้าย mutable runtime state ไป Redis (metrics counters, telemetry cache และ WebSocket room membership) เพื่อความสอดคล้องของข้อมูล (consistency) เมื่อใช้งานหลาย worker
 - เพิ่มนโยบาย signed outbound proxy (HMAC request intent + per-tenant allowlist) เพื่อเสริมความแข็งแรงด้าน SSRF ระดับองค์กร
 - สร้าง contract-fuzz pipeline: ตัวสร้าง payload แบบ property-based + mutation corpus สำหรับ stress test schema regression
 - เพิ่ม TSDB แบบ persisted (InfluxDB/TimescaleDB) พร้อม retention และ downsampling policies

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Aetherium Manifest คือเลเยอร์แสดงผลฝั่ง 
 - ย้าย mutable runtime state ไป Redis (metrics counters, telemetry cache และ WebSocket room membership) เพื่อความสอดคล้องของข้อมูล (consistency) เมื่อใช้งานหลาย worker
 - เพิ่มนโยบาย signed outbound proxy (HMAC request intent + per-tenant allowlist) เพื่อเสริมความแข็งแรงด้าน SSRF ระดับองค์กร
 - สร้าง contract-fuzz pipeline: ตัวสร้าง payload แบบ property-based + mutation corpus สำหรับ stress test schema regression
-- เพิ่ม TSDB แบบ persisted (InfluxDB/TimescaleDB) พร้อม retention และ downsampling policies
+- เพิ่ม TSDB แบบ persisted (InfluxDB/TimescaleDB) พร้อมนโยบายการเก็บรักษา (retention) และการลดความละเอียดข้อมูล (downsampling)
 - เพิ่ม proxy allowlist/denylist พร้อม guardrails ด้าน content-type และขนาดข้อมูล เพื่อเพิ่มความปลอดภัยจาก SSRF
 - เพิ่ม locale QA checks ใน CI (ตัวสแกน missing key + pseudolocale)
 - เพิ่ม voice A/B routing และเก็บตัวชี้วัด WER/latency แยกตาม language-region cohort

--- a/README.md
+++ b/README.md
@@ -46,16 +46,15 @@ python3 -m http.server 4173
 # open http://localhost:4173
 ```
 
-### Recommended Next Steps
-- ✅ Proxy fetch upgraded to async `httpx` with SSRF guardrails (host allowlist + private/link-local/loopback/rfc-reserved IP blocking).
-- ✅ Mutable runtime states are protected with `asyncio.Lock` (metrics, telemetry store, and state-sync rooms) to ensure concurrency safety.
-- ✅ Contract checker now uses `jsonschema` and keeps payload fixtures immutable during validation (audit-only fallback hints).
-- ✅ Browser URL analysis now routes through server-side proxy endpoint `/api/v1/proxy/fetch` to reduce CORS issues.
-- ✅ Telemetry pipeline now ingests to in-memory time-series storage via `/api/v1/telemetry/ingest` and aggregates via `/api/v1/telemetry/query`.
-- ✅ i18n now uses dynamic locale bundles in `locales/*.json`.
-- ✅ Voice model resolution now supports language-region mapping via `/api/v1/voice/model`, with region selector in Settings.
-- ✅ Deterministic multi-user state synchronization is available via `/ws/state-sync/{room_id}`.
-- ✅ Runtime quality tests were updated to match immutable contract-check behavior and async telemetry endpoints.
+### Recommended Next Steps (Pending)
+- Move mutable runtime state to Redis (metrics counters, telemetry cache, and WebSocket room membership) for multi-worker consistency.
+- Add a signed outbound proxy policy (HMAC request intent + per-tenant allowlist) to strengthen enterprise SSRF controls.
+- Build a contract-fuzz pipeline: property-based payload generators + mutation corpus for schema regression stress tests.
+- Add a persisted TSDB backend (InfluxDB/TimescaleDB) with retention and downsampling policies.
+- Add proxy allowlist/denylist + content-type and size guardrails for stronger SSRF safety.
+- Add locale QA checks (missing key scanner + pseudolocale) in CI.
+- Add voice A/B routing and collect WER and latency metrics by language-region cohort.
+- Add CRDT merge (Yjs/Automerge) for conflict-free collaborative editing beyond simple delta updates.
 
 ---
 
@@ -83,24 +82,12 @@ Aetherium Manifest คือเลเยอร์แสดงผลฝั่ง 
 ### API Gateway (ต้นแบบ)
 โฟลเดอร์ `api_gateway/` มีตัวอย่าง Cognitive DSL gateway พร้อม endpoint สำหรับ emit/validate/health/websocket
 
-### แนวทางต่อยอด
-- ✅ อัปเกรด proxy เป็น async (`httpx`) พร้อม SSRF protection (allowlist + block private/link-local/loopback IP)
-- ✅ เพิ่ม asyncio locks ครอบ state ที่แก้ไขได้ เพื่อความปลอดภัยในการทำงานพร้อมกัน
-- ✅ เปลี่ยน contract checker ไปใช้ `jsonschema` และตัด side effects ที่ไปแก้ payload ระหว่างการตรวจสอบ
-- ✅ ทำ URL proxy ฝั่งเซิร์ฟเวอร์ผ่าน `/api/v1/proxy/fetch` เพื่อลดปัญหา CORS
-- ✅ เก็บ telemetry ลง time-series store ผ่าน `/api/v1/telemetry/ingest` และสรุปผลผ่าน `/api/v1/telemetry/query`
-- ✅ ทำ i18n แบบแยกไฟล์ภาษาใน `locales/*.json` และโหลดแบบ dynamic
-- ✅ เลือกโมเดลเสียงตามภาษา/ภูมิภาคผ่าน `/api/v1/voice/model` และตัวเลือกภูมิภาคในหน้า Settings
-- ✅ เพิ่ม state sync แบบ deterministic สำหรับหลายผู้ใช้ด้วย `/ws/state-sync/{room_id}`
-- ✅ ปรับปรุงชุดทดสอบ runtime quality ให้สอดคล้องกับพฤติกรรมใหม่ (contract checker แบบไม่แก้ payload และ telemetry endpoint แบบ async)
-
-
-## Extension Ideas
-- Move mutable runtime state to Redis (metrics counters, telemetry cache, ws room membership) for multi-worker consistency.
-- Add signed outbound proxy policy (HMAC request intent + per-tenant allowlist) to harden enterprise SSRF controls.
-- Build contract-fuzz pipeline: property-based payload generators + mutation corpus for schema regression stress tests.
-- Add persisted TSDB backend (InfluxDB/TimescaleDB) with retention + downsampling policies.
-- Add proxy allowlist/denylist + content-type and size guardrails for stronger SSRF safety.
-- Add locale QA checks (missing key scanner + pseudolocale) in CI.
-- Add voice A/B routing and collect WER / latency metrics by language-region cohort.
-- Add CRDT merge (Yjs/Automerge) for conflict-free collaborative editing beyond simple delta updates.
+### แนวทางต่อยอด (ค้างดำเนินการ)
+- ย้าย mutable runtime state ไป Redis (metrics counters, telemetry cache และ WebSocket room membership) เพื่อรองรับหลาย worker ได้สม่ำเสมอ
+- เพิ่มนโยบาย signed outbound proxy (HMAC request intent + per-tenant allowlist) เพื่อเสริมความแข็งแรงด้าน SSRF ระดับองค์กร
+- สร้าง contract-fuzz pipeline: ตัวสร้าง payload แบบ property-based + mutation corpus สำหรับ stress test schema regression
+- เพิ่ม TSDB แบบ persisted (InfluxDB/TimescaleDB) พร้อม retention และ downsampling policies
+- เพิ่ม proxy allowlist/denylist พร้อม guardrails ด้าน content-type และขนาดข้อมูล เพื่อเพิ่มความปลอดภัยจาก SSRF
+- เพิ่ม locale QA checks ใน CI (ตัวสแกน missing key + pseudolocale)
+- เพิ่ม voice A/B routing และเก็บตัวชี้วัด WER/latency แยกตาม language-region cohort
+- เพิ่ม CRDT merge (Yjs/Automerge) เพื่อแก้ conflict ในการแก้ไขร่วมกันให้ดีกว่า delta update แบบพื้นฐาน


### PR DESCRIPTION
### Motivation
- Keep documentation and backlog hygiene by removing already-completed checklist items so outstanding recommendations are not mixed with finished work.
- Make roadmap status explicit in both English and Thai sections to reduce reader confusion about what remains to be done.

### Description
- Replaced the English "Recommended Next Steps" checked items with a new "Recommended Next Steps (Pending)" list containing only outstanding work and extension ideas.
- Updated the Thai section to mirror the English change as "แนวทางต่อยอด (ค้างดำเนินการ)" and removed completed items there as well.
- Reformatted the lists to remove completed (✅) entries and consolidate pending items for clearer backlog visibility.
- No runtime code changes were made as this PR focuses on documentation hygiene.

### Testing
- Ran `pytest -q` and observed `26 passed` indicating existing automated tests continue to pass after the documentation update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c4ebafe08320ba0751cc460adf48)