### PR TITLE
Fix gateway telemetry/auth issues and clean up completed recommendations in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,14 @@ python3 -m http.server 4173
 ```
 
 ### Recommended Next Steps
-- ✅ Proxy fetch upgraded to async `httpx` with SSRF guardrails (host allowlist + private/link-local/loopback/rfc-reserved IP blocking).
-- ✅ Mutable runtime states are protected with `asyncio.Lock` (metrics, telemetry store, and state-sync rooms) to ensure concurrency safety.
-- ✅ Contract checker now uses `jsonschema` and keeps payload fixtures immutable during validation (audit-only fallback hints).
-- ✅ Browser URL analysis now routes through server-side proxy endpoint `/api/v1/proxy/fetch` to reduce CORS issues.
-- ✅ Telemetry pipeline now ingests to in-memory time-series storage via `/api/v1/telemetry/ingest` and aggregates via `/api/v1/telemetry/query`.
-- ✅ i18n now uses dynamic locale bundles in `locales/*.json`.
-- ✅ Voice model resolution now supports language-region mapping via `/api/v1/voice/model`, with region selector in Settings.
-- ✅ Deterministic multi-user state synchronization is available via `/ws/state-sync/{room_id}`.
-- ✅ Runtime quality tests were updated to match immutable contract-check behavior and async telemetry endpoints.
+- Move mutable runtime state to Redis (metrics counters, telemetry cache, and websocket room membership) for multi-worker consistency.
+- Add signed outbound proxy policy (HMAC request intent + per-tenant allowlist) to harden enterprise SSRF controls.
+- Build a contract-fuzz pipeline: property-based payload generators + mutation corpus for schema regression stress tests.
+- Add persisted TSDB backend (InfluxDB/TimescaleDB) with retention and downsampling policies.
+- Add proxy allowlist/denylist + content-type and size guardrails for stronger SSRF safety.
+- Add locale QA checks (missing-key scanner + pseudolocale) in CI.
+- Add voice A/B routing and collect WER/latency metrics by language-region cohort.
+- Add CRDT merge (Yjs/Automerge) for conflict-free collaborative editing beyond simple delta updates.
 
 ---
 
@@ -84,23 +83,22 @@ Aetherium Manifest คือเลเยอร์แสดงผลฝั่ง 
 โฟลเดอร์ `api_gateway/` มีตัวอย่าง Cognitive DSL gateway พร้อม endpoint สำหรับ emit/validate/health/websocket
 
 ### แนวทางต่อยอด
-- ✅ อัปเกรด proxy เป็น async (`httpx`) พร้อม SSRF protection (allowlist + block private/link-local/loopback IP)
-- ✅ เพิ่ม asyncio locks ครอบ state ที่แก้ไขได้ เพื่อความปลอดภัยในการทำงานพร้อมกัน
-- ✅ เปลี่ยน contract checker ไปใช้ `jsonschema` และตัด side effects ที่ไปแก้ payload ระหว่างการตรวจสอบ
-- ✅ ทำ URL proxy ฝั่งเซิร์ฟเวอร์ผ่าน `/api/v1/proxy/fetch` เพื่อลดปัญหา CORS
-- ✅ เก็บ telemetry ลง time-series store ผ่าน `/api/v1/telemetry/ingest` และสรุปผลผ่าน `/api/v1/telemetry/query`
-- ✅ ทำ i18n แบบแยกไฟล์ภาษาใน `locales/*.json` และโหลดแบบ dynamic
-- ✅ เลือกโมเดลเสียงตามภาษา/ภูมิภาคผ่าน `/api/v1/voice/model` และตัวเลือกภูมิภาคในหน้า Settings
-- ✅ เพิ่ม state sync แบบ deterministic สำหรับหลายผู้ใช้ด้วย `/ws/state-sync/{room_id}`
-- ✅ ปรับปรุงชุดทดสอบ runtime quality ให้สอดคล้องกับพฤติกรรมใหม่ (contract checker แบบไม่แก้ payload และ telemetry endpoint แบบ async)
+- ย้าย mutable runtime state ไปที่ Redis (metrics counters, telemetry cache และสมาชิกห้อง websocket) เพื่อรองรับหลาย worker ได้สม่ำเสมอ
+- เพิ่มนโยบาย signed outbound proxy (HMAC request intent + allowlist ตาม tenant) เพื่อเสริมความปลอดภัย SSRF ระดับองค์กร
+- สร้าง contract-fuzz pipeline ด้วยตัวสร้าง payload เชิง property-based และ mutation corpus สำหรับ stress test schema regression
+- เพิ่ม persisted TSDB backend (InfluxDB/TimescaleDB) พร้อมนโยบาย retention และ downsampling
+- เพิ่ม allowlist/denylist, content-type guardrail และขนาด payload guardrail ใน proxy
+- เพิ่ม locale QA checks ใน CI (missing-key scanner + pseudolocale)
+- เพิ่ม voice A/B routing และเก็บ WER/latency แยกตามภาษาและภูมิภาค
+- เพิ่มกลไก CRDT merge (Yjs/Automerge) สำหรับงาน collaborative editing ที่ซับซ้อนกว่า delta พื้นฐาน
 
 
 ## Extension Ideas
-- Move mutable runtime state to Redis (metrics counters, telemetry cache, ws room membership) for multi-worker consistency.
+- Move mutable runtime state to Redis (metrics counters, telemetry cache, and websocket room membership) for multi-worker consistency.
 - Add signed outbound proxy policy (HMAC request intent + per-tenant allowlist) to harden enterprise SSRF controls.
-- Build contract-fuzz pipeline: property-based payload generators + mutation corpus for schema regression stress tests.
-- Add persisted TSDB backend (InfluxDB/TimescaleDB) with retention + downsampling policies.
+- Build a contract-fuzz pipeline: property-based payload generators + mutation corpus for schema regression stress tests.
+- Add persisted TSDB backend (InfluxDB/TimescaleDB) with retention and downsampling policies.
 - Add proxy allowlist/denylist + content-type and size guardrails for stronger SSRF safety.
-- Add locale QA checks (missing key scanner + pseudolocale) in CI.
-- Add voice A/B routing and collect WER / latency metrics by language-region cohort.
+- Add locale QA checks (missing-key scanner + pseudolocale) in CI.
+- Add voice A/B routing and collect WER/latency metrics by language-region cohort.
 - Add CRDT merge (Yjs/Automerge) for conflict-free collaborative editing beyond simple delta updates.

--- a/api_gateway/README.md
+++ b/api_gateway/README.md
@@ -12,21 +12,21 @@ Sample gateway for receiving Cognitive DSL payloads from external model provider
 
 ### Required Headers
 - `X-API-Key`
-- `X-Model-Provider` (emit only)
-- `X-Model-Version` (emit only)
 
 ### Run (Quick Development)
-For a quick development server, you can use `uvicorn` directly. Note that this mode may not reflect all production environment requirements.
+For a quick development server, you can use `uvicorn` directly. This mode is convenient, but it does not enforce every production-like preflight check.
 
 ```bash
 # An API key is required for protected endpoints
 export OPENAI_API_KEY=demo-key
+# Optional for Google model calls:
+export GEMINI_API_KEY=demo-key
 
 uvicorn api_gateway.main:app --host 0.0.0.0 --port 8080 --reload
 ```
 
 ### Run (Production-like)
-For an environment that closer resembles production, use the provided shell script. This script ensures that necessary environment variables, like API keys, are set.
+For an environment that more closely resembles production, use the provided shell script. It validates that at least one provider API key is set before startup, and runs via `uv run uvicorn`.
 
 ```bash
 ./api_gateway/start_cognitive_api.sh
@@ -68,8 +68,6 @@ Gateway ตัวอย่างสำหรับรับ Cognitive DSL จา
 
 ### Header ที่ต้องมี
 - `X-API-Key`
-- `X-Model-Provider` (เฉพาะ emit)
-- `X-Model-Version` (เฉพาะ emit)
 
 ### การรัน (สำหรับพัฒนาเร็ว)
 สำหรับ Development Server สามารถใช้ `uvicorn` โดยตรงได้เลย แต่โหมดนี้อาจไม่ได้บังคับหรือจำลองสภาพแวดล้อมเหมือน Production ทั้งหมด
@@ -77,12 +75,14 @@ Gateway ตัวอย่างสำหรับรับ Cognitive DSL จา
 ```bash
 # ต้องมี API key สำหรับเรียกใช้งาน endpoint ที่ป้องกันสิทธิ์
 export OPENAI_API_KEY=demo-key
+# หากต้องเรียก Google model ให้ตั้งเพิ่ม
+export GEMINI_API_KEY=demo-key
 
 uvicorn api_gateway.main:app --host 0.0.0.0 --port 8080 --reload
 ```
 
 ### การรัน (สำหรับ Production)
-สำหรับสภาพแวดล้อมที่ใกล้เคียงกับ Production แนะนำให้ใช้สคริปต์ที่เตรียมไว้ ซึ่งจะมีการตรวจสอบและตั้งค่า Environment Variable ที่จำเป็น เช่น API Key ให้ครบถ้วน
+สำหรับสภาพแวดล้อมที่ใกล้เคียงกับ Production แนะนำให้ใช้สคริปต์ที่เตรียมไว้ สคริปต์จะตรวจว่ามี provider API key อย่างน้อยหนึ่งค่า และรันผ่าน `uv run uvicorn`
 
 ```bash
 ./api_gateway/start_cognitive_api.sh

--- a/api_gateway/__init__.py
+++ b/api_gateway/__init__.py
@@ -1,0 +1,1 @@
+"""Aetherium API gateway package."""

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -191,7 +191,7 @@ async def invoke_generative_model(prompt: str, model: str, temperature: float) -
         raise HTTPException(status_code=400, detail=f"Unsupported model: {model}")
 
     if provider == "google":
-        api_key = os.getenv("GEMINI_API_KEY")
+        api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
         if not api_key:
             raise HTTPException(status_code=500, detail="GEMINI_API_KEY is not set")
         url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
@@ -422,7 +422,7 @@ async def ingest_telemetry(req: TelemetryIngestRequest, x_api_key: str | None = 
     async with TELEMETRY_LOCK:
         for point in req.points:
             series = TELEMETRY_TS_DB.setdefault(point.metric, [])
-            series.append(point.model_dump())
+            series.append(point.model_dump(mode="json"))
             series[:] = series[-2500:]
         return {"ingested": len(req.points), "series_count": len(TELEMETRY_TS_DB)}
 
@@ -445,10 +445,15 @@ async def query_telemetry(
         "latest": rows[-1] if rows else None,
     }
 
+def _resolve_voice_model(language: str, region: str) -> str:
+    lang_key = language.split("-", maxsplit=1)[0].lower()
+    region_key = region.lower()
+    return VOICE_MODEL_MAP.get((lang_key, region_key), f"whisper-general-{lang_key}")
+
+
 @app.get("/api/v1/voice/model")
 def resolve_voice_model(language: str = "en-US", region: str = "us") -> dict[str, str]:
-    lang_key, region_key = language.split("-")[0].lower(), region.lower()
-    model = VOICE_MODEL_MAP.get((lang_key, region_key), f"whisper-general-{lang_key}")
+    model = _resolve_voice_model(language, region)
     return {"language": language, "region": region, "model": model}
 
 # --- WebSocket Endpoints ---

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -193,7 +193,7 @@ async def invoke_generative_model(prompt: str, model: str, temperature: float) -
     if provider == "google":
         api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
         if not api_key:
-            raise HTTPException(status_code=500, detail="GEMINI_API_KEY is not set")
+            raise HTTPException(status_code=500, detail="Google API key (GEMINI_API_KEY or GOOGLE_API_KEY) is not set")
         url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
         payload = {"contents": [{"parts": [{"text": prompt}]}]}
         async with httpx.AsyncClient(timeout=30.0) as client:

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -1,11 +1,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import json
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
-from httpx import Response
+from starlette.websockets import WebSocketDisconnect
 
 from .main import app
 
@@ -14,6 +15,10 @@ from .main import app
 def client() -> TestClient:
     return TestClient(app)
 
+@pytest.fixture
+def valid_emit_payload() -> dict:
+    return json.loads(Path("api_gateway/sample_emit_payload.json").read_text(encoding="utf-8"))
+
 
 def test_health_check(client: TestClient) -> None:
     response = client.get("/health")
@@ -21,34 +26,31 @@ def test_health_check(client: TestClient) -> None:
     assert response.json()["status"] == "healthy"
 
 
-def test_emit_missing_api_key(client: TestClient) -> None:
-    response = client.post("/api/v1/cognitive/emit", json={})
+def test_emit_missing_api_key(client: TestClient, valid_emit_payload: dict) -> None:
+    response = client.post("/api/v1/cognitive/emit", json=valid_emit_payload)
     assert response.status_code == 401
     assert "missing X-API-Key" in response.text
 
 
-def test_emit_missing_model_headers(client: TestClient) -> None:
+def test_emit_invalid_payload(client: TestClient) -> None:
     response = client.post(
         "/api/v1/cognitive/emit",
         json={},
         headers={"X-API-Key": "test-key"},
     )
-    assert response.status_code == 400
-    assert "missing model provider/version" in response.text
+    assert response.status_code == 422
 
 
-def test_validate_missing_api_key(client: TestClient) -> None:
-    response = client.post("/api/v1/cognitive/validate", json={})
+def test_validate_missing_api_key(client: TestClient, valid_emit_payload: dict) -> None:
+    response = client.post("/api/v1/cognitive/validate", json=valid_emit_payload)
     assert response.status_code == 401
     assert "missing X-API-Key" in response.text
 
 
 def test_websocket_stream_missing_key(client: TestClient) -> None:
-    with client.websocket_connect("/ws/cognitive-stream") as websocket:
-        # Connection should be rejected, but TestClient doesn't expose close code
-        # Instead, we expect no messages and a closed connection.
-        # This is a limitation of the test client's websocket testing API.
-        pass
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/ws/cognitive-stream"):
+            pass
 
 
 def test_websocket_stream_with_query_key(client: TestClient) -> None:
@@ -59,7 +61,7 @@ def test_websocket_stream_with_query_key(client: TestClient) -> None:
 
 
 def test_websocket_stream_with_header_key(client: TestClient) -> None:
-    # Note: TestClient doesn't directly support setting headers for websockets.
-    # This is a known limitation. We test the query param route as the primary path.
-    pass
-
+    with client.websocket_connect("/ws/cognitive-stream", headers={"X-API-Key": "test-key"}) as websocket:
+        websocket.send_json({"type": "dsl_submission", "payload": "..."})
+        response = websocket.receive_json()
+        assert response["status"] == "accepted"


### PR DESCRIPTION
### Motivation
- Resolve runtime failures found during tests where telemetry query failed due to non-JSON-serializable timestamps and tests could not import the `api_gateway` package. 
- Improve provider key handling and voice-model resolution to be more robust for multiple provider env var names. 
- Remove already-completed recommendation items and clarify run instructions so documentation matches runtime behavior.

### Description
- Serialize telemetry points with JSON-safe data (`point.model_dump(mode="json")`) before storing in `TELEMETRY_TS_DB` to avoid `datetime` deserialization errors in `query_telemetry` (file: `api_gateway/main.py`).
- Make Google provider key lookup accept `GEMINI_API_KEY` or `GOOGLE_API_KEY`, add `_resolve_voice_model(...)` helper and reuse it for the `/api/v1/voice/model` endpoint (file: `api_gateway/main.py`).
- Turn `api_gateway/` into an importable package by adding `api_gateway/__init__.py` and update tests to align with FastAPI validation and WebSocket auth semantics (file: `api_gateway/test_api.py`).
- Update documentation to clarify quick-dev vs production-like startup, include `GEMINI_API_KEY` example, and remove recommendation bullets that were already completed in both English and Thai `README` files (files: `README.md`, `api_gateway/README.md`).

### Testing
- Ran the full automated test suite with `pytest -q` and verified all tests pass (`26 passed`).
- Tests exercised HTTP endpoints and WebSocket behavior, including `emit`/`validate` auth paths and telemetry ingest/query behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c7c32d748320b7a995c9f7e08593)