### PR TITLE
[gateway-docs] Align provider keys, harden adapter coercion, and clear completed audit backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,21 @@ uvicorn main:app --host 0.0.0.0 --port 8090 --reload
 
 ```bash
 cd api_gateway && pytest -q
+cd ../ws_gateway && pytest -q
+cd ..
 python3 tools/contracts/contract_checker.py
 python3 tools/contracts/contract_fuzz.py
 python3 tools/benchmarks/runtime_semantic_benchmark.py --input tools/benchmarks/runtime_semantic_samples.sample.json
 npx --yes tsx --test test_runtime_governor_psycho_safety.test.ts
 npm run lint
 ```
+
+## Provider key configuration
+
+- OpenAI models (`gpt*`, `o*`) use `OPENAI_API_KEY`.
+- Anthropic models (`claude*`) use `ANTHROPIC_API_KEY`.
+- Gemini models (`gemini*`) use `GEMINI_API_KEY`.
+- `GOOGLE_API_KEY` is still accepted as a temporary fallback for startup scripts, but it is deprecated and should be migrated to `GEMINI_API_KEY`.
 
 ## Security and governance
 

--- a/api_gateway/README.md
+++ b/api_gateway/README.md
@@ -1,4 +1,4 @@
-# AGNS Cognitive DSL API Gateway
+# Aetherium Cognitive DSL API Gateway
 
 เอกสารและโค้ดตัวอย่างสำหรับระบบรับ Cognitive DSL จากโมเดลภายนอก (OpenAI / Anthropic / Google / Custom)
 
@@ -7,7 +7,9 @@
 - `POST /api/v1/cognitive/emit`
 - `POST /api/v1/cognitive/validate`
 - `GET /health`
-- `WS /ws/cognitive-stream`
+- `POST /api/v1/cognitive/generate`
+
+> หมายเหตุ: WebSocket endpoints (`/ws/cognitive-stream`, `/ws/state-sync/{room_id}`) อยู่ใน `ws_gateway/main.py`
 
 ## WebSocket scaling primitives (prototype)
 
@@ -34,7 +36,7 @@ uvicorn api_gateway.main:app --host 0.0.0.0 --port 8080 --reload
 ```
 
 ### การรัน (สำหรับ Production)
-สำหรับสภาพแวดล้อมที่ใกล้เคียงกับ Production แนะนำให้ใช้สคริปต์ที่เตรียมไว้ ซึ่งจะมีการตรวจสอบและตั้งค่า Environment Variable ที่จำเป็น เช่น API Key ให้ครบถ้วน
+สำหรับสภาพแวดล้อมที่ใกล้เคียงกับ Production แนะนำให้ใช้สคริปต์ที่เตรียมไว้ ซึ่งจะตรวจสอบและตั้งค่า environment variables ที่จำเป็นให้ครบถ้วน
 
 ```bash
 ./api_gateway/start_cognitive_api.sh

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -178,7 +178,7 @@ def _require_provider_key(model: str | None) -> None:
             logger.warning("GOOGLE_API_KEY is deprecated. Please migrate to GEMINI_API_KEY.")
             return
         raise HTTPException(status_code=500, detail="GEMINI_API_KEY is not set")
-    if model_name.startswith(("gpt", "o1", "o3", "o4")) and not os.getenv("OPENAI_API_KEY"):
+    if model_name.startswith(("gpt", "o")) and not os.getenv("OPENAI_API_KEY"):
         raise HTTPException(status_code=500, detail="OPENAI_API_KEY is not set")
     if model_name.startswith("claude") and not os.getenv("ANTHROPIC_API_KEY"):
         raise HTTPException(status_code=500, detail="ANTHROPIC_API_KEY is not set")

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -167,6 +167,22 @@ async def incr_metric(name: str):
         try: await r.incr(f"metrics:{name}")
         except Exception: pass
 
+
+def _require_provider_key(model: str | None) -> None:
+    model_name = str(model or "").strip().lower()
+    if model_name.startswith("gemini"):
+        if os.getenv("GEMINI_API_KEY"):
+            return
+        google_fallback = os.getenv("GOOGLE_API_KEY")
+        if google_fallback:
+            logger.warning("GOOGLE_API_KEY is deprecated. Please migrate to GEMINI_API_KEY.")
+            return
+        raise HTTPException(status_code=500, detail="GEMINI_API_KEY is not set")
+    if model_name.startswith(("gpt", "o1", "o3", "o4")) and not os.getenv("OPENAI_API_KEY"):
+        raise HTTPException(status_code=500, detail="OPENAI_API_KEY is not set")
+    if model_name.startswith("claude") and not os.getenv("ANTHROPIC_API_KEY"):
+        raise HTTPException(status_code=500, detail="ANTHROPIC_API_KEY is not set")
+
 async def _metrics_snapshot() -> dict[str, Any]:
     m = {"total_dsl_submissions": 0, "successful_renders": 0, "validation_failures": 0}
     if r:
@@ -318,8 +334,10 @@ async def generate_cognitive_dsl(
     x_api_key: str | None = Header(default=None, alias="X-API-Key"),
 ) -> dict[str, Any]:
     _ensure_api_key(x_api_key)
-    if request.get("model") == "unknown-model":
+    model = request.get("model")
+    if model == "unknown-model":
         raise HTTPException(status_code=400, detail="Unsupported model")
+    _require_provider_key(model)
     return {"status": "success"}
 
 @app.get("/api/v1/reliability/temporal-morphogenesis")

--- a/api_gateway/start_cognitive_api.sh
+++ b/api_gateway/start_cognitive_api.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 export AGNS_ENVIRONMENT="${AGNS_ENVIRONMENT:-production}"
 export UV_PROJECT_ENVIRONMENT="${UV_PROJECT_ENVIRONMENT:-/app/.venv}"
 
-if [[ -z "${OPENAI_API_KEY:-}" ]] && [[ -z "${ANTHROPIC_API_KEY:-}" ]] && [[ -z "${GOOGLE_API_KEY:-}" ]]; then
+if [[ -n "${GOOGLE_API_KEY:-}" ]] && [[ -z "${GEMINI_API_KEY:-}" ]]; then
+  echo "Warning: GOOGLE_API_KEY is deprecated. Please migrate to GEMINI_API_KEY."
+  export GEMINI_API_KEY="${GOOGLE_API_KEY}"
+fi
+
+if [[ -z "${OPENAI_API_KEY:-}" ]] && [[ -z "${ANTHROPIC_API_KEY:-}" ]] && [[ -z "${GEMINI_API_KEY:-}" ]]; then
   echo "Error: ต้องตั้งค่าอย่างน้อยหนึ่ง API key"
   exit 1
 fi

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -64,6 +64,29 @@ def test_generate_rejects_unsupported_model_with_400(client: TestClient) -> None
     assert "Unsupported model" in response.text
 
 
+def test_generate_requires_gemini_key_when_using_gemini_model(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    response = client.post(
+        "/api/v1/cognitive/generate",
+        headers={"X-API-Key": "test-key"},
+        json={"prompt": "hello", "model": "gemini-pro"},
+    )
+    assert response.status_code == 500
+    assert "GEMINI_API_KEY is not set" in response.text
+
+
+def test_generate_requires_openai_key_when_using_openai_model(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    response = client.post(
+        "/api/v1/cognitive/generate",
+        headers={"X-API-Key": "test-key"},
+        json={"prompt": "hello", "model": "gpt-4o"},
+    )
+    assert response.status_code == 500
+    assert "OPENAI_API_KEY is not set" in response.text
+
+
 def test_proxy_fetch_rejects_urls_with_credentials(client: TestClient) -> None:
     response = client.get(
         "/api/v1/proxy/fetch",

--- a/docs/CODEBASE_AUDIT_2026-04-13.md
+++ b/docs/CODEBASE_AUDIT_2026-04-13.md
@@ -1,23 +1,7 @@
-# Codebase audit backlog (2026-04-13)
+# Codebase audit backlog (updated 2026-04-16)
 
-เอกสารนี้สรุปประเด็นที่ตรวจพบจากการสำรวจโค้ด พร้อมงานที่แนะนำให้ทำต่ออย่างละ 1 งานตามหมวดที่ร้องขอ
+All previously listed backlog items have been completed and removed from this file to avoid mixing done work with active work.
 
-## 1) งานแก้ไขข้อความที่พิมพ์ผิด (Typo fix)
-- **ปัญหา:** หัวข้อเอกสาร `api_gateway/README.md` ใช้คำว่า `AGNS Cognitive DSL API Gateway` ซึ่งไม่ตรงกับชื่อโปรเจกต์ใน repo (`Aetherium Manifest`) และสร้างความสับสนด้าน branding
-- **ไฟล์อ้างอิง:** `api_gateway/README.md` บรรทัดแรก
-- **งานที่เสนอ:** เปลี่ยนหัวข้อเป็น `Aetherium Cognitive DSL API Gateway` และตรวจคำย่อ AGNS/Aetherium ให้สอดคล้องทั้งเอกสาร
+## Open items
 
-## 2) งานแก้ไขบั๊ก (Bug fix)
-- **ปัญหา:** ฟังก์ชัน `to_visual_manifestation` แปลง `device_tier` ด้วย `int(device_tier)` โดยตรง ทำให้ input ที่ไม่ใช่ตัวเลข (เช่น `"mid"`) โยน `ValueError` และทำให้ pipeline พังแทนที่จะ fallback
-- **ไฟล์อ้างอิง:** `tools/contracts/particle_control_adapter.py`
-- **งานที่เสนอ:** เพิ่ม safe-coercion (try/except + default tier = 1) แล้วค่อย clamp ช่วง `[1,4]` เพื่อทำให้ adapter ทนทานกับข้อมูลจาก upstream
-
-## 3) งานแก้ไขคอมเมนต์/ความคลาดเคลื่อนของเอกสาร
-- **ปัญหา:** `api_gateway/README.md` ระบุ endpoint `WS /ws/cognitive-stream` แต่ใน `api_gateway/main.py` ไม่มี route WebSocket ดังกล่าว
-- **ไฟล์อ้างอิง:** `api_gateway/README.md`, `api_gateway/main.py`
-- **งานที่เสนอ:** ตัด endpoint นี้ออกจาก README หรือย้ายเอกสารไปชี้ `ws_gateway/main.py` ให้ชัดเจนว่า WebSocket อยู่ service ไหน
-
-## 4) งานปรับปรุงการทดสอบ (Test improvement)
-- **ปัญหา:** ชุดทดสอบ `tools/contracts/test_particle_control_adapter.py` ยังไม่ครอบคลุมเคส input ผิดชนิดของ `device_tier`
-- **ไฟล์อ้างอิง:** `tools/contracts/test_particle_control_adapter.py`
-- **งานที่เสนอ:** เพิ่ม test case สำหรับ `device_tier="mid"`, `None`, ค่าติดลบ และค่ามากกว่าเพดาน เพื่อยืนยันพฤติกรรม fallback + clamping
+- None in this audit cycle.

--- a/docs/CODEBASE_AUDIT_TASKS_TH.md
+++ b/docs/CODEBASE_AUDIT_TASKS_TH.md
@@ -1,54 +1,9 @@
-# Codebase Audit: ข้อเสนอแผนงานแก้ไข (Thai)
+# Codebase Audit: งานคงค้าง (Thai)
 
-เอกสารนี้สรุปผลการตรวจสอบโค้ดล่าสุด และเสนอ "งานแก้ไข" อย่างละ 1 งานตามหมวดที่ร้องขอ
+อัปเดตล่าสุด: 2026-04-16
 
-## 1) งานแก้ไขข้อความพิมพ์ผิด (Typo Fix)
+รายการข้อเสนอที่เคยอยู่ในเอกสารนี้ถูกดำเนินการครบแล้ว และได้ลบออกเพื่อไม่ให้ปะปนกับงานที่เสร็จสิ้น
 
-**ปัญหาที่พบ**
-- ใน `api_gateway/README.md` มีประโยคภาษาอังกฤษพิมพ์ตกคำ:
-  - `For an environment that is closer to production, ...`
-- ปรับให้ถ้อยคำสอดคล้องกับสำนวนอังกฤษมาตรฐาน และชี้ตรงกับคำแนะนำการใช้งานสคริปต์
+## งานที่ยังคงค้าง
 
-**งานที่เสนอ**
-- แก้เป็น:
-  - `For an environment that is closer to production, use the provided shell script.`
-- ตรวจทานทั้งไฟล์ README ภาษาอังกฤษ/ไทยแบบรอบเดียวเพื่อเก็บ typo ใกล้เคียงกัน
-
----
-
-## 2) งานแก้ไขบั๊ก (Bug Fix)
-
-**ปัญหาที่พบ**
-- Runtime ใน `api_gateway/main.py` อ่าน Google key จาก `GEMINI_API_KEY`
-- แต่สคริปต์รัน `api_gateway/start_cognitive_api.sh` ตรวจ `GOOGLE_API_KEY`
-- ผลคือสคริปต์อาจผ่านเงื่อนไขได้ แต่ API เรียกใช้งานจริงล้มเหลวด้วย error `GEMINI_API_KEY is not set`
-
-**งานที่เสนอ**
-- ทำให้ชื่อ env สอดคล้องกันทั้งระบบ โดยเลือกใช้ `GEMINI_API_KEY` เป็นค่าหลัก
-- เพิ่ม fallback ชั่วคราว (`GOOGLE_API_KEY` -> `GEMINI_API_KEY`) พร้อมข้อความ deprecation
-
----
-
-## 3) งานแก้ไขคอมเมนต์/ความคลาดเคลื่อนของเอกสาร (Comment/Docs Discrepancy)
-
-**ปัญหาที่พบ**
-- ใน `api_gateway/test_api.py` มีคอมเมนต์ว่า TestClient ตั้ง header ให้ websocket ไม่ได้:
-  - `TestClient doesn't directly support setting headers for websockets.`
-- แต่ FastAPI/Starlette `websocket_connect` รองรับการส่ง header ได้ และเทสต์ `test_websocket_stream_with_header_key` ถูกปล่อยเป็น `pass`
-
-**งานที่เสนอ**
-- อัปเดตคอมเมนต์ให้ตรงพฤติกรรม framework ปัจจุบัน
-- แทนที่ `pass` ด้วยเทสต์จริงที่ส่ง `X-API-Key` ผ่าน header และ assert ว่า websocket รับข้อความได้
-
----
-
-## 4) งานปรับปรุงการทดสอบ (Test Improvement)
-
-**ปัญหาที่พบ**
-- ปัจจุบันมีเทสต์กรณี unsupported model (`unknown-model`) แต่ยังไม่มีเทสต์กรณี provider ถูกต้องแต่ key ขาด
-- เส้นทางนี้สำคัญเพราะผูกกับ config production โดยตรง
-
-**งานที่เสนอ**
-- เพิ่มเทสต์สำหรับ `POST /api/v1/cognitive/generate` เมื่อใช้โมเดล Google (`gemini-pro`) แล้วไม่มี `GEMINI_API_KEY`
-- Assert สถานะ `500` และข้อความ `GEMINI_API_KEY is not set`
-- เสริมอีกเคสหนึ่งสำหรับ OpenAI ที่ไม่มี `OPENAI_API_KEY` เพื่อให้ครอบคลุมทั้งสอง provider หลัก
+- ไม่มีงานคงค้างในรอบนี้

--- a/tools/contracts/particle_control_adapter.py
+++ b/tools/contracts/particle_control_adapter.py
@@ -34,6 +34,14 @@ def _particle_count_from_density(density: float) -> int:
     return int(round(density * 50000))
 
 
+def _coerce_device_tier(value: Any, default: int = 1) -> int:
+    try:
+        tier = int(value)
+    except (TypeError, ValueError):
+        tier = default
+    return max(1, min(4, tier))
+
+
 def to_renderer_controls(particle_control: dict[str, Any]) -> dict[str, Any]:
     """Compile canonical particle intent/state into explicit renderer/runtime controls."""
     intent = particle_control.get("intent_state", {})
@@ -88,7 +96,7 @@ def to_visual_manifestation(particle_control: dict[str, Any], transition_type: s
         },
         "chromatic_mode": renderer.get("chromatic_mode", "adaptive"),
         "emergency_override": False,
-        "device_tier": max(1, min(4, int(device_tier))),
+        "device_tier": _coerce_device_tier(device_tier),
         "adapter_metadata": {
             "cohesion": _clamp_float(uniforms.get("cohesion"), default=0.5),
             "flicker": _clamp_float(uniforms.get("flicker"), default=0.0),

--- a/tools/contracts/test_particle_control_adapter.py
+++ b/tools/contracts/test_particle_control_adapter.py
@@ -61,3 +61,17 @@ def test_to_visual_manifestation_uses_compiled_renderer_controls() -> None:
     assert visual["particle_physics"]["particle_count"] == 10000
     assert visual["chromatic_mode"] == "adaptive"
     assert visual["device_tier"] == 3
+
+
+def test_to_visual_manifestation_device_tier_fallback_and_clamp() -> None:
+    payload = {"intent_state": {"palette": {}}}
+
+    non_numeric_tier = to_visual_manifestation(payload, device_tier="mid")
+    none_tier = to_visual_manifestation(payload, device_tier=None)
+    negative_tier = to_visual_manifestation(payload, device_tier=-9)
+    over_max_tier = to_visual_manifestation(payload, device_tier=99)
+
+    assert non_numeric_tier["device_tier"] == 1
+    assert none_tier["device_tier"] == 1
+    assert negative_tier["device_tier"] == 1
+    assert over_max_tier["device_tier"] == 4

--- a/ws_gateway/test_ws_gateway.py
+++ b/ws_gateway/test_ws_gateway.py
@@ -25,6 +25,13 @@ def test_websocket_stream_with_query_key(client: TestClient) -> None:
         assert response['status'] == 'accepted'
 
 
+def test_websocket_stream_with_header_key(client: TestClient) -> None:
+    with client.websocket_connect('/ws/cognitive-stream', headers={'x-api-key': 'test-key'}) as websocket:
+        websocket.send_json({'type': 'dsl_submission', 'payload': '...'})
+        response = websocket.receive_json()
+        assert response['status'] == 'accepted'
+
+
 def test_state_sync_websocket_requires_api_key(client: TestClient) -> None:
     with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect('/ws/state-sync/demo-room'):


### PR DESCRIPTION
### Motivation

- Fix inconsistent provider API key handling that caused startup vs runtime mismatches and potential  runtime errors when model provider keys were missing. 
- Harden the particle-control adapter to avoid crashes when `device_tier` is non-numeric or out-of-range. 
- Clean up documentation and audit backlog entries so completed items do not mix with active work. 
- Add tests that assert provider-key validation and websocket header auth to prevent regressions.

### Description

- Added `_require_provider_key` helper and enforced provider key checks in `POST /api/v1/cognitive/generate` so `gemini*` requires `GEMINI_API_KEY` (with a `GOOGLE_API_KEY` fallback warning), `gpt*/o*` require `OPENAI_API_KEY`, and `claude*` requires `ANTHROPIC_API_KEY` (`api_gateway/main.py`).
- Updated startup script to map deprecated `GOOGLE_API_KEY` to `GEMINI_API_KEY` with a warning and to validate at least one provider key is present (`api_gateway/start_cognitive_api.sh`).
- Replaced direct `int(device_tier)` with a safe coercion function `_coerce_device_tier` that falls back and clamps to `[1,4]`, and used it in `to_visual_manifestation` to avoid `ValueError` from malformed upstream inputs (`tools/contracts/particle_control_adapter.py`).
- Added tests for `device_tier` fallback/clamp, provider-key requirements for `generate`, and websocket header auth; updated `README.md` and `api_gateway/README.md` for endpoint accuracy and provider key guidance; cleared completed items from audit backlog docs (`tools/contracts/test_particle_control_adapter.py`, `api_gateway/test_api.py`, `ws_gateway/test_ws_gateway.py`, `README.md`, `api_gateway/README.md`, `docs/*`).

### Testing

- Ran targeted Python unit tests: `PYTHONPATH=. pytest -q tools/contracts/test_particle_control_adapter.py` passed (`3 passed`), `AETHERIUM_API_KEY=test-key pytest -q api_gateway/test_api.py` passed (`16 passed, 2 warnings`), and `AETHERIUM_API_KEY=test-key pytest -q ws_gateway/test_ws_gateway.py` passed (`4 passed, 2 warnings`).
- Ran contract checks with `python3 tools/contracts/contract_checker.py` which completed successfully and reported expected audits.
- Ran linter `npm run lint` which failed due to repository lacking an ESLint flat config under ESLint v9 (existing repo issue, not introduced by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d2d1f0708320b2c65276329fd95d)