### PR TITLE
[repo] Remove unused GitHub and Azure automation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ python3 -m http.server 4173
 # open http://localhost:4173
 ```
 
-
-### CI/CD note
+### CI/CD Note
 - GitHub/Azure automation that was not in active use has been removed from this repository.
 - Deployment and quality checks should be run manually or from an external CI system outside this repo.
 - If branch protection requires status checks, update required checks in GitHub repository settings to match your active process.
+- See [remove-unused-platform-automation.md](docs/repo-maintenance/remove-unused-platform-automation.md) for more details.
 
 ### Recommended Next Steps
 - Move mutable runtime state to Redis (metrics counters, telemetry cache, and websocket room membership) for multi-worker consistency.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ python3 -m http.server 4173
 # open http://localhost:4173
 ```
 
+
+### CI/CD note
+- GitHub/Azure automation that was not in active use has been removed from this repository.
+- Deployment and quality checks should be run manually or from an external CI system outside this repo.
+- If branch protection requires status checks, update required checks in GitHub repository settings to match your active process.
+
 ### Recommended Next Steps
 - Move mutable runtime state to Redis (metrics counters, telemetry cache, and websocket room membership) for multi-worker consistency.
 - Add signed outbound proxy policy (HMAC request intent + per-tenant allowlist) to harden enterprise SSRF controls.

--- a/docs/repo-maintenance/remove-unused-platform-automation.md
+++ b/docs/repo-maintenance/remove-unused-platform-automation.md
@@ -1,30 +1,36 @@
 # Remove unused GitHub and Azure automation
 
-## Summary
+## What changed
 
-This repository removes unused GitHub/Azure platform automation to reduce maintenance overhead:
+This maintenance update removes unused repository automation that was tied to GitHub/Azure platform workflows and bots.
 
-- Removed unused GitHub workflow files tied to Azure deployment and repo-level automation that is no longer in use.
-- Removed Dependabot configuration that is no longer in use.
+Requested cleanup targets:
+
+- `.github/workflows/azure-kubernetes-service-helm-build.yml`
+- `.github/workflows/codeql-analysis.yml`
+- `.github/workflows/security-scorecards.yml`
+- `.github/workflows/workflow-hygiene.yml`
+- `.github/workflows/codex-review.yml`
+- `.github/dependabot.yml`
 
 ## Runtime impact
 
-Core runtime behavior is unchanged:
+Core runtime paths remain unchanged:
 
-- Frontend runtime assets remain intact.
-- API gateway and WebSocket gateway paths remain intact.
-- Governor and contract-first runtime paths remain intact.
+- Frontend manifestation runtime remains intact.
+- API gateway and WebSocket runtime remain intact.
+- Contract/governor behavior remains intact.
 
-## Local and development paths remain available
+## Local/dev paths remain available
 
-The existing local/dev execution paths still work:
+You can continue to run and validate the project without those repository automations:
 
-- Manual service startup (frontend + API + WS)
-- Existing scripts for local stack startup (for example `start_services.sh`)
-- Existing Docker Compose/manual deployment paths where already documented in-repo
+- Manual local run (`python3 -m http.server 4173`, FastAPI/Uvicorn flow in `api_gateway/`)
+- Existing Docker Compose or manual service startup paths already documented in-repo
+- Contract and runtime checks can still be run directly from local commands
 
-## Branch protection note
+## Branch protection reminder
 
-If your repository uses GitHub branch protection with required status checks, review and update required checks in **GitHub Settings**.
+If GitHub branch protection uses required status checks, review those settings manually in GitHub repository settings.
 
-Because the removed workflows no longer run, any previous required checks tied to those workflows must be removed or replaced with checks provided by your current manual/external CI process.
+Because the previous workflows were removed, any required checks pointing to them must be removed or replaced with checks from your active external/manual CI process.

--- a/docs/repo-maintenance/remove-unused-platform-automation.md
+++ b/docs/repo-maintenance/remove-unused-platform-automation.md
@@ -25,7 +25,7 @@ Core runtime paths remain unchanged:
 
 You can continue to run and validate the project without those repository automations:
 
-- Manual local run (`python3 -m http.server 4173`, FastAPI/Uvicorn flow in `api_gateway/`)
+- Manual local run (Frontend: python3 -m http.server 4173, API: uvicorn api_gateway.main:app --port 8080)
 - Existing Docker Compose or manual service startup paths already documented in-repo
 - Contract and runtime checks can still be run directly from local commands
 


### PR DESCRIPTION
### Motivation
- Reduce maintenance overhead by removing unused GitHub/Azure automation references and make README/docs consistent with a manual/external CI approach. 
- Preserve the core runtime and gateway behavior while clearly documenting operational and branch-protection implications.

### Description
- Added a neutral CI/CD note to `README.md` clarifying that removed automation is now handled manually or by external CI and that branch-protection required checks must be updated in GitHub settings. 
- Added `docs/repo-maintenance/remove-unused-platform-automation.md` documenting the targeted workflow/dependabot entries, runtime impact, local/dev run guidance, and a branch-protection reminder. 
- Verified the specific workflow/dependabot targets listed for removal do not exist in the current working tree and made no changes to runtime code or prompts/templates.

### Testing
- Ran `npm run lint` which completed successfully. 
- Ran `cd api_gateway && pytest -q` which failed during collection due to a pre-existing `NameError: logging is not defined` in `api_gateway/main.py`. 
- Ran `python3 tools/contracts/contract_checker.py` which also failed for the same import-time `NameError` when importing `api_gateway.main`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e30c91c88320a363e6c8ccdf283d)