### PR TITLE
[api_gateway] Cast loader to Any to satisfy mypy attr-defined for msgspec cache

### DIFF
--- a/api_gateway/aetherbus_extreme.py
+++ b/api_gateway/aetherbus_extreme.py
@@ -79,10 +79,9 @@ async def async_zero_copy_send(
 
 
 def _load_msgspec() -> Any:
-    load_msgspec = cast(Any, _load_msgspec)
-    if not hasattr(load_msgspec, "_module"):
-        load_msgspec._module = importlib.import_module("msgspec")
-    return load_msgspec._module
+    if not hasattr(_load_msgspec, "_module"):
+        setattr(_load_msgspec, "_module", importlib.import_module("msgspec"))
+    return getattr(_load_msgspec, "_module")
 
 
 def serialize_to_msgpack(data: Any) -> bytes:

--- a/api_gateway/aetherbus_extreme.py
+++ b/api_gateway/aetherbus_extreme.py
@@ -6,7 +6,7 @@ import uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any, Awaitable, Callable, Mapping, cast
+from typing import Any, Awaitable, Callable, Mapping
 
 import importlib
 

--- a/api_gateway/aetherbus_extreme.py
+++ b/api_gateway/aetherbus_extreme.py
@@ -6,7 +6,7 @@ import uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any, Awaitable, Callable, Mapping
+from typing import Any, Awaitable, Callable, Mapping, cast
 
 import importlib
 
@@ -79,9 +79,10 @@ async def async_zero_copy_send(
 
 
 def _load_msgspec() -> Any:
-    if not hasattr(_load_msgspec, "_module"):
-        _load_msgspec._module = importlib.import_module("msgspec")
-    return _load_msgspec._module
+    load_msgspec = cast(Any, _load_msgspec)
+    if not hasattr(load_msgspec, "_module"):
+        load_msgspec._module = importlib.import_module("msgspec")
+    return load_msgspec._module
 
 
 def serialize_to_msgpack(data: Any) -> bytes:


### PR DESCRIPTION
### Motivation
- Fix static type checking noise where Mypy complains about the cached `._module` attribute on the `_load_msgspec` function while preserving the existing lazy-import cache behavior in the messagepack helper.

### Description
- Added `cast` to the `typing` import and changed `_load_msgspec` in `api_gateway/aetherbus_extreme.py` to use `load_msgspec = cast(Any, _load_msgspec)` before accessing/assigning `._module`, keeping the original lazy-import caching logic intact.

### Testing
- Ran `npm run lint` and it succeeded.
- Ran `cd api_gateway && pytest -q` and collection failed due to a pre-existing `NameError: name 'logging' is not defined` in `api_gateway/main.py`, unrelated to this change.
- Ran `python3 tools/contracts/contract_checker.py` and it failed for the same pre-existing `logging` import issue in `api_gateway/main.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0eae10ac0832894cc1a33ac555ad7)