### PR TITLE
[first-surface] Refactor homepage into clean light-first runtime

### DIFF
--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -1,173 +1,59 @@
-const canvas = document.getElementById('manifestation-canvas');
-const context = canvas.getContext('2d');
-const input = document.getElementById('intent-input');
-const form = document.getElementById('composer');
-const statusText = document.getElementById('ambient-status');
-const fallbackText = document.getElementById('readable-fallback');
-const settingsPanel = document.getElementById('settings-panel');
-const settingsToggle = document.getElementById('settings-toggle');
-const closeSettings = document.getElementById('close-settings');
-const voiceBtn = document.getElementById('voice-btn');
+import { createLanguageLayer } from './first_use_surface/language-layer.js';
+import { createLightManifestation } from './first_use_surface/light-manifestation.js';
+import { routeLightResponse } from './first_use_surface/response-orchestrator.js';
+
+const elements = {
+  canvas: document.getElementById('manifestation-canvas'),
+  form: document.getElementById('composer'),
+  input: document.getElementById('intent-input'),
+  sendButton: document.getElementById('send-btn'),
+  statusText: document.getElementById('ambient-status'),
+  fallbackText: document.getElementById('readable-fallback'),
+  settingsPanel: document.getElementById('settings-panel'),
+  settingsToggle: document.getElementById('settings-toggle'),
+  closeSettings: document.getElementById('close-settings'),
+  voiceButton: document.getElementById('voice-btn'),
+};
 
 const settings = {
   languagePreference: 'auto',
   useLocalDetector: true,
+  localModelProfile: 'tiny-rules',
   reducedMotion: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
   voiceEnabled: true,
   apiBase: '/api',
   wsBase: '/ws/cognitive-stream',
   runtimeMode: 'calm',
   telemetry: true,
+  lineage: false,
+  scholar: false,
+  governorDebug: false,
+  developerTools: false,
   sessionLanguageMemory: 'th',
 };
 
 const sessionAudit = [];
-const particles = Array.from({ length: 280 }, () => ({
-  x: Math.random(), y: Math.random(), r: Math.random() * 1.8 + 0.5, vx: (Math.random() - 0.5) * 0.0006, vy: (Math.random() - 0.5) * 0.0006,
-}));
+const languageLayer = createLanguageLayer(settings);
+const manifestationEngine = createLightManifestation(elements.canvas, settings.reducedMotion);
 
-const manifestation = {
-  text: '',
-  at: 0,
-  mood: 'calm',
-};
-
-function resize() {
-  const dpr = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
-  canvas.width = Math.floor(window.innerWidth * dpr);
-  canvas.height = Math.floor(window.innerHeight * dpr);
-  context.setTransform(dpr, 0, 0, dpr, 0, 0);
+function setStatus(statusText) {
+  elements.statusText.textContent = statusText;
 }
 
-function detectFromInput(text) {
-  if (!text) return 'unknown';
-  const thaiChars = (text.match(/[\u0E00-\u0E7F]/g) || []).length;
-  const latinChars = (text.match(/[A-Za-z]/g) || []).length;
-  if (thaiChars > latinChars) return 'th';
-  if (latinChars > 0) return 'en';
-  return 'unknown';
+function setReadableFallback(text) {
+  elements.fallbackText.textContent = text;
 }
 
-function detectFromBrowser() {
-  const locale = (navigator.languages && navigator.languages[0]) || navigator.language || 'en';
-  return locale.toLowerCase().startsWith('th') ? 'th' : 'en';
+function applySubmissionState(isBusy) {
+  elements.input.disabled = isBusy;
+  elements.sendButton.disabled = isBusy;
 }
 
-function optionalLocalDetector(text) {
-  if (!settings.useLocalDetector || !text) return 'unknown';
-  const normalized = text.toLowerCase();
-  if (/[\u0E00-\u0E7F]/.test(normalized) || /ครับ|ค่ะ|สวัสดี|ขอบคุณ/.test(normalized)) return 'th';
-  if (/\b(hello|hi|thanks|please|what|how)\b/.test(normalized)) return 'en';
-  return 'unknown';
-}
-
-function chooseLanguage(text) {
-  if (settings.languagePreference !== 'auto') return settings.languagePreference;
-  const browserLang = detectFromBrowser();
-  const inputLang = detectFromInput(text);
-  const localModelLang = optionalLocalDetector(text);
-  const resolved = inputLang !== 'unknown'
-    ? inputLang
-    : localModelLang !== 'unknown'
-      ? localModelLang
-      : settings.sessionLanguageMemory || browserLang;
-  settings.sessionLanguageMemory = resolved;
-  return resolved;
-}
-
-function routeResponse(text, language) {
-  const normalized = text.trim().toLowerCase();
-  const isGreeting = /^(hello|hi|hey|สวัสดี|หวัดดี)/i.test(normalized);
-  const isGratitude = /(thank|ขอบคุณ)/i.test(normalized);
-  const isQuestion = normalized.includes('?') || /^(what|how|why|when|where|อะไร|ทำไม|อย่างไร)/i.test(normalized);
-
-  if (isGreeting) {
-    return {
-      mood: 'greeting',
-      status: language === 'th' ? 'กำลังก่อรูปคำทักทาย' : 'Manifesting a greeting',
-      text: language === 'th' ? 'สวัสดี ยินดีที่ได้พบคุณ' : 'Hello, glad you are here.',
-    };
-  }
-
-  if (isGratitude) {
-    return {
-      mood: 'warm',
-      status: language === 'th' ? 'ตอบรับด้วยความอบอุ่น' : 'Acknowledging warmly',
-      text: language === 'th' ? 'ด้วยความยินดี ฉันอยู่ตรงนี้เพื่อคุณ' : 'You are welcome. I am here with you.',
-    };
-  }
-
-  if (isQuestion) {
-    return {
-      mood: 'answer',
-      status: language === 'th' ? 'กำลังตีความคำถาม' : 'Interpreting your question',
-      text: language === 'th'
-        ? 'ฉันรับคำถามแล้ว และกำลังก่อรูปคำตอบให้ชัดที่สุด'
-        : 'I hear your question and will shape a concise answer.',
-    };
-  }
-
-  return {
-    mood: 'ambiguity',
-    status: language === 'th' ? 'กำลังตีความอย่างนุ่มนวล' : 'Interpreting softly',
-    text: language === 'th'
-      ? 'ฉันรับสัญญาณของคุณแล้ว ลองขยายเพิ่มอีกเล็กน้อยได้เสมอ'
-      : 'I received your signal. You can add a little more detail anytime.',
-  };
-}
-
-function manifestText(text, mood) {
-  manifestation.text = text;
-  manifestation.at = performance.now();
-  manifestation.mood = mood;
-  fallbackText.textContent = text;
-}
-
-function setStatus(text) {
-  statusText.textContent = text;
-}
-
-function render(ts) {
-  const w = window.innerWidth;
-  const h = window.innerHeight;
-  context.clearRect(0, 0, w, h);
-
-  context.fillStyle = 'rgba(4,5,10,0.24)';
-  context.fillRect(0, 0, w, h);
-
-  const wave = settings.reducedMotion ? 0 : Math.sin(ts * 0.00045) * 0.12;
-  for (const p of particles) {
-    if (!settings.reducedMotion) {
-      p.x += p.vx + wave * 0.00015;
-      p.y += p.vy;
-      if (p.x < 0 || p.x > 1) p.vx *= -1;
-      if (p.y < 0 || p.y > 1) p.vy *= -1;
-    }
-    const x = p.x * w;
-    const y = p.y * h;
-    const glow = settings.reducedMotion ? 0.18 : 0.3 + Math.sin((x + ts * 0.1) * 0.01) * 0.1;
-    context.fillStyle = `rgba(127,228,255,${glow})`;
-    context.beginPath();
-    context.arc(x, y, p.r, 0, Math.PI * 2);
-    context.fill();
-  }
-
-  if (manifestation.text) {
-    const elapsed = Math.max(0, ts - manifestation.at);
-    const alpha = settings.reducedMotion ? 1 : Math.min(1, elapsed / 540);
-    const blur = manifestation.mood === 'warm' ? 22 : manifestation.mood === 'answer' ? 16 : 14;
-    context.save();
-    context.textAlign = 'center';
-    context.textBaseline = 'middle';
-    context.font = `600 ${Math.max(24, Math.min(56, w * 0.045))}px Sarabun, Inter, sans-serif`;
-    context.shadowColor = 'rgba(127,228,255,0.9)';
-    context.shadowBlur = settings.reducedMotion ? 0 : blur;
-    context.fillStyle = `rgba(235,249,255,${alpha})`;
-    context.fillText(manifestation.text, w * 0.5, h * 0.46);
-    context.restore();
-  }
-
-  requestAnimationFrame(render);
+function pushSessionEvent(payload) {
+  sessionAudit.push({
+    ...payload,
+    at: new Date().toISOString(),
+  });
 }
 
 function exportSessionAudit() {
@@ -176,6 +62,7 @@ function exportSessionAudit() {
     settings,
     trail: sessionAudit,
   };
+
   const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
@@ -185,31 +72,39 @@ function exportSessionAudit() {
   URL.revokeObjectURL(url);
 }
 
-function applySettingsBindings() {
-  document.getElementById('language-preference').addEventListener('change', (event) => {
-    settings.languagePreference = event.target.value;
-  });
-  document.getElementById('local-detector-toggle').addEventListener('change', (event) => {
-    settings.useLocalDetector = event.target.checked;
-  });
-  document.getElementById('reduced-motion-toggle').addEventListener('change', (event) => {
-    settings.reducedMotion = event.target.checked;
-  });
-  document.getElementById('voice-enabled-toggle').addEventListener('change', (event) => {
-    settings.voiceEnabled = event.target.checked;
-  });
-  document.getElementById('api-base').addEventListener('input', (event) => { settings.apiBase = event.target.value.trim(); });
-  document.getElementById('ws-base').addEventListener('input', (event) => { settings.wsBase = event.target.value.trim(); });
-  document.getElementById('runtime-mode').addEventListener('change', (event) => { settings.runtimeMode = event.target.value; });
-  document.getElementById('telemetry-toggle').addEventListener('change', (event) => { settings.telemetry = event.target.checked; });
-  document.getElementById('export-session').addEventListener('click', exportSessionAudit);
+function bindSettings() {
+  const byId = (id) => document.getElementById(id);
+
+  const bindingMap = [
+    ['language-preference', 'change', (event) => { settings.languagePreference = event.target.value; }],
+    ['local-detector-toggle', 'change', (event) => { settings.useLocalDetector = event.target.checked; }],
+    ['local-model-profile', 'change', (event) => { settings.localModelProfile = event.target.value; }],
+    ['reduced-motion-toggle', 'change', (event) => {
+      settings.reducedMotion = event.target.checked;
+      manifestationEngine.setReducedMotion(settings.reducedMotion);
+    }],
+    ['voice-enabled-toggle', 'change', (event) => { settings.voiceEnabled = event.target.checked; }],
+    ['api-base', 'input', (event) => { settings.apiBase = event.target.value.trim(); }],
+    ['ws-base', 'input', (event) => { settings.wsBase = event.target.value.trim(); }],
+    ['runtime-mode', 'change', (event) => { settings.runtimeMode = event.target.value; }],
+    ['telemetry-toggle', 'change', (event) => { settings.telemetry = event.target.checked; }],
+    ['lineage-toggle', 'change', (event) => { settings.lineage = event.target.checked; }],
+    ['scholar-toggle', 'change', (event) => { settings.scholar = event.target.checked; }],
+    ['governor-toggle', 'change', (event) => { settings.governorDebug = event.target.checked; }],
+    ['devtools-toggle', 'change', (event) => { settings.developerTools = event.target.checked; }],
+  ];
+
+  bindingMap.forEach(([id, type, handler]) => byId(id).addEventListener(type, handler));
+  byId('export-session').addEventListener('click', exportSessionAudit);
+
+  byId('reduced-motion-toggle').checked = settings.reducedMotion;
 }
 
 function initVoice() {
   const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
   if (!SpeechRecognition) {
-    voiceBtn.disabled = true;
-    voiceBtn.title = 'Speech API unavailable';
+    elements.voiceButton.disabled = true;
+    elements.voiceButton.title = 'Speech API unavailable';
     return;
   }
 
@@ -218,28 +113,31 @@ function initVoice() {
   recognition.interimResults = false;
 
   let listening = false;
-  voiceBtn.addEventListener('click', () => {
+
+  elements.voiceButton.addEventListener('click', () => {
     if (!settings.voiceEnabled) return;
+
     if (listening) {
       recognition.stop();
       return;
     }
-    recognition.lang = chooseLanguage(input.value || '') === 'th' ? 'th-TH' : 'en-US';
+
+    const language = languageLayer.resolveLanguage(elements.input.value || '');
+    recognition.lang = language === 'th' ? 'th-TH' : 'en-US';
     recognition.start();
   });
 
   recognition.onstart = () => {
     listening = true;
-    voiceBtn.setAttribute('aria-pressed', 'true');
+    elements.voiceButton.setAttribute('aria-pressed', 'true');
     setStatus(settings.sessionLanguageMemory === 'th' ? 'กำลังฟังเสียง' : 'Listening');
   };
 
   recognition.onresult = (event) => {
     const transcript = event.results?.[0]?.[0]?.transcript?.trim();
-    if (transcript) {
-      input.value = transcript;
-      form.requestSubmit();
-    }
+    if (!transcript) return;
+    elements.input.value = transcript;
+    elements.form.requestSubmit();
   };
 
   recognition.onerror = () => {
@@ -248,42 +146,63 @@ function initVoice() {
 
   recognition.onend = () => {
     listening = false;
-    voiceBtn.setAttribute('aria-pressed', 'false');
+    elements.voiceButton.setAttribute('aria-pressed', 'false');
   };
 }
 
-form.addEventListener('submit', (event) => {
+function onComposerSubmit(event) {
   event.preventDefault();
-  const text = input.value.trim();
+  const text = elements.input.value.trim();
   if (!text) return;
 
-  const language = chooseLanguage(text);
-  const response = routeResponse(text, language);
+  applySubmissionState(true);
+  setStatus(settings.sessionLanguageMemory === 'th' ? 'กำลังตีความ' : 'Interpreting');
+
+  const language = languageLayer.resolveLanguage(text);
+  const response = routeLightResponse(text, language);
+
+  manifestationEngine.manifestText(response.text, response.mood);
+  setReadableFallback(response.text);
   setStatus(response.status);
-  manifestText(response.text, response.mood);
 
-  sessionAudit.push({ at: new Date().toISOString(), input: text, language, response });
-  input.value = '';
-});
+  pushSessionEvent({
+    input: text,
+    language,
+    response,
+  });
 
-settingsToggle.addEventListener('click', () => {
-  const open = settingsPanel.hidden;
-  settingsPanel.hidden = !open;
-  settingsToggle.setAttribute('aria-expanded', String(open));
-  if (open) document.getElementById('api-base').focus();
-});
+  elements.input.value = '';
+  applySubmissionState(false);
+}
 
-closeSettings.addEventListener('click', () => {
-  settingsPanel.hidden = true;
-  settingsToggle.setAttribute('aria-expanded', 'false');
-  settingsToggle.focus();
-});
+function bindSettingsPanel() {
+  elements.settingsToggle.addEventListener('click', () => {
+    const willOpen = elements.settingsPanel.hidden;
+    elements.settingsPanel.hidden = !willOpen;
+    elements.settingsToggle.setAttribute('aria-expanded', String(willOpen));
+    if (willOpen) document.getElementById('api-base').focus();
+  });
 
-window.addEventListener('resize', resize);
+  elements.closeSettings.addEventListener('click', () => {
+    elements.settingsPanel.hidden = true;
+    elements.settingsToggle.setAttribute('aria-expanded', 'false');
+    elements.settingsToggle.focus();
+  });
+}
 
-applySettingsBindings();
-initVoice();
-resize();
-setStatus('พร้อมฟัง');
-manifestText('สวัสดี — Hello', 'greeting');
-requestAnimationFrame(render);
+function bootstrap() {
+  bindSettings();
+  bindSettingsPanel();
+  initVoice();
+
+  elements.form.addEventListener('submit', onComposerSubmit);
+  window.addEventListener('resize', manifestationEngine.resize);
+
+  manifestationEngine.resize();
+  setStatus('พร้อมฟัง');
+  manifestationEngine.manifestText('สวัสดี — Hello', 'greeting');
+  setReadableFallback('สวัสดี — Hello');
+  requestAnimationFrame(manifestationEngine.render);
+}
+
+bootstrap();

--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -94,7 +94,10 @@ function bindSettings() {
     ['devtools-toggle', 'change', (event) => { settings.developerTools = event.target.checked; }],
   ];
 
-  bindingMap.forEach(([id, type, handler]) => byId(id).addEventListener(type, handler));
+  bindingMap.forEach(([id, type, handler]) => {
+    const el = byId(id);
+    if (el) el.addEventListener(type, handler);
+  });
   byId('export-session').addEventListener('click', exportSessionAudit);
 
   byId('reduced-motion-toggle').checked = settings.reducedMotion;

--- a/docs/clean_first_use_surface.md
+++ b/docs/clean_first_use_surface.md
@@ -9,19 +9,26 @@ The homepage intentionally renders only:
 - Full-screen manifestation canvas (light field).
 - Minimal bottom composer.
 - One Settings button.
-- Subtle human-readable status text.
+- Subtle human-readable status text and a lightweight readable fallback line.
 
 No dashboard/HUD/debug panels are shown on first view.
 
 ## Module split
 
 - `clean-first-surface.js`
-  - `manifestText`: text-from-light orchestration and readable fallback.
-  - `chooseLanguage`: deterministic language selection with session memory.
-  - `routeResponse`: first-run deterministic response rules.
-  - `initVoice`: progressive speech enhancement with graceful fallback.
-- `clean-first-surface.css`
-  - calm visual language, keyboard focus visibility, and reduced motion behavior.
+  - App bootstrap and orchestration.
+  - Settings wiring and session audit export.
+  - Voice progressive-enhancement integration.
+- `first_use_surface/light-manifestation.js`
+  - Luminous text renderer with glyph-sampling particle halo.
+  - Calm ambient particle field.
+  - Reduced-motion aware transitions.
+- `first_use_surface/language-layer.js`
+  - Deterministic language choice with session memory.
+  - Browser-locale + character-range baseline detection.
+  - Optional local rule-based detector layer.
+- `first_use_surface/response-orchestrator.js`
+  - Deterministic first-run response rules for greeting/gratitude/question/unknown intent.
 
 ## Language detection strategy
 
@@ -40,11 +47,17 @@ All advanced controls are kept inside Settings:
 - API/WS base paths.
 - Runtime mode and telemetry options.
 - Lineage/replay/scholar/governor/developer toggles.
-- Language and voice options.
+- Reduced-motion and language/voice/local-detector options.
 - Session audit export.
+
+## Fallback behavior
+
+- If SpeechRecognition is not available, voice control disables itself without breaking the composer flow.
+- If language detection confidence is low, the runtime uses deterministic fallback + session memory.
+- If animations are reduced, luminous text remains readable without relying on motion cues.
 
 ## Limitations
 
 - Current language detector is heuristic and local-rule based (no heavy ML model).
 - Voice input depends on browser SpeechRecognition availability.
-- Exported session audit is local file download and in-memory only.
+- Session audit export remains local-download + in-memory trail.

--- a/first_use_surface/language-layer.js
+++ b/first_use_surface/language-layer.js
@@ -1,0 +1,73 @@
+const THAI_REGEX = /[\u0E00-\u0E7F]/;
+const ENGLISH_REGEX = /[A-Za-z]/;
+
+function detectFromBrowser() {
+  const locales = navigator.languages && navigator.languages.length > 0
+    ? navigator.languages
+    : [navigator.language || 'en'];
+  return locales.some((locale) => locale.toLowerCase().startsWith('th')) ? 'th' : 'en';
+}
+
+function detectFromCharacters(text) {
+  if (!text) return 'unknown';
+
+  const thaiChars = (text.match(/[\u0E00-\u0E7F]/g) || []).length;
+  const englishChars = (text.match(/[A-Za-z]/g) || []).length;
+
+  if (thaiChars > englishChars) return 'th';
+  if (englishChars > thaiChars) return 'en';
+
+  if (THAI_REGEX.test(text)) return 'th';
+  if (ENGLISH_REGEX.test(text)) return 'en';
+  return 'unknown';
+}
+
+function optionalLocalDetector(text, enabled, profile) {
+  if (!enabled || profile === 'none' || !text) return 'unknown';
+  const normalized = text.trim().toLowerCase();
+
+  if (/\b(สวัสดี|หวัดดี|ขอบคุณ|ครับ|ค่ะ|ช่วย|อะไร|ทำไม|อย่างไร)\b/.test(normalized)) {
+    return 'th';
+  }
+
+  if (/\b(hello|hi|hey|thanks|thank you|please|what|how|why|where|can you)\b/.test(normalized)) {
+    return 'en';
+  }
+
+  return 'unknown';
+}
+
+export function createLanguageLayer(settings) {
+  const state = {
+    sessionLanguageMemory: settings.sessionLanguageMemory || 'en',
+  };
+
+  function resolveLanguage(inputText) {
+    if (settings.languagePreference !== 'auto') {
+      state.sessionLanguageMemory = settings.languagePreference;
+      settings.sessionLanguageMemory = settings.languagePreference;
+      return settings.languagePreference;
+    }
+
+    const browserLanguage = detectFromBrowser();
+    const inputLanguage = detectFromCharacters(inputText);
+    const optionalLanguage = optionalLocalDetector(inputText, settings.useLocalDetector, settings.localModelProfile);
+
+    const resolvedLanguage = inputLanguage !== 'unknown'
+      ? inputLanguage
+      : optionalLanguage !== 'unknown'
+        ? optionalLanguage
+        : state.sessionLanguageMemory || browserLanguage;
+
+    state.sessionLanguageMemory = resolvedLanguage;
+    settings.sessionLanguageMemory = resolvedLanguage;
+
+    return resolvedLanguage;
+  }
+
+  return {
+    detectFromBrowser,
+    detectFromCharacters,
+    resolveLanguage,
+  };
+}

--- a/first_use_surface/light-manifestation.js
+++ b/first_use_surface/light-manifestation.js
@@ -55,10 +55,10 @@ export function createLightManifestation(canvas, reducedMotion) {
 
     const width = Math.max(420, Math.floor(window.innerWidth * 0.7));
     const height = 160;
-    const offscreen = document.createElement('canvas');
+    const offscreen = updateGlyphMap.canvas || (updateGlyphMap.canvas = document.createElement('canvas'));
+    const offscreenContext = updateGlyphMap.ctx || (updateGlyphMap.ctx = offscreen.getContext('2d', { willReadFrequently: true }));
     offscreen.width = width;
     offscreen.height = height;
-    const offscreenContext = offscreen.getContext('2d', { willReadFrequently: true });
 
     offscreenContext.clearRect(0, 0, width, height);
     offscreenContext.textAlign = 'center';

--- a/first_use_surface/light-manifestation.js
+++ b/first_use_surface/light-manifestation.js
@@ -1,0 +1,173 @@
+function createParticleField(count) {
+  return Array.from({ length: count }, () => ({
+    x: Math.random(),
+    y: Math.random(),
+    r: Math.random() * 1.4 + 0.5,
+    vx: (Math.random() - 0.5) * 0.00045,
+    vy: (Math.random() - 0.5) * 0.00045,
+  }));
+}
+
+function moodPalette(mood) {
+  switch (mood) {
+    case 'warm':
+      return { glow: '255, 210, 138', core: '255, 244, 220' };
+    case 'answer':
+      return { glow: '146, 222, 255', core: '236, 248, 255' };
+    case 'ambiguity':
+      return { glow: '184, 165, 255', core: '241, 237, 255' };
+    case 'greeting':
+    default:
+      return { glow: '127, 228, 255', core: '235, 249, 255' };
+  }
+}
+
+function clampAlpha(alpha) {
+  return Math.max(0, Math.min(1, alpha));
+}
+
+export function createLightManifestation(canvas, reducedMotion) {
+  const context = canvas.getContext('2d');
+  const particles = createParticleField(320);
+  const manifestation = {
+    text: '',
+    mood: 'greeting',
+    startedAt: performance.now(),
+    glyphPoints: [],
+  };
+
+  const options = {
+    reducedMotion,
+  };
+
+  function resize() {
+    const dpr = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
+    canvas.width = Math.floor(window.innerWidth * dpr);
+    canvas.height = Math.floor(window.innerHeight * dpr);
+    context.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  function updateGlyphMap(text) {
+    if (!text) {
+      manifestation.glyphPoints = [];
+      return;
+    }
+
+    const width = Math.max(420, Math.floor(window.innerWidth * 0.7));
+    const height = 160;
+    const offscreen = document.createElement('canvas');
+    offscreen.width = width;
+    offscreen.height = height;
+    const offscreenContext = offscreen.getContext('2d', { willReadFrequently: true });
+
+    offscreenContext.clearRect(0, 0, width, height);
+    offscreenContext.textAlign = 'center';
+    offscreenContext.textBaseline = 'middle';
+    offscreenContext.fillStyle = '#ffffff';
+    offscreenContext.font = `700 ${Math.max(24, Math.min(54, width * 0.075))}px Inter, Sarabun, sans-serif`;
+    offscreenContext.fillText(text, width * 0.5, height * 0.54);
+
+    const imageData = offscreenContext.getImageData(0, 0, width, height).data;
+    const points = [];
+    const step = options.reducedMotion ? 8 : 6;
+
+    for (let y = 0; y < height; y += step) {
+      for (let x = 0; x < width; x += step) {
+        const pixelIndex = (y * width + x) * 4 + 3;
+        if (imageData[pixelIndex] > 100) {
+          points.push({
+            x: x / width,
+            y: y / height,
+          });
+        }
+      }
+    }
+
+    manifestation.glyphPoints = points;
+  }
+
+  function manifestText(text, mood) {
+    manifestation.text = text;
+    manifestation.mood = mood;
+    manifestation.startedAt = performance.now();
+    updateGlyphMap(text);
+  }
+
+  function setReducedMotion(value) {
+    options.reducedMotion = value;
+    if (manifestation.text) updateGlyphMap(manifestation.text);
+  }
+
+  function render(ts) {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+    context.clearRect(0, 0, width, height);
+    context.fillStyle = 'rgba(5, 8, 14, 0.25)';
+    context.fillRect(0, 0, width, height);
+
+    const wave = options.reducedMotion ? 0 : Math.sin(ts * 0.00035) * 0.25;
+    particles.forEach((particle, index) => {
+      if (!options.reducedMotion) {
+        particle.x += particle.vx + wave * 0.00012;
+        particle.y += particle.vy;
+        if (particle.x < 0 || particle.x > 1) particle.vx *= -1;
+        if (particle.y < 0 || particle.y > 1) particle.vy *= -1;
+      }
+
+      const x = particle.x * width;
+      const y = particle.y * height;
+      const alpha = options.reducedMotion
+        ? 0.18
+        : 0.24 + Math.sin(ts * 0.001 + index * 0.16) * 0.08;
+
+      context.fillStyle = `rgba(127,228,255,${clampAlpha(alpha)})`;
+      context.beginPath();
+      context.arc(x, y, particle.r, 0, Math.PI * 2);
+      context.fill();
+    });
+
+    if (manifestation.text) {
+      const elapsed = Math.max(0, ts - manifestation.startedAt);
+      const alpha = options.reducedMotion ? 1 : clampAlpha(elapsed / 520);
+      const palette = moodPalette(manifestation.mood);
+      const centerY = height * 0.43;
+      const fontSize = Math.max(26, Math.min(58, width * 0.047));
+
+      if (!options.reducedMotion && manifestation.glyphPoints.length > 0) {
+        const glyphWidth = Math.max(420, Math.floor(width * 0.7));
+        const glyphHeight = 160;
+        const originX = (width - glyphWidth) * 0.5;
+        const originY = centerY - glyphHeight * 0.5;
+
+        context.fillStyle = `rgba(${palette.glow},${clampAlpha(alpha * 0.85)})`;
+        manifestation.glyphPoints.forEach((point, index) => {
+          if (index % 2 !== 0) return;
+          const shimmer = Math.sin(ts * 0.007 + index * 0.11) * 0.7;
+          const radius = 1 + Math.max(0, shimmer);
+          context.beginPath();
+          context.arc(originX + point.x * glyphWidth, originY + point.y * glyphHeight, radius, 0, Math.PI * 2);
+          context.fill();
+        });
+      }
+
+      context.save();
+      context.textAlign = 'center';
+      context.textBaseline = 'middle';
+      context.font = `700 ${fontSize}px Inter, Sarabun, sans-serif`;
+      context.shadowColor = `rgba(${palette.glow},0.9)`;
+      context.shadowBlur = options.reducedMotion ? 0 : 22;
+      context.fillStyle = `rgba(${palette.core},${alpha})`;
+      context.fillText(manifestation.text, width * 0.5, centerY);
+      context.restore();
+    }
+
+    requestAnimationFrame(render);
+  }
+
+  return {
+    manifestText,
+    resize,
+    render,
+    setReducedMotion,
+  };
+}

--- a/first_use_surface/response-orchestrator.js
+++ b/first_use_surface/response-orchestrator.js
@@ -1,0 +1,50 @@
+function localized(language, thText, enText) {
+  return language === 'th' ? thText : enText;
+}
+
+export function routeLightResponse(inputText, language) {
+  const normalized = inputText.trim().toLowerCase();
+
+  const isGreeting = /^(hello|hi|hey|สวัสดี|หวัดดี|ดีจ้า|โย่ว)/i.test(normalized);
+  const isGratitude = /(thank|ขอบคุณ|thx|ขอบใจ)/i.test(normalized);
+  const isQuestion = normalized.includes('?')
+    || /^(what|how|why|when|where|who|can|could|should|do|does|is|are|อะไร|ทำไม|อย่างไร|เมื่อไร|ที่ไหน|ใคร)/i.test(normalized);
+
+  if (isGreeting) {
+    return {
+      mood: 'greeting',
+      status: localized(language, 'กำลังก่อรูปคำทักทาย', 'Manifesting a greeting'),
+      text: localized(language, 'สวัสดี ยินดีที่ได้พบคุณ', 'Hello. It is good to meet you.'),
+    };
+  }
+
+  if (isGratitude) {
+    return {
+      mood: 'warm',
+      status: localized(language, 'ตอบรับด้วยความอบอุ่น', 'Responding with warmth'),
+      text: localized(language, 'ด้วยความยินดี ฉันอยู่ตรงนี้เพื่อช่วยคุณ', 'You are welcome. I am here to help.'),
+    };
+  }
+
+  if (isQuestion) {
+    return {
+      mood: 'answer',
+      status: localized(language, 'กำลังตีความคำถาม', 'Interpreting your question'),
+      text: localized(
+        language,
+        'ฉันรับคำถามแล้ว ลองเพิ่มบริบทอีกเล็กน้อยเพื่อคำตอบที่แม่นขึ้น',
+        'I received your question. Add a bit more context for a sharper answer.',
+      ),
+    };
+  }
+
+  return {
+    mood: 'ambiguity',
+    status: localized(language, 'กำลังตีความอย่างนุ่มนวล', 'Interpreting softly'),
+    text: localized(
+      language,
+      'ฉันรับสัญญาณของคุณแล้ว คุณสามารถขยายความได้อีกนิด',
+      'I received your signal. You can expand it a little for clarity.',
+    ),
+  };
+}

--- a/index.html
+++ b/index.html
@@ -86,6 +86,12 @@
           </select>
         </label>
         <label><input id="local-detector-toggle" type="checkbox" checked /> Use local language detector</label>
+        <label>Local model profile
+          <select id="local-model-profile">
+            <option value="none">None (heuristics only)</option>
+            <option value="tiny-rules" selected>Tiny rules (short text)</option>
+          </select>
+        </label>
         <label><input id="reduced-motion-toggle" type="checkbox" /> Reduced motion</label>
         <label><input id="voice-enabled-toggle" type="checkbox" checked /> Voice input options</label>
       </section>


### PR DESCRIPTION
### Motivation
- Replace the dashboard-like homepage with a calm, minimal first-use surface that presents a full-screen light manifestation, a simple bottom composer, a single Settings entry point, and subtle human-readable status text.
- Move all secondary/advanced runtime, telemetry, lineage, debug and connection controls into the Settings panel only so the first view remains uncluttered and backend-optional.
- Provide a deterministic, local-first language-aware response layer and a reliable luminous text manifestation so first-run interactions are readable and meaningful without cloud dependencies.

### Description
- Reworked homepage HTML and UI shell in `index.html` to show only the full-screen canvas, bottom composer, one settings toggle, ambient status, and readable fallback line, and moved advanced controls into the `Settings` drawer. (`index.html`).
- Split and refactored runtime into modular pieces: `first_use_surface/light-manifestation.js` (luminous text renderer + glyph-sampled particle halo, reduced-motion aware), `first_use_surface/language-layer.js` (deterministic language resolution chain with session memory), and `first_use_surface/response-orchestrator.js` (first-run deterministic rules: greeting/gratitude/question/ambiguity). (`first_use_surface/*`).
- Rewrote orchestration into `clean-first-surface.js` to wire settings bindings, session audit export, voice progressive enhancement, language layer, and the manifestation engine, and added a `localModelProfile` option for pluggable local detectors. (`clean-first-surface.js`).
- Documentation updated at `docs/clean_first_use_surface.md` describing module split, language detection strategy, fallback behavior, and limitations.

### Testing
- Ran `npm run lint` against the web package and it completed successfully. 
- Ran `python3 tools/contracts/contract_checker.py` and it failed in this environment due to a Pydantic runtime/model rebuild error (`CognitiveEmitRequest` not fully defined) unrelated to the frontend changes; this is an existing runtime check failure and not caused by the homepage refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e142ebfc70832092c2329a374630e9)