### PR TITLE
[first-use-surface] Stabilize clean homepage language-first interaction flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,26 +3,29 @@
 ## English Documentation
 
 ### Overview
-Aetherium Manifest is the frontend expression layer of the Aetherium ecosystem. It visualizes AI intent, confidence, and runtime state through light, motion, and abstract form.
+Aetherium Manifest is a light-native first-use runtime. The homepage stays intentionally calm and minimal: one manifestation field, one composer, and one Settings entry point.
 
-### Architecture
-- **AETHERIUM-GENESIS (Backend):** reasoning core, intent generation, telemetry interpretation.
-- **Aetherium Manifest (Frontend):** visual embodiment and interaction runtime.
-- **Transport:** API/WebSocket contract over AetherBus.
+### First-use Surface (Current)
+- Full-screen light field/canvas as the primary reasoning and presentation surface.
+- Minimal bottom composer for immediate natural-language input.
+- Single Settings button for all advanced controls.
+- Subtle human-readable status line plus a readable fallback text line.
+- Greeting inputs (for example: `hello`, `hi`, `สวัสดี`) respond through luminous text manifestation rather than dashboard widgets.
 
-### Current Runtime Capabilities
-- Real-time particle/shape rendering mapped from intent vectors.
-- Voice interaction pipeline (VAD mock + STT mock + intent mapping).
-- Adaptive quality tier and frame-rate management.
-- Accessibility-focused controls with visual microphone feedback.
-- Window manager for all HUD panels:
-  - close (✕) per panel
-  - reopen from Settings > Panels
-  - drag-to-move and resize
-- Settings with 5 tabs: `Display`, `Panels`, `Links`, `Language`, `Voice`.
-- External URL analysis entry point in Settings (`Analyze URL`).
-- Event-driven command bus + telemetry counters + delta-state patch helper.
-- Upgraded to an installable web application (PWA) with manifest, service worker, and core assets.
+### Settings as the Single Advanced Surface
+All technical/runtime controls are intentionally moved into Settings:
+- API Base / WS Base
+- Runtime mode, telemetry, lineage/replay, scholar/search, governor debug, developer tools
+- Reduced motion, language preference, local language detector profile, voice options
+- Session audit export
+
+### Language-aware Response Layer (First-run)
+Deterministic language resolution is implemented with progressive fallback:
+1. Explicit language preference in Settings
+2. Browser locale (`navigator.languages` / `navigator.language`)
+3. Input-text heuristics (Thai vs English character ranges)
+4. Optional local detector rules (pluggable; no required network call)
+5. Session language memory
 
 ### API Gateway (Prototype)
 The `api_gateway/` folder includes a sample Cognitive DSL gateway:
@@ -31,80 +34,52 @@ The `api_gateway/` folder includes a sample Cognitive DSL gateway:
 - `GET /health`
 - `WS /ws/cognitive-stream`
 
-### AetherBusExtreme Utilities
-`api_gateway/aetherbus_extreme.py` includes:
-- Zero-copy socket send (`memoryview`) + async-safe send helper (`loop.sock_sendall`)
-- Immutable envelope models
-- Async queue bus with backpressure
-- MsgPack helpers
-- NATS async manager
-- State convergence processor
-
 ### Run Locally
 ```bash
 python3 -m http.server 4173
 # open http://localhost:4173
 ```
 
-### CI/CD Note
-- GitHub/Azure automation that was not in active use has been removed from this repository.
-- Deployment and quality checks should be run manually or from an external CI system outside this repo.
-- If branch protection requires status checks, update required checks in GitHub repository settings to match your active process.
-- See [remove-unused-platform-automation.md](docs/repo-maintenance/remove-unused-platform-automation.md) for more details.
-
-### Recommended Next Steps
-- Move mutable runtime state to Redis (metrics counters, telemetry cache, and websocket room membership) for multi-worker consistency.
-- Add signed outbound proxy policy (HMAC request intent + per-tenant allowlist) to harden enterprise SSRF controls.
-- Build a contract-fuzz pipeline: property-based payload generators + mutation corpus for schema regression stress tests.
-- Add persisted TSDB backend (InfluxDB/TimescaleDB) with retention and downsampling policies.
-- Add proxy allowlist/denylist + content-type and size guardrails for stronger SSRF safety.
-- Add locale QA checks (missing-key scanner + pseudolocale) in CI.
-- Add voice A/B routing and collect WER/latency metrics by language-region cohort.
-- Add CRDT merge (Yjs/Automerge) for conflict-free collaborative editing beyond simple delta updates.
+### Recommended Next Steps (Open)
+- Add persistent telemetry storage with retention/downsampling policies.
+- Add enterprise outbound proxy hardening (allow/deny lists, payload/content guardrails).
+- Expand deterministic response rules beyond greeting/gratitude/simple question flows.
+- Add broader language coverage beyond Thai/English short-text first-run heuristics.
 
 ---
 
 ## เอกสารภาษาไทย
 
 ### ภาพรวม
-Aetherium Manifest คือเลเยอร์แสดงผลฝั่ง Frontend ของระบบ Aetherium โดยแปลงเจตนาและสถานะของ AI ให้เป็นภาพเคลื่อนไหวเชิงนามธรรม
+Aetherium Manifest คือรันไทม์หน้าแรกแบบ light-native ที่ออกแบบให้สงบ เรียบ และเริ่มใช้งานได้ทันที โดยให้ “แสง” เป็นแกนหลักของการสื่อความหมาย
 
-### โครงสร้างระบบ
-- **AETHERIUM-GENESIS (Backend):** คิด วิเคราะห์ และสร้าง intent
-- **Aetherium Manifest (Frontend):** แสดงผลและโต้ตอบผู้ใช้
-- **การเชื่อมต่อ:** ผ่าน API/WebSocket บน AetherBus
+### หน้าแรก (เวอร์ชันปัจจุบัน)
+- พื้นที่แสงเต็มหน้าจอเป็นแกนของการให้เหตุผลและการแสดงผล
+- Composer ด้านล่างแบบมินิมอลสำหรับพิมพ์ข้อความได้ทันที
+- ปุ่ม Settings เพียงจุดเดียว
+- มีสถานะที่มนุษย์อ่านได้ และบรรทัดข้อความ fallback ที่อ่านชัด
+- อินพุตทักทาย เช่น `hello`, `hi`, `สวัสดี` จะตอบผ่านข้อความเรืองแสง ไม่ใช้แดชบอร์ดหรือวิดเจ็ตหนัก
 
-### ความสามารถปัจจุบัน
-- ระบบแสดงผลแบบเรียลไทม์ด้วยอนุภาคและรูปทรงตาม intent
-- Voice pipeline (VAD/STT แบบ mock) + intent mapping
-- ปรับคุณภาพกราฟิกตามเครื่องและจัดการเฟรมเรต
-- ปุ่มควบคุมที่เป็นมิตรต่อการเข้าถึง (Accessibility)
-- HUD ทุกหน้าต่างมีปุ่มปิด เปิดคืนได้จาก Settings และลาก/ย่อ-ขยายได้
-- Settings แบ่ง 5 แท็บ: `Display`, `Panels`, `Links`, `Language`, `Voice`
-- มีช่องวิเคราะห์ลิงก์ URL ภายนอก
-- มีโครง telemetry + event bus + delta-state สำหรับต่อยอด
-- ยกระดับเป็น installable web application (PWA) พร้อม manifest, service worker และ asset แกนหลัก
+### Settings เป็นศูนย์รวมฟังก์ชันขั้นสูง
+ฟังก์ชันเชิงเทคนิคทั้งหมดอยู่ใน Settings เท่านั้น:
+- API Base / WS Base
+- Runtime mode, telemetry, lineage/replay, scholar/search, governor debug, developer tools
+- Reduced motion, language preference, local detector profile, voice options
+- ส่งออก session audit
+
+### ชั้นการตอบสนองเชิงภาษา (สำหรับ first-run)
+ลำดับการเลือกภาษาแบบ deterministic:
+1. ภาษาที่ผู้ใช้กำหนดใน Settings
+2. ภาษาจากเบราว์เซอร์ (`navigator.languages` / `navigator.language`)
+3. ตรวจจากตัวอักษรในข้อความอินพุต (ไทย/อังกฤษ)
+4. local detector แบบเบา (เปิด/ปิดได้ และไม่บังคับเรียกเครือข่าย)
+5. หน่วยความจำภาษาใน session
 
 ### API Gateway (ต้นแบบ)
 โฟลเดอร์ `api_gateway/` มีตัวอย่าง Cognitive DSL gateway พร้อม endpoint สำหรับ emit/validate/health/websocket
 
-### แนวทางต่อยอด
-- ย้าย mutable runtime state ไปที่ Redis (metrics counters, telemetry cache และสมาชิกห้อง websocket) เพื่อรองรับหลาย worker ได้สม่ำเสมอ
-- เพิ่มนโยบาย signed outbound proxy (HMAC request intent + allowlist ตาม tenant) เพื่อเสริมความปลอดภัย SSRF ระดับองค์กร
-- สร้าง contract-fuzz pipeline ด้วยตัวสร้าง payload เชิง property-based และ mutation corpus สำหรับ stress test schema regression
-- เพิ่ม persisted TSDB backend (InfluxDB/TimescaleDB) พร้อมนโยบาย retention และ downsampling
-- เพิ่ม allowlist/denylist, content-type guardrail และขนาด payload guardrail ใน proxy
-- เพิ่ม locale QA checks ใน CI (missing-key scanner + pseudolocale)
-- เพิ่ม voice A/B routing และเก็บ WER/latency แยกตามภาษาและภูมิภาค
-- เพิ่มกลไก CRDT merge (Yjs/Automerge) สำหรับงาน collaborative editing ที่ซับซ้อนกว่า delta พื้นฐาน
-
-
-## Extension Ideas
-- Move mutable runtime state to Redis (metrics counters, telemetry cache, and websocket room membership) for multi-worker consistency.
-- Add signed outbound proxy policy (HMAC request intent + per-tenant allowlist) to harden enterprise SSRF controls.
-- Build a contract-fuzz pipeline: property-based payload generators + mutation corpus for schema regression stress tests.
-- Add persisted TSDB backend (InfluxDB/TimescaleDB) with retention and downsampling policies.
-- Add proxy allowlist/denylist + content-type and size guardrails for stronger SSRF safety.
-- Add locale QA checks (missing-key scanner + pseudolocale) in CI.
-- Add voice A/B routing and collect WER/latency metrics by language-region cohort.
-- Add CRDT merge (Yjs/Automerge) for conflict-free collaborative editing beyond simple delta updates.
+### แนวทางต่อยอด (ที่ยังเปิดอยู่)
+- เพิ่มระบบเก็บ telemetry แบบถาวร พร้อมนโยบาย retention/downsampling
+- เสริมความปลอดภัย outbound proxy ระดับองค์กร (allow/deny list และ guardrail ด้าน payload/content)
+- ขยาย deterministic response rules ให้ครอบคลุมเจตนาที่หลากหลายขึ้น
+- เพิ่มการรองรับภาษาอื่นนอกเหนือจากไทย/อังกฤษในกรณีข้อความสั้น

--- a/clean-first-surface.css
+++ b/clean-first-surface.css
@@ -94,7 +94,7 @@ body {
   padding: 10px;
   border-radius: 18px;
   background: rgba(8, 11, 18, 0.56);
-  border: 1px solid rgba(200, 236, 255, 0.2);
+  border: 1px solid var(--line);
   backdrop-filter: blur(8px);
 }
 

--- a/clean-first-surface.css
+++ b/clean-first-surface.css
@@ -1,6 +1,6 @@
 :root {
   color-scheme: dark;
-  --bg: #04050a;
+  --bg: #03040a;
   --ink: #f4fbff;
   --line: rgba(200, 236, 255, 0.28);
   --panel: rgba(11, 14, 20, 0.88);
@@ -16,7 +16,7 @@ body {
   height: 100%;
   overflow: hidden;
   font-family: Inter, Sarabun, system-ui, -apple-system, sans-serif;
-  background: radial-gradient(circle at 50% 16%, #12162a 0%, var(--bg) 48%);
+  background: radial-gradient(circle at 50% 16%, #101527 0%, var(--bg) 52%);
   color: var(--ink);
 }
 
@@ -76,32 +76,32 @@ body {
 .ambient-status {
   opacity: 0.84;
   font-size: clamp(14px, 2.2vw, 20px);
-  margin-bottom: 12px;
+  margin-bottom: 10px;
 }
 
 .readable-fallback {
   min-height: 1.2em;
-  margin-bottom: 18px;
+  margin-bottom: 16px;
   opacity: 0.92;
 }
 
 .composer {
   margin: 0 auto;
-  width: min(860px, calc(100vw - 28px));
+  width: min(780px, calc(100vw - 28px));
   display: grid;
   grid-template-columns: 1fr auto auto;
   gap: 10px;
   padding: 10px;
   border-radius: 18px;
-  background: rgba(12, 16, 24, 0.64);
-  border: 1px solid var(--line);
-  backdrop-filter: blur(10px);
+  background: rgba(8, 11, 18, 0.56);
+  border: 1px solid rgba(200, 236, 255, 0.2);
+  backdrop-filter: blur(8px);
 }
 
 #intent-input {
   border: 1px solid transparent;
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.07);
+  background: rgba(255, 255, 255, 0.06);
   color: var(--ink);
   padding: 0 12px;
   height: 42px;

--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -15,6 +15,23 @@ const elements = {
   voiceButton: document.getElementById('voice-btn'),
 };
 
+const uiText = {
+  th: {
+    ready: 'พร้อมฟัง',
+    interpreting: 'กำลังตีความ',
+    listening: 'กำลังฟังเสียง',
+    voiceUnavailable: 'เสียงไม่พร้อม ใช้การพิมพ์แทน',
+    speechApiUnavailable: 'เบราว์เซอร์ไม่รองรับ Speech API',
+  },
+  en: {
+    ready: 'Ready to listen',
+    interpreting: 'Interpreting',
+    listening: 'Listening',
+    voiceUnavailable: 'Voice unavailable, type instead',
+    speechApiUnavailable: 'Speech API unavailable in this browser',
+  },
+};
+
 const settings = {
   languagePreference: 'auto',
   useLocalDetector: true,
@@ -35,6 +52,15 @@ const settings = {
 const sessionAudit = [];
 const languageLayer = createLanguageLayer(settings);
 const manifestationEngine = createLightManifestation(elements.canvas, settings.reducedMotion);
+
+function activeLanguage() {
+  return settings.sessionLanguageMemory === 'en' ? 'en' : 'th';
+}
+
+function localizedUI(key) {
+  const language = activeLanguage();
+  return uiText[language][key];
+}
 
 function setStatus(statusText) {
   elements.statusText.textContent = statusText;
@@ -98,8 +124,8 @@ function bindSettings() {
     const el = byId(id);
     if (el) el.addEventListener(type, handler);
   });
-  byId('export-session').addEventListener('click', exportSessionAudit);
 
+  byId('export-session').addEventListener('click', exportSessionAudit);
   byId('reduced-motion-toggle').checked = settings.reducedMotion;
 }
 
@@ -107,7 +133,7 @@ function initVoice() {
   const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
   if (!SpeechRecognition) {
     elements.voiceButton.disabled = true;
-    elements.voiceButton.title = 'Speech API unavailable';
+    elements.voiceButton.title = localizedUI('speechApiUnavailable');
     return;
   }
 
@@ -133,7 +159,7 @@ function initVoice() {
   recognition.onstart = () => {
     listening = true;
     elements.voiceButton.setAttribute('aria-pressed', 'true');
-    setStatus(settings.sessionLanguageMemory === 'th' ? 'กำลังฟังเสียง' : 'Listening');
+    setStatus(localizedUI('listening'));
   };
 
   recognition.onresult = (event) => {
@@ -144,12 +170,13 @@ function initVoice() {
   };
 
   recognition.onerror = () => {
-    setStatus(settings.sessionLanguageMemory === 'th' ? 'เสียงไม่พร้อม ใช้การพิมพ์แทน' : 'Voice unavailable, type instead');
+    setStatus(localizedUI('voiceUnavailable'));
   };
 
   recognition.onend = () => {
     listening = false;
     elements.voiceButton.setAttribute('aria-pressed', 'false');
+    setStatus(localizedUI('ready'));
   };
 }
 
@@ -159,9 +186,9 @@ function onComposerSubmit(event) {
   if (!text) return;
 
   applySubmissionState(true);
-  setStatus(settings.sessionLanguageMemory === 'th' ? 'กำลังตีความ' : 'Interpreting');
-
   const language = languageLayer.resolveLanguage(text);
+  setStatus(localizedUI('interpreting'));
+
   const response = routeLightResponse(text, language);
 
   manifestationEngine.manifestText(response.text, response.mood);
@@ -191,6 +218,14 @@ function bindSettingsPanel() {
     elements.settingsToggle.setAttribute('aria-expanded', 'false');
     elements.settingsToggle.focus();
   });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && !elements.settingsPanel.hidden) {
+      elements.settingsPanel.hidden = true;
+      elements.settingsToggle.setAttribute('aria-expanded', 'false');
+      elements.settingsToggle.focus();
+    }
+  });
 }
 
 function bootstrap() {
@@ -202,9 +237,11 @@ function bootstrap() {
   window.addEventListener('resize', manifestationEngine.resize);
 
   manifestationEngine.resize();
-  setStatus('พร้อมฟัง');
-  manifestationEngine.manifestText('สวัสดี — Hello', 'greeting');
-  setReadableFallback('สวัสดี — Hello');
+  const bootLanguage = languageLayer.resolveLanguage('');
+  settings.sessionLanguageMemory = bootLanguage;
+  setStatus(localizedUI('ready'));
+  manifestationEngine.manifestText(bootLanguage === 'th' ? 'สวัสดี' : 'Hello', 'greeting');
+  setReadableFallback(bootLanguage === 'th' ? 'สวัสดี' : 'Hello');
   requestAnimationFrame(manifestationEngine.render);
 }
 

--- a/docs/clean_first_use_surface.md
+++ b/docs/clean_first_use_surface.md
@@ -29,18 +29,19 @@ No dashboard/HUD/debug panels are shown on first view.
   - Optional local rule-based detector layer.
 - `first_use_surface/response-orchestrator.js`
   - Deterministic first-run response rules for greeting/gratitude/question/unknown intent.
+  - Language mismatch adaptation message for preference/input divergence.
 
 ## Language detection strategy
 
 Resolution order:
 
 1. Explicit user preference in Settings.
-2. Browser locale (`navigator.languages` / `navigator.language`).
-3. Input heuristics (Thai unicode range vs Latin range).
+2. Browser locale (`navigator.languages` / `navigator.language`) as deterministic default.
+3. Input heuristics (Thai Unicode range vs Latin range).
 4. Optional local detector rules (pluggable and safe when disabled).
-5. Session language memory.
+5. Session language memory fallback.
 
-## Settings as single advanced-control surface
+## Settings as a single advanced-control surface
 
 All advanced controls are kept inside Settings:
 
@@ -52,12 +53,12 @@ All advanced controls are kept inside Settings:
 
 ## Fallback behavior
 
-- If SpeechRecognition is not available, voice control disables itself without breaking the composer flow.
-- If language detection confidence is low, the runtime uses deterministic fallback + session memory.
-- If animations are reduced, luminous text remains readable without relying on motion cues.
+- If `SpeechRecognition` is not available, voice control disables itself without breaking composer input.
+- If language confidence is low, the runtime falls back deterministically without external calls.
+- If reduced motion is enabled, luminous text remains readable without relying on animation cues.
 
 ## Limitations
 
 - Current language detector is heuristic and local-rule based (no heavy ML model).
 - Voice input depends on browser SpeechRecognition availability.
-- Session audit export remains local-download + in-memory trail.
+- Session audit export remains local-download plus in-memory trail.

--- a/first_use_surface/language-layer.js
+++ b/first_use_surface/language-layer.js
@@ -1,40 +1,46 @@
-const THAI_REGEX = /[\u0E00-\u0E7F]/;
-const ENGLISH_REGEX = /[A-Za-z]/;
+const THAI_CHAR_REGEX = /[\u0E00-\u0E7F]/;
+const ENGLISH_CHAR_REGEX = /[A-Za-z]/;
+const THAI_HINT_REGEX = /(สวัสดี|หวัดดี|ขอบคุณ|ครับ|ค่ะ|ช่วย|อะไร|ทำไม|อย่างไร|ได้ไหม)/;
+const ENGLISH_HINT_REGEX = /\b(hello|hi|hey|thanks|thank you|please|what|how|why|where|can you|could you)\b/;
 
 function detectFromBrowser() {
   const locales = navigator.languages && navigator.languages.length > 0
     ? navigator.languages
     : [navigator.language || 'en'];
+
   return locales.some((locale) => locale.toLowerCase().startsWith('th')) ? 'th' : 'en';
 }
 
 function detectFromCharacters(text) {
-  if (!text) return 'unknown';
+  if (!text) return { language: 'unknown', confidence: 0 };
 
   const thaiChars = (text.match(/[\u0E00-\u0E7F]/g) || []).length;
   const englishChars = (text.match(/[A-Za-z]/g) || []).length;
+  const totalLetters = thaiChars + englishChars;
 
-  if (thaiChars > englishChars) return 'th';
-  if (englishChars > thaiChars) return 'en';
+  if (totalLetters === 0) return { language: 'unknown', confidence: 0 };
+  if (thaiChars > englishChars) return { language: 'th', confidence: thaiChars / totalLetters };
+  if (englishChars > thaiChars) return { language: 'en', confidence: englishChars / totalLetters };
 
-  if (THAI_REGEX.test(text)) return 'th';
-  if (ENGLISH_REGEX.test(text)) return 'en';
-  return 'unknown';
+  if (THAI_CHAR_REGEX.test(text)) return { language: 'th', confidence: 0.5 };
+  if (ENGLISH_CHAR_REGEX.test(text)) return { language: 'en', confidence: 0.5 };
+
+  return { language: 'unknown', confidence: 0 };
 }
 
 function optionalLocalDetector(text, enabled, profile) {
-  if (!enabled || profile === 'none' || !text) return 'unknown';
+  if (!enabled || profile === 'none' || !text) return { language: 'unknown', confidence: 0 };
   const normalized = text.trim().toLowerCase();
 
-  if (/\b(สวัสดี|หวัดดี|ขอบคุณ|ครับ|ค่ะ|ช่วย|อะไร|ทำไม|อย่างไร)\b/.test(normalized)) {
-    return 'th';
+  if (THAI_HINT_REGEX.test(normalized)) {
+    return { language: 'th', confidence: 0.82 };
   }
 
-  if (/\b(hello|hi|hey|thanks|thank you|please|what|how|why|where|can you)\b/.test(normalized)) {
-    return 'en';
+  if (ENGLISH_HINT_REGEX.test(normalized)) {
+    return { language: 'en', confidence: 0.82 };
   }
 
-  return 'unknown';
+  return { language: 'unknown', confidence: 0 };
 }
 
 export function createLanguageLayer(settings) {
@@ -50,14 +56,13 @@ export function createLanguageLayer(settings) {
     }
 
     const browserLanguage = detectFromBrowser();
-    const inputLanguage = detectFromCharacters(inputText);
-    const optionalLanguage = optionalLocalDetector(inputText, settings.useLocalDetector, settings.localModelProfile);
+    const characterSignal = detectFromCharacters(inputText);
+    const localSignal = optionalLocalDetector(inputText, settings.useLocalDetector, settings.localModelProfile);
 
-    const resolvedLanguage = inputLanguage !== 'unknown'
-      ? inputLanguage
-      : optionalLanguage !== 'unknown'
-        ? optionalLanguage
-        : state.sessionLanguageMemory || browserLanguage;
+    const strongestInputSignal = localSignal.confidence >= characterSignal.confidence ? localSignal : characterSignal;
+    const resolvedLanguage = strongestInputSignal.language !== 'unknown'
+      ? strongestInputSignal.language
+      : state.sessionLanguageMemory || browserLanguage;
 
     state.sessionLanguageMemory = resolvedLanguage;
     settings.sessionLanguageMemory = resolvedLanguage;

--- a/first_use_surface/response-orchestrator.js
+++ b/first_use_surface/response-orchestrator.js
@@ -2,8 +2,29 @@ function localized(language, thText, enText) {
   return language === 'th' ? thText : enText;
 }
 
+function detectInputLanguage(inputText) {
+  const thaiChars = (inputText.match(/[\u0E00-\u0E7F]/g) || []).length;
+  const englishChars = (inputText.match(/[A-Za-z]/g) || []).length;
+  if (thaiChars > englishChars) return 'th';
+  if (englishChars > thaiChars) return 'en';
+  return 'unknown';
+}
+
 export function routeLightResponse(inputText, language) {
   const normalized = inputText.trim().toLowerCase();
+  const inputLanguage = detectInputLanguage(normalized);
+
+  if (inputLanguage !== 'unknown' && inputLanguage !== language) {
+    return {
+      mood: 'warm',
+      status: localized(language, 'กำลังปรับภาษาให้ตรงกับคุณ', 'Adapting language to your preference'),
+      text: localized(
+        language,
+        'ฉันจะตอบเป็นภาษาไทยให้ชัดเจนขึ้น หากต้องการเปลี่ยนภาษา ปรับได้ใน Settings',
+        'I will respond in English for clarity. You can change language anytime in Settings.',
+      ),
+    };
+  }
 
   const isGreeting = /^(hello|hi|hey|สวัสดี|หวัดดี|ดีจ้า|โย่ว)/i.test(normalized);
   const isGratitude = /(thank|ขอบคุณ|thx|ขอบใจ)/i.test(normalized);


### PR DESCRIPTION
### Motivation
- Provide a calm, minimal first-use homepage where the light/manifestation canvas and a single composer are the primary surface and all advanced controls are hidden in Settings.
- Make first-run interactions deterministic and language-aware so greetings and short intents are reliably manifested as readable luminous text without relying on backend or heavy ML models.
- Ensure voice is progressive-enhancement only, support accessibility (keyboard focus, aria labels, `prefers-reduced-motion`) and preserve deny-by-default controls in Settings.

### Description
- Refactored homepage orchestration in `clean-first-surface.js` to centralize localized UI strings, safe voice progressive-enhancement, settings panel keyboard escape handling, deterministic boot language, and session audit export.
- Rewrote the language layer in `first_use_surface/language-layer.js` to use a confidence-based resolution pipeline (`preference → browser locale → character heuristics → optional local detector → session memory`) and expose a stable `resolveLanguage` API.
- Enhanced deterministic response rules in `first_use_surface/response-orchestrator.js` to handle greeting/gratitude/question/ambiguity cases and to adapt politely on language-mismatch without opening panels or heavy UI chrome.
- Polished first-surface visuals and layout in `clean-first-surface.css` and updated documentation (`README.md`, `docs/clean_first_use_surface.md`) to reflect the clean first-use contract and implementation; key files changed: `clean-first-surface.js`, `clean-first-surface.css`, `first_use_surface/language-layer.js`, `first_use_surface/response-orchestrator.js`, `README.md`, `docs/clean_first_use_surface.md`.

### Testing
- Ran `npm run lint` which completed successfully (with an npm env warning but no lint errors).
- Ran backend tests with `cd api_gateway && pytest -q` which reported multiple failures and errors (test summary from run: 43 passed, 8 failed, 2 errors) and therefore did not fully pass.
- Ran contract checks with `python3 tools/contracts/contract_checker.py` which exercised runtime guards but terminated with a Pydantic model-definition error (`CognitiveEmitRequest` not fully defined) that should be addressed separately before contract checks fully pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e151f5a5488320ba385f0dddd95502)