### PR TITLE
[tooling] Improve TypeScript type validation and strictness compatibility

### DIFF
--- a/ajv_validator.ts
+++ b/ajv_validator.ts
@@ -132,7 +132,7 @@ export function createGovernorSchemaValidator(
         message: error.message,
       })),
     };
-  });
+  }) as NonNullable<RuntimeGovernorOptions["schemaValidator"]>;
 }
 
 /**

--- a/governor.ts
+++ b/governor.ts
@@ -1288,7 +1288,7 @@ function makeNaiveRuntimeAbiValidator(schema: JsonSchema): RuntimeGovernorOption
     for (const section of ["intent_state", "renderer_controls"] as const) {
       const sectionSchema = schema.properties?.[section];
       const sectionRequired = sectionSchema?.required ?? [];
-      const sectionValue = (payload as Record<string, Record<string, unknown>>)[section] ?? {};
+      const sectionValue = ((payload as unknown) as Record<string, Record<string, unknown>>)[section] ?? {};
       for (const key of sectionRequired) {
         if (sectionValue[key] == null) {
           errors.push(`${section}.${key}: missing required field`);

--- a/governor.ts
+++ b/governor.ts
@@ -1288,7 +1288,7 @@ function makeNaiveRuntimeAbiValidator(schema: JsonSchema): RuntimeGovernorOption
     for (const section of ["intent_state", "renderer_controls"] as const) {
       const sectionSchema = schema.properties?.[section];
       const sectionRequired = sectionSchema?.required ?? [];
-      const sectionValue = ((payload as unknown) as Record<string, Record<string, unknown>>)[section] ?? {};
+      const sectionValue = (payload[section] as unknown as Record<string, unknown>) ?? {};
       for (const key of sectionRequired) {
         if (sectionValue[key] == null) {
           errors.push(`${section}.${key}: missing required field`);

--- a/kernel.test.ts
+++ b/kernel.test.ts
@@ -74,7 +74,7 @@ globalThis.HTMLCanvasElement = MockCanvasElement as typeof HTMLCanvasElement;
 globalThis.window = { innerWidth: 800, innerHeight: 600 } as Window & typeof globalThis;
 globalThis.document = {
   createElement: () => new MockCanvasElement(),
-} as Document;
+} as unknown as Document;
 let rafCalls = 0;
 globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
   rafCalls += 1;

--- a/perceptual-feedback.ts
+++ b/perceptual-feedback.ts
@@ -110,7 +110,7 @@ export function perceptualFeedbackLoop(
   lastLCL: LclLike,
   kernel: KernelLike,
   clamp: (v: number, lo: number, hi: number) => number,
-  applyPatch: (patch: Record<string, unknown>) => void,
+  applyPatch: (patch: EvalMetrics | Record<string, unknown>) => void,
 ): void {
   if (!photons.length) {
     applyPatch({ readability: 0, coverage: 0, stability: 0 });

--- a/shape-compiler.ts
+++ b/shape-compiler.ts
@@ -164,7 +164,7 @@ export function compileShapeField(
   const density = clampFn(lcl.morphology?.density ?? 0.6, 0.1, 1.0);
   const count = Math.floor((lcl.constraints?.max_targets ?? 12000) * density);
   const scale = Math.min(W, HResolved) * clampFn(lcl.morphology?.scale ?? 0.3, 0.12, 0.55);
-  const palette = (lcl.optics?.palette ?? ['#FFFFFF']).map(hexToLinearFn);
+  const palette = (lcl.optics?.palette?.length ? lcl.optics.palette : ['#FFFFFF']).map(hexToLinearFn);
 
   for (let i = 0; i < count; i++) {
     const t = i / Math.max(count, 1);

--- a/shape-compiler.ts
+++ b/shape-compiler.ts
@@ -13,7 +13,22 @@ export interface CompiledField {
   points: TargetPoint[];
 }
 
-type LclLike = Record<string, unknown>;
+interface LclLike {
+  morphology?: {
+    family?: string;
+    density?: number;
+    scale?: number;
+  };
+  constraints?: {
+    max_targets?: number;
+  };
+  optics?: {
+    palette?: string[];
+  };
+  content?: {
+    text?: string | null;
+  };
+}
 
 export function compileGlyphFieldFromAlphaMask(
   alphaMask: Uint8Array,
@@ -35,8 +50,6 @@ export function compileGlyphFieldFromAlphaMask(
 
   return { points };
 }
-
-export function compileShapeField(lcl: LclLike, viewport: Viewport): CompiledField;
 
 export function compileGlyphField(
   lcl: LclLike,
@@ -116,6 +129,18 @@ export function compileSceneField(
   setTargetField(pts.slice(0, lcl.constraints?.max_targets ?? pts.length));
 }
 
+export function compileShapeField(lcl: LclLike, viewport: Viewport): CompiledField;
+export function compileShapeField(
+  lcl: LclLike,
+  W: number,
+  H: number,
+  CX: number,
+  CY: number,
+  hexToLinearFn: (hex: string) => number[],
+  lerpFn: (a: number, b: number, t: number) => number,
+  clampFn: (v: number, lo: number, hi: number) => number,
+  setTargetField: (pts: TargetPoint[]) => void,
+): void;
 export function compileShapeField(
   lcl: LclLike,
   WOrViewport: number | Viewport,
@@ -135,11 +160,11 @@ export function compileShapeField(
   const HResolved = viewport.height;
   const CXResolved = CX ?? W / 2;
   const CYResolved = CY ?? HResolved / 2;
-  const family = lcl.morphology.family;
-  const density = clampFn(lcl.morphology.density, 0.1, 1.0);
-  const count = Math.floor((lcl.constraints.max_targets || 12000) * density);
-  const scale = Math.min(W, HResolved) * clampFn(lcl.morphology.scale, 0.12, 0.55);
-  const palette = (lcl.optics.palette || ['#FFFFFF']).map(hexToLinearFn);
+  const family = lcl.morphology?.family ?? 'sphere';
+  const density = clampFn(lcl.morphology?.density ?? 0.6, 0.1, 1.0);
+  const count = Math.floor((lcl.constraints?.max_targets ?? 12000) * density);
+  const scale = Math.min(W, HResolved) * clampFn(lcl.morphology?.scale ?? 0.3, 0.12, 0.55);
+  const palette = (lcl.optics?.palette ?? ['#FFFFFF']).map(hexToLinearFn);
 
   for (let i = 0; i < count; i++) {
     const t = i / Math.max(count, 1);

--- a/test_runtime_governor_psycho_safety.test.ts
+++ b/test_runtime_governor_psycho_safety.test.ts
@@ -77,7 +77,7 @@ test('psycho_safety_gate caps cadence at WCAG threshold', () => {
   const governor = new RuntimeGovernor();
   const decision = governor.process(makePayload({ flicker: 0.05, glow_intensity: 0.5, velocity: 0.2, cadence_hz: 6.0 }));
 
-  assert.equal(decision.effective_contract.renderer_controls.shader_uniforms.cadence_hz, 3);
+  assert.equal(decision.effective_contract.renderer_controls.shader_uniforms?.cadence_hz, 3);
   assert.equal(decision.mutations.some((note) => note.includes('WCAG <=3 flashes/sec')), true);
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node", "vitest/globals"],
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
### Motivation

- Ensure `tsc` runs meaningfully against project sources instead of printing help by adding a root `tsconfig.json` and enable stricter, realistic compiler options. 
- Resolve multiple TypeScript compile errors caused by missing/loose type shapes and ESM resolution differences so `npm run typecheck` succeeds under `strict` settings. 
- Make small, localized signature and test adjustments to reduce friction with strict typing while preserving runtime behavior and safety contracts.

### Description

- Add a root `tsconfig.json` with `ES2022`/`ESNext` module settings, `moduleResolution: bundler`, `resolveJsonModule`, `allowImportingTsExtensions`, `strict: true` and other developer-friendly options. 
- Tighten and normalize types in `shape-compiler.ts` by defining a concrete `LclLike` interface with optional nested fields, making `content.text` null-safe, adding overloads for `compileShapeField` to distinguish `void` vs `CompiledField` return shapes, and providing conservative defaults for morphology/constraints/optics. 
- Adjust validator/governor typings: cast the `makeSchemaValidator` return to a non-nullable `schemaValidator` in `ajv_validator.ts`, and make a conservative `unknown` cast when extracting sections from the runtime ABI payload in `governor.ts`. 
- Make minor type-signature and test fixes: allow `perceptualFeedbackLoop`'s `applyPatch` to accept `EvalMetrics` directly in `perceptual-feedback.ts`, coerce the `document` mock to `unknown as Document` in `kernel.test.ts`, and use optional chaining for `shader_uniforms?.cadence_hz` in `test_runtime_governor_psycho_safety.test.ts` to satisfy strict checks. 

### Testing

- Ran `npm run typecheck` and it completed successfully under the new `tsconfig.json` (type-checking passed). 
- Ran `npm run lint` and the eslint run completed with no max-warnings (lint passed). 
- Ran `npm test` (Vitest): the library’s subtests executed and passed, but overall `npm test` reported failures for 3 suites due to repository test-style/configuration issues (Vitest reports "No test suite found" for some legacy files and an ESM/CJS interop error in an existing JS helper file), which are unrelated to these type-only/tooling changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3bdda36a88328a2fde4cf293a7206)