### PR TITLE
[frontend] Shift first-surface client to intent transport flow

### DIFF
--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -1,6 +1,5 @@
 import { createLanguageLayer } from './first_use_surface/language-layer.js';
 import { createLightManifestation } from './first_use_surface/light-manifestation.js';
-import { routeLightResponse } from './first_use_surface/response-orchestrator.js';
 import {
   markCompositionEnd,
   markCompositionStart,
@@ -9,6 +8,12 @@ import {
 } from './first_use_surface/input-event-policy.js';
 
 const STORAGE_KEY = 'aetherium:first-surface-settings:v1';
+const DEFAULT_INTENT_TIMEOUT_MS = 10000;
+
+function createSessionId() {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  return `session_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
 
 const elements = {
   canvas: document.getElementById('manifestation-canvas'),
@@ -82,6 +87,7 @@ function persistSettings() {
 }
 
 const settings = loadSettings();
+const sessionId = createSessionId();
 const sessionAudit = [];
 const languageLayer = createLanguageLayer(settings);
 const manifestationEngine = createLightManifestation(elements.canvas, settings.reducedMotion);
@@ -130,29 +136,73 @@ function exportSessionAudit() {
   URL.revokeObjectURL(url);
 }
 
-function submitIntent(intent) {
+async function emitIntent(intent) {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), DEFAULT_INTENT_TIMEOUT_MS);
+
+  try {
+    const apiBase = settings.apiBase.replace(/\/$/, '');
+    const response = await fetch(`${apiBase}/intent`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        intent,
+        session_id: sessionId,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      throw new Error(`Timeout after ${DEFAULT_INTENT_TIMEOUT_MS}ms`);
+    }
+    throw error;
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
+
+async function submitIntent(intent) {
   const text = intent.trim();
   if (!text) return;
 
   applySubmissionState(true);
-  setStatus(localizedUI('interpreting'));
+  setStatus('Intent sent');
 
-  const language = languageLayer.resolveLanguage(text);
-  const response = routeLightResponse(text, language);
+  try {
+    await emitIntent(text);
+    console.info('Intent sent', { session_id: sessionId });
+    setStatus('Awaiting stream update');
+    setReadableFallback('Awaiting stream update');
+    console.info('Awaiting stream update', { session_id: sessionId });
 
-  manifestationEngine.manifestText(response.text, response.mood);
-  setReadableFallback(response.text);
-  setStatus(response.status);
+    pushSessionEvent({
+      session_id: sessionId,
+      intent: text,
+      transport: 'intent_posted',
+    });
 
-  pushSessionEvent({
-    input: text,
-    language,
-    response,
-  });
-
-  elements.input.value = '';
-  persistSettings();
-  applySubmissionState(false);
+    elements.input.value = '';
+    persistSettings();
+  } catch (error) {
+    const transportError = `Transport error: ${error.message}`;
+    console.error(transportError);
+    setStatus(transportError);
+    setReadableFallback(transportError);
+    pushSessionEvent({
+      session_id: sessionId,
+      intent: text,
+      transport: 'intent_failed',
+      error: error.message,
+    });
+  } finally {
+    applySubmissionState(false);
+  }
 }
 
 function bindInputEvents() {

--- a/docs/clean_first_use_surface.md
+++ b/docs/clean_first_use_surface.md
@@ -29,9 +29,9 @@ No dashboard, HUD, debug panel, scholar panel, lineage panel, or runtime console
   - Deterministic language choice with session memory.
   - Browser-locale + character-range baseline detection.
   - Optional local rule-based detector layer (pluggable).
-- `first_use_surface/response-orchestrator.js`
-  - Deterministic first-run response rules for greeting/gratitude/question/unknown intent.
-  - Language mismatch adaptation message for preference/input divergence.
+- `clean-first-surface.js` intent transport
+  - `emitIntent(intent)` sends `{ intent, session_id }` to `${apiBase}/intent`.
+  - Frontend treats backend response as transport-only success/failure and waits for validated state via stream update.
 
 ## Language detection strategy
 
@@ -64,3 +64,4 @@ All advanced controls are kept inside Settings:
 - Current language detector is heuristic and local-rule based (no heavy ML model).
 - Voice input depends on browser SpeechRecognition availability.
 - Session audit export remains local-download plus in-memory trail.
+- Composer now only produces intent; visual/business state is expected from validated stream events.


### PR DESCRIPTION
### Motivation
- Simplify the first-surface client so it only produces intents and does not locally interpret or call external model endpoints. 
- Route intent submission through a transport API to centralize validation/decision-making on the backend. 
- Surface only transport-level errors in the client and reflect the new producer/consumer flow in UX/logs. 

### Description
- Removed local response orchestration and the `routeLightResponse` usage so the client no longer interprets business payloads. 
- Added `emitIntent(intent)` which `POST`s `{ intent, session_id }` to `${apiBase}/intent` with a client-generated `session_id` and request timeout (`DEFAULT_INTENT_TIMEOUT_MS`). 
- Client now treats submit flow as transport-only: it sends intents, handles network/timeout/status code errors only, and updates UI to `Intent sent` / `Awaiting stream update` without parsing business responses. 
- Updated `docs/clean_first_use_surface.md` to document the new intent transport behavior and that visual state is supplied via validated stream updates. 

### Testing
- Ran `npm run lint` which completed successfully. 
- Ran backend suite `cd api_gateway && pytest -q` which passed (`53 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e569dd25b88328a22d22f608a8b507)