### PR TITLE
[frontend] Harden WS reconnect flow and connection observability

### DIFF
--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -9,6 +9,11 @@ import {
 
 const STORAGE_KEY = 'aetherium:first-surface-settings:v1';
 const DEFAULT_INTENT_TIMEOUT_MS = 10000;
+const CONNECTION_STATES = Object.freeze({
+  CONNECTED: 'CONNECTED',
+  RECONNECTING: 'RECONNECTING',
+  DISCONNECTED: 'DISCONNECTED',
+});
 
 function createSessionId() {
   if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
@@ -127,7 +132,9 @@ function setStatus(statusText) {
 
 function setConnectionStatus(state) {
   if (!elements.connectionStatus) return;
-  elements.connectionStatus.textContent = state;
+  const normalizedState = CONNECTION_STATES[state] ?? CONNECTION_STATES.DISCONNECTED;
+  elements.connectionStatus.textContent = normalizedState;
+  elements.connectionStatus.dataset.connectionState = normalizedState.toLowerCase();
 }
 
 function setReadableFallback(text) {
@@ -168,6 +175,16 @@ function clearReconnectTimer() {
   if (connectionRuntime.reconnectTimer === null) return;
   window.clearTimeout(connectionRuntime.reconnectTimer);
   connectionRuntime.reconnectTimer = null;
+}
+
+function parseWsPayload(rawMessage) {
+  if (typeof rawMessage !== 'string') return null;
+  try {
+    return JSON.parse(rawMessage);
+  } catch {
+    console.warn('Dropped non-JSON WS message', { rawMessage });
+    return null;
+  }
 }
 
 function clampToVisualRange(value) {
@@ -297,6 +314,12 @@ function scheduleReconnect() {
 function connectWS(url) {
   const resolvedUrl = resolveWsUrl(url);
   connectionRuntime.url = resolvedUrl;
+  if (!resolvedUrl) {
+    connectionRuntime.shouldReconnect = false;
+    setConnectionStatus('DISCONNECTED');
+    setStatus('WS url is empty');
+    return;
+  }
 
   clearReconnectTimer();
 
@@ -319,13 +342,19 @@ function connectWS(url) {
   };
 
   socket.onmessage = (event) => {
-    const payload = JSON.parse(event.data);
-    handleIncomingState(payload);
+    const payload = parseWsPayload(event.data);
+    if (payload !== null) {
+      handleIncomingState(payload);
+    }
   };
 
   socket.onclose = () => {
     if (connectionRuntime.socket === socket) {
       connectionRuntime.socket = null;
+    }
+    if (!connectionRuntime.shouldReconnect) {
+      setConnectionStatus('DISCONNECTED');
+      return;
     }
     scheduleReconnect();
   };
@@ -531,6 +560,8 @@ function bindSettings() {
   if (byId('btn-connect')) {
     byId('btn-connect').addEventListener('click', () => {
       const manualUrl = byId('cfg-ws')?.value?.trim() ?? settings.wsBase;
+      settings.wsBase = manualUrl || settings.wsBase;
+      persistSettings();
       connectWS(manualUrl);
     });
   }


### PR DESCRIPTION
### Motivation
- Improve robustness of the frontend WebSocket integration so malformed frames cannot crash the runtime and operators can observe connection state clearly.
- Provide a simple backoff reconnect strategy and allow manual reconnects from the settings UI while persisting the chosen WS URL.

### Description
- Added `CONNECTION_STATES` and updated `setConnectionStatus` to surface state text and `data-connection-state` for better UI observability (`CONNECTED`, `RECONNECTING`, `DISCONNECTED`).
- Added `parseWsPayload` to safely `JSON.parse` inbound frames and only forward valid objects into `handleIncomingState(payload)` from `socket.onmessage`.
- Hardened `connectWS(url)` to handle empty/invalid resolved URLs, manage socket lifecycle, and drive reconnection state via `onopen/onclose/onerror` handlers.
- Kept exponential reconnect backoff via `nextReconnectDelayMs` (2s, 4s, 8s cap) and updated `btn-connect` handler to read `cfg-ws`, persist it (`persistSettings()`), and trigger immediate reconnect.

### Testing
- Ran `npm run lint` and the lint check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62738556c8328bb80aaa544eeb86b)