### PR TITLE
[frontend] Harden incoming visual-state validation before mutating sysState

### DIFF
--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -227,6 +227,14 @@ function validateIncomingStateSchema(payload) {
     return { ok: false, reason: 'payload.visual.color_palette must be an object' };
   }
 
+  if (typeof visual.color_palette.primary !== 'string') {
+    return { ok: false, reason: 'payload.visual.color_palette.primary must be a string' };
+  }
+
+  if (typeof visual.color_palette.secondary !== 'string') {
+    return { ok: false, reason: 'payload.visual.color_palette.secondary must be a string' };
+  }
+
   return {
     ok: true,
     value: {
@@ -266,20 +274,21 @@ function applyVisualParameters(visual) {
 
 function handleIncomingState(payload) {
   const validation = validateIncomingStateSchema(payload);
-  if (validation.ok) {
-    sysState.state = validation.value.state;
-    applyVisualParameters(validation.value.visual);
-  } else {
+  if (!validation.ok) {
     console.warn('Non-fatal stream validation failure', {
       reason: validation.reason,
       payload,
     });
+    return;
   }
+
+  sysState.state = validation.value.state;
+  applyVisualParameters(validation.value.visual);
 
   const fallbackText = payload?.text
     ?? payload?.message
     ?? payload?.intent_state?.state
-    ?? (validation.ok ? validation.value.state : '')
+    ?? validation.value.state
     ?? '';
 
   if (fallbackText) {


### PR DESCRIPTION
### Motivation
- Ensure incoming websocket/state payloads are validated and normalized before updating `sysState` or touching renderer geometry to avoid runtime errors from malformed inputs.
- Enforce the expected shape for `state`, `visual.energy`, `visual.entropy`, and `visual.color_palette` and surface non-fatal logs to aid stream quality debugging.

### Description
- Added required-type checks for `visual.color_palette.primary` and `visual.color_palette.secondary` in `validateIncomingStateSchema` and return a normalized `value` with clamped numeric fields via `clampToVisualRange` and sanitized palette entries via `sanitizePaletteValue`.
- Changed `handleIncomingState(payload)` to use an explicit guard clause that logs validation failures and `return`s early, and only sets `sysState.state` and calls `applyVisualParameters` for validated input.
- Kept `applyVisualParameters(visual)` as the single application point that sanitizes/clamps values and constructs `THREE.Color` from sanitized palette hex codes.
- Updated fallback text selection to prefer the validated `state` value from `validation.value.state` for readable fallback UI.

### Testing
- Ran `npm run lint`, which completed successfully.
- No other automated tests were executed for this frontend-only change (recommended backend `pytest` in `api_gateway` was not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cad5d8e0832881abf41017534d53)