### PR TITLE
[frontend] Decouple state mode from visual parameter animation

### DIFF
--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -88,13 +88,23 @@ const connectionRuntime = {
 
 const sysState = {
   state: '',
-  visual: {
-    energy: 0,
-    entropy: 0,
-    color_palette: {
-      primary: '#7FE4FF',
-      secondary: '#EBF9FF',
-    },
+  energyLevel: 0,
+  entropyLevel: 0,
+  palette: {
+    primary: '#7FE4FF',
+    secondary: '#EBF9FF',
+  },
+  target: {
+    energyLevel: 0,
+    entropyLevel: 0,
+    turbulence: 0,
+    flow: 0,
+    shape: 0,
+  },
+  future: {
+    turbulence: 0,
+    flow: 0,
+    shape: 0,
   },
 };
 
@@ -187,8 +197,16 @@ function parseWsPayload(rawMessage) {
   }
 }
 
-function clampToVisualRange(value) {
-  return Math.max(0, Math.min(1.5, value));
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function clampVisualLevel(value) {
+  return clamp(value, 0, 1.5);
+}
+
+function clampFutureLevel(value) {
+  return clamp(value, 0, 1);
 }
 
 function isRecord(value) {
@@ -240,15 +258,31 @@ function validateIncomingStateSchema(payload) {
     value: {
       state: state.trim(),
       visual: {
-        energy: clampToVisualRange(visual.energy),
-        entropy: clampToVisualRange(visual.entropy),
+        energy: clampVisualLevel(visual.energy),
+        entropy: clampVisualLevel(visual.entropy),
         color_palette: {
           primary: sanitizePaletteValue(visual.color_palette.primary, '#7FE4FF'),
           secondary: sanitizePaletteValue(visual.color_palette.secondary, '#EBF9FF'),
         },
+        turbulence: Number.isFinite(visual.turbulence) ? clampFutureLevel(visual.turbulence) : undefined,
+        flow: Number.isFinite(visual.flow) ? clampFutureLevel(visual.flow) : undefined,
+        shape: Number.isFinite(visual.shape) ? clampFutureLevel(visual.shape) : undefined,
       },
     },
   };
+}
+
+function setSystemState(mode) {
+  sysState.state = typeof mode === 'string' ? mode.trim() : '';
+  document.documentElement.dataset.systemState = sysState.state.toLowerCase();
+}
+
+function updateVisualIndicators() {
+  const rootStyle = document.documentElement.style;
+  rootStyle.setProperty('--system-energy-level', String(clamp(sysState.energyLevel, 0, 1.5)));
+  rootStyle.setProperty('--system-entropy-level', String(clamp(sysState.entropyLevel, 0, 1.5)));
+  rootStyle.setProperty('--system-palette-primary', sysState.palette.primary);
+  rootStyle.setProperty('--system-palette-secondary', sysState.palette.secondary);
 }
 
 function applyVisualParameters(visual) {
@@ -257,19 +291,35 @@ function applyVisualParameters(visual) {
     secondary: sanitizePaletteValue(visual.color_palette?.secondary, '#EBF9FF'),
   };
 
-  sysState.visual = {
-    energy: clampToVisualRange(visual.energy),
-    entropy: clampToVisualRange(visual.entropy),
-    color_palette: palette,
+  sysState.target.energyLevel = clampVisualLevel(visual.energy);
+  sysState.target.entropyLevel = clampVisualLevel(visual.entropy);
+  sysState.target.turbulence = Number.isFinite(visual.turbulence)
+    ? clampFutureLevel(visual.turbulence)
+    : sysState.target.turbulence;
+  sysState.target.flow = Number.isFinite(visual.flow)
+    ? clampFutureLevel(visual.flow)
+    : sysState.target.flow;
+  sysState.target.shape = Number.isFinite(visual.shape)
+    ? clampFutureLevel(visual.shape)
+    : sysState.target.shape;
+
+  sysState.future = {
+    turbulence: sysState.target.turbulence,
+    flow: sysState.target.flow,
+    shape: sysState.target.shape,
   };
 
-  if (globalThis.THREE?.Color) {
-    // เตรียมสีที่ sanitize แล้วสำหรับ stage geometry/material ที่ใช้ THREE.
-    sysState.visual.color = {
-      primary: new globalThis.THREE.Color(palette.primary),
-      secondary: new globalThis.THREE.Color(palette.secondary),
-    };
-  }
+  sysState.palette = palette;
+  updateVisualIndicators();
+}
+
+function animate() {
+  const lerp = (current, target, factor) => current + ((target - current) * factor);
+
+  sysState.energyLevel = lerp(sysState.energyLevel, sysState.target.energyLevel, 0.08);
+  sysState.entropyLevel = lerp(sysState.entropyLevel, sysState.target.entropyLevel, 0.08);
+  updateVisualIndicators();
+  requestAnimationFrame(animate);
 }
 
 function handleIncomingState(payload) {
@@ -282,7 +332,7 @@ function handleIncomingState(payload) {
     return;
   }
 
-  sysState.state = validation.value.state;
+  setSystemState(validation.value.state);
   applyVisualParameters(validation.value.visual);
 
   const fallbackText = payload?.text
@@ -693,6 +743,7 @@ function bootstrap() {
   setConnectionStatus('DISCONNECTED');
   manifestationEngine.manifestText(bootLanguage === 'th' ? 'สวัสดี' : 'Hello', 'greeting');
   setReadableFallback(bootLanguage === 'th' ? 'สวัสดี' : 'Hello');
+  animate();
   requestAnimationFrame(manifestationEngine.render);
   connectWS(settings.wsBase);
 }


### PR DESCRIPTION
### Motivation
- Reduce coupling between semantic system state (mode/label) and the visual physics/targets that drive the renderer so UI state changes do not implicitly overwrite visual animation targets. 
- Centralize ingress sanitization and clamping for streamed visual fields to ensure consistent normalization. 
- Provide a small forward-compatible surface for future visual fields (`turbulence`, `flow`, `shape`) without adding mode-branching logic.

### Description
- Reworked `sysState` shape in `clean-first-surface.js` to expose `energyLevel`, `entropyLevel`, `palette`, `target`, and `future` buckets and removed the previous nested `visual` object. 
- Added a generic `clamp(v, min, max)` plus `clampVisualLevel` and `clampFutureLevel` helpers and used them at ingress in `validateIncomingStateSchema()` to sanitize `visual.*` values. 
- Introduced `setSystemState(mode)` that updates only the canonical state label and `document.documentElement.dataset.systemState` and no longer mutates visual physics targets. 
- Centralized visual updates in `applyVisualParameters()` which updates `sysState.target` (for `energyLevel`, `entropyLevel`) and stores palette and optional future hooks (`turbulence`, `flow`, `shape`) without mode branching, and calls `updateVisualIndicators()` to sync CSS vars. 
- Added an `animate()` loop that performs lerp smoothing from current -> target for `energyLevel` and `entropyLevel` (factor `0.08`) and does not overwrite targets coming from mode; `animate()` is started from `bootstrap()`. 

### Testing
- Ran `npm run lint` and it completed successfully. 
- Ran backend tests with `cd api_gateway && pytest -q` and the test suite passed (`28 passed`). 
- Ran `python3 tools/contracts/contract_checker.py` which failed in this environment due to a missing module (`ModuleNotFoundError: tools.contracts.runtime_drift_guard`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cc1a79948328a83f53f6464fcc77)