### PR TITLE
[frontend] Blank home shell with settings workspace and deferred runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Aetherium Manifest is a **light-native cognition runtime**: intent is interprete
 
 ---
 
+## First-view product boundary
+
+- Homepage is a strict blank-entry surface with a single Settings trigger.
+- Greeting/composer/HUD/runtime logs are intentionally removed from first paint.
+- Runtime initialization is deferred until Settings interaction (default: Interaction pane).
+
 ## Architecture
 
 ### Runtime planes
@@ -54,12 +60,14 @@ Core contracts/schemas in this repo include:
 ## Runtime flow
 
 ### Intent-to-light flow (first-use surface)
-1. User opens Settings and submits text from the Interaction composer.
-2. Language layer resolves language deterministically:
+1. User enters through a blank home shell and opens Settings Workspace.
+2. Interaction pane activation lazily starts runtime connectivity (WS/voice/manifestation).
+3. User submits text from the Interaction composer.
+4. Language layer resolves language deterministically:
    - explicit setting → browser locale → char heuristics → optional local detector → session memory
-3. Response orchestrator maps intent class (greeting/question/etc.) to deterministic text+mood.
-4. Manifestation engine renders mood/text into the light scene.
-5. Session audit trail appends event metadata (optional export from Settings).
+5. Response orchestrator maps intent class (greeting/question/etc.) to deterministic text+mood.
+6. Manifestation engine renders mood/text into the light scene.
+7. Session audit trail appends event metadata (optional export from Settings).
 
 ### Gateway/governor integration flow (full stack)
 1. Emit payload is validated against contract.

--- a/clean-first-surface.css
+++ b/clean-first-surface.css
@@ -1,9 +1,9 @@
 :root {
   color-scheme: dark;
-  --bg: #03040a;
+  --bg: #020309;
   --ink: #f4fbff;
-  --line: rgba(200, 236, 255, 0.24);
-  --panel: rgba(11, 14, 20, 0.92);
+  --line: rgba(197, 232, 255, 0.24);
+  --panel: rgba(8, 10, 16, 0.96);
   --glow: #7fe4ff;
 }
 
@@ -14,10 +14,9 @@ body {
   margin: 0;
   width: 100%;
   height: 100%;
-  overflow: hidden;
-  font-family: Inter, Sarabun, system-ui, -apple-system, sans-serif;
-  background: var(--bg);
+  background: radial-gradient(circle at 30% 20%, #0a1220, #020309 60%);
   color: var(--ink);
+  font-family: Inter, Sarabun, system-ui, -apple-system, sans-serif;
 }
 
 #manifestation-canvas {
@@ -27,31 +26,22 @@ body {
   height: 100%;
   display: block;
   opacity: 0;
-  transition: opacity 220ms ease;
+  pointer-events: none;
+  transition: opacity 180ms ease;
 }
 
-.runtime-active #manifestation-canvas { opacity: 1; }
+.runtime-active #manifestation-canvas { opacity: 0.42; }
 
 .first-surface {
   position: fixed;
   inset: 0;
-  pointer-events: none;
-}
-
-.icon-btn,
-.send-btn,
-#intent-input,
-.settings input,
-.settings select,
-.settings button {
-  pointer-events: auto;
 }
 
 #settings-toggle {
   position: fixed;
   top: 20px;
   right: 20px;
-  z-index: 4;
+  z-index: 2;
 }
 
 .icon-btn,
@@ -60,105 +50,114 @@ body {
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.04);
   color: var(--ink);
+  min-height: 40px;
   cursor: pointer;
 }
 
-.icon-btn { width: 42px; height: 42px; }
-.send-btn { padding: 0 18px; height: 44px; }
+.icon-btn { width: 42px; }
+.send-btn { padding: 0 18px; }
 
-.ambient-status,
-.readable-fallback {
-  margin: 0;
-  text-shadow: 0 0 18px rgba(127, 228, 255, 0.35);
-}
-
-.ambient-status {
-  opacity: 0.84;
-  font-size: 13px;
-}
-
-.readable-fallback {
-  min-height: 1.4em;
-  margin: 6px 0 12px;
-  opacity: 0.92;
-  font-size: 14px;
-}
-
-.composer {
-  width: 100%;
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  gap: 10px;
-  padding: 8px;
-  border-radius: 16px;
-  background: rgba(12, 16, 24, 0.5);
-  border: 1px solid var(--line);
-  backdrop-filter: blur(8px);
-}
-
-#intent-input {
-  border: 1px solid transparent;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--ink);
-  padding: 0 14px;
-  height: 44px;
-  min-width: 0;
-}
-
-#intent-input::placeholder { color: rgba(238, 249, 255, 0.56); }
-
-:focus-visible {
-  outline: 2px solid var(--glow);
-  outline-offset: 2px;
-}
-
-.settings {
+.workspace-shell {
   position: fixed;
-  top: 20px;
-  right: 20px;
-  width: min(460px, calc(100vw - 24px));
-  max-height: calc(100vh - 40px);
-  overflow: auto;
+  inset: 0;
+  z-index: 10;
+  background: rgba(0, 0, 0, 0.48);
+  display: grid;
+  place-items: center;
+}
+
+.workspace-dialog {
+  width: min(980px, calc(100vw - 28px));
+  max-height: calc(100vh - 28px);
+  border-radius: 18px;
   border: 1px solid var(--line);
   background: var(--panel);
-  border-radius: 18px;
-  padding: 14px;
-  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
-.settings-header {
+.workspace-dialog[data-layout='fullscreen'] {
+  width: 100vw;
+  height: 100vh;
+  max-height: 100vh;
+  border-radius: 0;
+}
+
+.workspace-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding: 12px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
 }
 
-.settings section {
-  margin-top: 14px;
-  padding-top: 10px;
-  border-top: 1px dashed rgba(255, 255, 255, 0.18);
+.workspace-layout {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  min-height: 0;
+  flex: 1;
 }
 
-.settings label,
-.settings p,
-.settings h3 {
-  display: block;
-  margin: 8px 0;
-  font-size: 13px;
+.workspace-nav {
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 10px;
+  display: grid;
+  gap: 8px;
+  align-content: start;
 }
 
-.settings input,
-.settings select,
-.settings button,
-.settings-inline-btn {
+.pane-tab {
   width: 100%;
-  margin-top: 6px;
+  text-align: left;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--ink);
+  padding: 9px 10px;
+  cursor: pointer;
+}
+
+.pane-tab[aria-selected='true'] {
+  border-color: rgba(127, 228, 255, 0.8);
+  background: rgba(127, 228, 255, 0.12);
+}
+
+.workspace-content {
+  min-height: 0;
+  overflow: auto;
+  padding: 14px;
+}
+
+.pane { display: grid; gap: 10px; }
+.pane-status { margin: 0; min-height: 1.2em; opacity: 0.9; }
+
+.composer {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+}
+
+input,
+select,
+.settings-inline-btn,
+#export-session {
+  width: 100%;
+  min-height: 38px;
   border-radius: 10px;
   border: 1px solid var(--line);
   background: rgba(255, 255, 255, 0.05);
   color: var(--ink);
-  min-height: 36px;
   padding: 0 10px;
+}
+
+.diagnostics {
+  min-height: 120px;
+  margin: 0;
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  padding: 8px;
+  overflow: auto;
 }
 
 .sr-only {
@@ -170,6 +169,23 @@ body {
   border: 0;
   clip: rect(0, 0, 0, 0);
   overflow: hidden;
+}
+
+:focus-visible {
+  outline: 2px solid var(--glow);
+  outline-offset: 2px;
+}
+
+@media (max-width: 799px) {
+  .workspace-layout { grid-template-columns: 1fr; }
+  .workspace-nav {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(132px, 1fr);
+    overflow-x: auto;
+    border-right: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -490,7 +490,7 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
       link.href = url;
       link.download = `aetherium_session_audit_${Date.now()}.json`;
       link.click();
-      URL.revokeObjectURL(url);
+      setTimeout(() => URL.revokeObjectURL(url), 100);
     });
 
     elements.clearSessionButton?.addEventListener('click', () => {

--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -300,7 +300,7 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     homeState.voiceReady = true;
 
     const toggleListening = () => {
-      if (!runtime.started || !runtime.recognition) return;
+      if (!runtime.started || !runtime.recognition || !preferences.voiceEnabled) return;
       if (runtime.voiceListening) {
         runtime.recognition.stop();
       } else {

--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -6,8 +6,9 @@ import {
   markInputCommitted,
   shouldSubmitOnEnter,
 } from './first_use_surface/input-event-policy.js';
+import { createSettingsStore } from './first_use_surface/settings-store.js';
+import { createSettingsWorkspace } from './first_use_surface/settings-workspace.js';
 
-const STORAGE_KEY = 'aetherium:first-surface-settings:v2';
 const DEFAULT_INTENT_TIMEOUT_MS = 10000;
 
 export const CONNECTION_STATES = Object.freeze({
@@ -16,53 +17,24 @@ export const CONNECTION_STATES = Object.freeze({
   DISCONNECTED: 'DISCONNECTED',
 });
 
-const DEFAULT_ADAPTER = Object.freeze({
-  apiCompatibilityPath: '/api/intent',
-  websocketPath: '/ws/cognitive-stream',
-});
-
-const defaultSettings = {
-  languagePreference: 'auto',
-  useLocalDetector: true,
-  localModelProfile: 'tiny-rules',
-  reducedMotion: false,
-  voiceEnabled: true,
-  apiBase: '/api',
-  wsBase: '/ws/cognitive-stream',
-  runtimeMode: 'calm',
-  telemetry: true,
-  lineage: false,
-  scholar: false,
-  governorDebug: false,
-  developerTools: false,
-  sessionLanguageMemory: 'en',
-};
-
-function createSessionId() {
-  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
-  return `session_${Date.now()}_${Math.random().toString(16).slice(2)}`;
-}
-
-function loadSettings(storage = globalThis.localStorage) {
-  const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
-  const language = (globalThis.navigator?.language || 'en').toLowerCase().startsWith('th') ? 'th' : 'en';
-
-  try {
-    const raw = storage?.getItem(STORAGE_KEY);
-    if (!raw) {
-      return { ...defaultSettings, reducedMotion, sessionLanguageMemory: language };
-    }
-    return { ...defaultSettings, reducedMotion, sessionLanguageMemory: language, ...JSON.parse(raw) };
-  } catch {
-    return { ...defaultSettings, reducedMotion, sessionLanguageMemory: language };
-  }
-}
-
-export function resolveCompatibilityEndpoints(settings) {
-  const apiBase = (settings.apiBase || '/api').replace(/\/$/, '');
+export function createDefaultHomeShellState(activePane = 'interaction', reducedMotion = false) {
   return {
-    intentUrl: `${apiBase}/intent`,
-    wsUrl: settings.wsBase || DEFAULT_ADAPTER.websocketPath,
+    settingsOpen: false,
+    activePane,
+    runtimeHydrated: false,
+    gatewayConnected: false,
+    voiceReady: false,
+    manifestationReady: false,
+    reducedMotion,
+  };
+}
+
+export function resolveCompatibilityEndpoints(preferences) {
+  const apiBase = (preferences.apiBase || '/api/v1/cognitive').replace(/\/$/, '');
+  return {
+    emitUrl: `${apiBase}/emit`,
+    validateUrl: `${apiBase}/validate`,
+    wsUrl: preferences.wsBase || '/ws/cognitive-stream',
   };
 }
 
@@ -106,22 +78,31 @@ function resolveWsUrl(inputUrl = '') {
   return `${wsProtocol}//${base.host}${source.startsWith('/') ? source : `/${source}`}`;
 }
 
+function createSessionId() {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  return `session_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
+
 export function createApp(documentRef = globalThis.document, deps = {}) {
   const documentAvailable = Boolean(documentRef?.getElementById);
   if (!documentAvailable) {
     return {
       bootstrap: () => {},
-      openSettingsPanel: () => {},
-      closeSettingsPanel: () => {},
+      openSettingsWorkspace: () => {},
+      closeSettingsWorkspace: () => {},
       startRuntime: async () => {},
       getRuntimeSnapshot: () => ({ started: false }),
+      getHomeState: () => createDefaultHomeShellState(),
     };
   }
 
   const storage = deps.storage ?? globalThis.localStorage;
-  const settings = loadSettings(storage);
+  const store = createSettingsStore(storage);
+  let preferences = store.load();
+
   const sessionId = createSessionId();
   const sessionAudit = [];
+  const inputRuntime = { isComposing: false, lastCompositionEndAt: -Infinity };
 
   const elements = {
     canvas: documentRef.getElementById('manifestation-canvas'),
@@ -131,18 +112,33 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     voiceButton: documentRef.getElementById('voice-btn'),
     statusText: documentRef.getElementById('ambient-status'),
     fallbackText: documentRef.getElementById('readable-fallback'),
-    settingsPanel: documentRef.getElementById('settings-panel'),
-    settingsToggle: documentRef.getElementById('settings-toggle'),
-    closeSettings: documentRef.getElementById('close-settings'),
-    voiceCaptureButton: documentRef.getElementById('voice-capture'),
     connectionStatus: documentRef.getElementById('connection-status'),
-    runtimeInitButton: documentRef.getElementById('init-runtime'),
+    apiBase: documentRef.getElementById('api-base'),
+    wsBase: documentRef.getElementById('ws-base'),
+    languagePreference: documentRef.getElementById('language-preference'),
+    fontScale: documentRef.getElementById('font-scale'),
+    runtimeMode: documentRef.getElementById('runtime-mode'),
+    reducedMotionToggle: documentRef.getElementById('reduced-motion-toggle'),
+    voiceEnabledToggle: documentRef.getElementById('voice-enabled-toggle'),
+    telemetryToggle: documentRef.getElementById('telemetry-toggle'),
+    governorToggle: documentRef.getElementById('governor-toggle'),
+    manifestationToggle: documentRef.getElementById('manifestation-toggle'),
+    developerToolsToggle: documentRef.getElementById('developer-tools-toggle'),
+    environmentTarget: documentRef.getElementById('environment-target'),
+    closeSettings: documentRef.getElementById('close-settings'),
+    connectButton: documentRef.getElementById('btn-connect'),
+    exportButton: documentRef.getElementById('export-session'),
+    clearSessionButton: documentRef.getElementById('clear-session'),
+    voiceCaptureButton: documentRef.getElementById('voice-capture'),
+    dangerResetButton: documentRef.getElementById('danger-reset'),
+    diagnostics: documentRef.getElementById('dev-diagnostics'),
   };
 
   const languageLayerFactory = deps.languageLayerFactory ?? createLanguageLayer;
   const manifestationFactory = deps.manifestationFactory ?? createLightManifestation;
-  const languageLayer = languageLayerFactory(settings);
-  const manifestationEngine = manifestationFactory(elements.canvas, settings.reducedMotion);
+
+  let languageLayer = null;
+  let manifestationEngine = null;
 
   const runtime = {
     started: false,
@@ -155,17 +151,17 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     recognition: null,
   };
 
-  const inputRuntime = { isComposing: false, lastCompositionEndAt: -Infinity };
+  const homeState = createDefaultHomeShellState(preferences.activePane, preferences.reducedMotion);
 
-  const persistSettings = () => {
-    storage?.setItem(STORAGE_KEY, JSON.stringify(settings));
+  const pushSessionEvent = (event) => {
+    sessionAudit.push({ ...event, at: new Date().toISOString() });
   };
 
-  const setStatus = (text) => {
+  const setStatus = (text = '') => {
     if (elements.statusText) elements.statusText.textContent = text;
   };
 
-  const setFallback = (text) => {
+  const setFallback = (text = '') => {
     if (elements.fallbackText) elements.fallbackText.textContent = text;
   };
 
@@ -174,19 +170,63 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     elements.connectionStatus.textContent = CONNECTION_STATES[state] ?? CONNECTION_STATES.DISCONNECTED;
   };
 
+  const writeDiagnostics = () => {
+    if (!elements.diagnostics) return;
+    const payload = {
+      pane: homeState.activePane,
+      runtimeHydrated: homeState.runtimeHydrated,
+      gatewayConnected: homeState.gatewayConnected,
+      voiceReady: homeState.voiceReady,
+      manifestationReady: homeState.manifestationReady,
+      reducedMotion: homeState.reducedMotion,
+    };
+    elements.diagnostics.textContent = JSON.stringify(payload, null, 2);
+  };
+
+  const persistPreferences = (patch) => {
+    preferences = store.merge({ ...preferences, ...patch });
+    homeState.activePane = preferences.activePane;
+    homeState.reducedMotion = Boolean(preferences.reducedMotion);
+    writeDiagnostics();
+  };
+
+  const hydrateControls = () => {
+    if (elements.apiBase) elements.apiBase.value = preferences.apiBase;
+    if (elements.wsBase) elements.wsBase.value = preferences.wsBase;
+    if (elements.languagePreference) elements.languagePreference.value = preferences.language;
+    if (elements.fontScale) elements.fontScale.value = preferences.fontScale;
+    if (elements.runtimeMode) elements.runtimeMode.value = preferences.runtimeMode;
+    if (elements.reducedMotionToggle) elements.reducedMotionToggle.checked = preferences.reducedMotion;
+    if (elements.voiceEnabledToggle) elements.voiceEnabledToggle.checked = preferences.voiceEnabled;
+    if (elements.telemetryToggle) elements.telemetryToggle.checked = preferences.telemetryVisible;
+    if (elements.governorToggle) elements.governorToggle.checked = preferences.governorVisible;
+    if (elements.manifestationToggle) elements.manifestationToggle.checked = preferences.manifestationEnabled;
+    if (elements.developerToolsToggle) elements.developerToolsToggle.checked = preferences.developerEnabled;
+    if (elements.environmentTarget) elements.environmentTarget.value = preferences.environmentTarget;
+  };
+
+  const ensureManifestation = () => {
+    if (manifestationEngine) return manifestationEngine;
+    manifestationEngine = manifestationFactory(elements.canvas, preferences.reducedMotion);
+    homeState.manifestationReady = true;
+    return manifestationEngine;
+  };
+
+  const ensureLanguageLayer = () => {
+    if (languageLayer) return languageLayer;
+    languageLayer = languageLayerFactory(preferences);
+    return languageLayer;
+  };
+
   const applySubmissionState = (busy) => {
     if (elements.input) elements.input.disabled = busy;
     if (elements.sendButton) elements.sendButton.disabled = busy;
   };
 
-  const pushSessionEvent = (event) => {
-    sessionAudit.push({ ...event, at: new Date().toISOString() });
-  };
-
   const handleIncomingState = (payload) => {
     const adapted = adaptIntentResponse(payload);
     if (adapted.text) {
-      manifestationEngine.manifestText(String(adapted.text), 'stream');
+      ensureManifestation().manifestText(String(adapted.text), 'stream');
       setFallback(String(adapted.text));
     }
     pushSessionEvent({ session_id: sessionId, transport: 'ws_state', payload: adapted });
@@ -194,6 +234,7 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
 
   const connectWS = (url) => {
     if (!runtime.started) return;
+
     const target = resolveWsUrl(url);
     if (!target) return;
 
@@ -209,18 +250,25 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
 
     socket.onopen = () => {
       runtime.wsConnected = true;
+      homeState.gatewayConnected = true;
       setConnection('CONNECTED');
-      setStatus('WS connected');
+      setStatus('Connected');
+      writeDiagnostics();
     };
 
     socket.onclose = () => {
       runtime.wsConnected = false;
+      homeState.gatewayConnected = false;
       runtime.socket = null;
       setConnection('DISCONNECTED');
+      writeDiagnostics();
     };
 
     socket.onerror = () => {
+      runtime.wsConnected = false;
+      homeState.gatewayConnected = false;
       setConnection('DISCONNECTED');
+      writeDiagnostics();
     };
 
     socket.onmessage = (event) => {
@@ -235,46 +283,43 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
 
   const initVoice = () => {
     if (runtime.voiceInitialized) return;
-    runtime.voiceInitialized = true;
 
     const SpeechRecognition = globalThis.SpeechRecognition || globalThis.webkitSpeechRecognition;
     runtime.voiceSupported = Boolean(SpeechRecognition);
+    runtime.voiceInitialized = true;
 
-    const isDisabled = !settings.voiceEnabled || !runtime.voiceSupported;
-    if (elements.voiceButton) elements.voiceButton.disabled = isDisabled;
-    if (elements.voiceCaptureButton) elements.voiceCaptureButton.disabled = isDisabled;
-
-    if (!runtime.voiceSupported) {
-      if (elements.voiceCaptureButton) {
-        elements.voiceCaptureButton.textContent = 'Voice unavailable';
-      }
+    if (!preferences.voiceEnabled || !runtime.voiceSupported) {
+      elements.voiceButton?.setAttribute('disabled', 'true');
+      elements.voiceCaptureButton?.setAttribute('disabled', 'true');
+      homeState.voiceReady = false;
+      writeDiagnostics();
       return;
     }
 
-    const recognition = new SpeechRecognition();
-    runtime.recognition = recognition;
+    runtime.recognition = new SpeechRecognition();
+    homeState.voiceReady = true;
 
     const toggleListening = () => {
-      if (!runtime.started || !settings.voiceEnabled || !runtime.recognition) return;
+      if (!runtime.started || !runtime.recognition) return;
       if (runtime.voiceListening) {
         runtime.recognition.stop();
       } else {
-        runtime.recognition.lang = settings.sessionLanguageMemory === 'th' ? 'th-TH' : 'en-US';
+        runtime.recognition.lang = preferences.language === 'th' ? 'th-TH' : 'en-US';
         runtime.recognition.start();
       }
     };
 
-    recognition.onstart = () => {
+    runtime.recognition.onstart = () => {
       runtime.voiceListening = true;
       setStatus('Listening');
     };
 
-    recognition.onend = () => {
+    runtime.recognition.onend = () => {
       runtime.voiceListening = false;
       setStatus('Ready');
     };
 
-    recognition.onresult = (event) => {
+    runtime.recognition.onresult = (event) => {
       const transcript = event.results?.[0]?.[0]?.transcript?.trim();
       if (!transcript) return;
       if (elements.input) elements.input.value = transcript;
@@ -283,6 +328,32 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
 
     elements.voiceButton?.addEventListener('click', toggleListening);
     elements.voiceCaptureButton?.addEventListener('click', toggleListening);
+    writeDiagnostics();
+  };
+
+  const startRuntime = async () => {
+    if (runtime.started) return;
+
+    runtime.started = true;
+    homeState.runtimeHydrated = true;
+    documentRef.documentElement.classList.add('runtime-active');
+
+    ensureManifestation();
+    ensureLanguageLayer();
+
+    setStatus('Runtime initialized');
+    connectWS(preferences.wsBase);
+
+    initVoice();
+
+    if (!runtime.animationStarted) {
+      manifestationEngine.resize();
+      const raf = deps.raf ?? globalThis.requestAnimationFrame;
+      raf?.(manifestationEngine.render);
+      runtime.animationStarted = true;
+    }
+
+    writeDiagnostics();
   };
 
   const emitIntent = async (intent) => {
@@ -290,18 +361,19 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     const timeoutId = globalThis.setTimeout(() => controller.abort(), DEFAULT_INTENT_TIMEOUT_MS);
 
     try {
-      const endpoints = resolveCompatibilityEndpoints(settings);
+      const endpoints = resolveCompatibilityEndpoints(preferences);
       const fetchImpl = deps.fetchImpl ?? fetch;
-      const response = await fetchImpl(endpoints.intentUrl, {
+      const response = await fetchImpl(endpoints.emitUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(adaptIntentRequest(intent, sessionId)),
         signal: controller.signal,
       });
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
       const payload = await response.json();
       const adapted = adaptIntentResponse(payload);
-      manifestationEngine.manifestText(adapted.text || intent, 'request');
+      ensureManifestation().manifestText(adapted.text || intent, 'request');
       setFallback(adapted.text || intent);
       return adapted;
     } finally {
@@ -309,13 +381,17 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     }
   };
 
+  const ensureInteractionRuntime = async () => {
+    await startRuntime();
+  };
+
   const submitIntent = async (intent) => {
     const text = intent.trim();
     if (!text) return;
-    applySubmissionState(true);
 
+    applySubmissionState(true);
     try {
-      await startRuntime();
+      await ensureInteractionRuntime();
       await emitIntent(text);
       pushSessionEvent({ session_id: sessionId, intent: text, transport: 'intent_posted' });
       if (elements.input) elements.input.value = '';
@@ -329,6 +405,28 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     }
   };
 
+  const onPaneActivated = async (pane) => {
+    persistPreferences({ activePane: pane });
+    if (pane === 'interaction') {
+      await ensureInteractionRuntime();
+    }
+  };
+
+  const workspace = createSettingsWorkspace(documentRef, {
+    windowRef: deps.windowRef ?? globalThis,
+    getLastPane: () => preferences.activePane,
+    onPaneActivated,
+    onOpened: () => {
+      homeState.settingsOpen = true;
+      hydrateControls();
+      writeDiagnostics();
+    },
+    onClosed: () => {
+      homeState.settingsOpen = false;
+      writeDiagnostics();
+    },
+  });
+
   const bindInputEvents = () => {
     elements.form?.addEventListener('submit', (event) => {
       event.preventDefault();
@@ -337,7 +435,6 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
 
     elements.input?.addEventListener('compositionstart', () => markCompositionStart(inputRuntime));
     elements.input?.addEventListener('compositionend', (event) => markCompositionEnd(inputRuntime, event.timeStamp));
-
     elements.input?.addEventListener('input', (event) => {
       if (event.isComposing) {
         markCompositionStart(inputRuntime);
@@ -353,58 +450,40 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     });
   };
 
-  const openSettingsPanel = () => {
-    if (!elements.settingsPanel) return;
-    elements.settingsPanel.hidden = false;
-    elements.settingsToggle?.setAttribute('aria-expanded', 'true');
-    (elements.runtimeInitButton || elements.input || elements.closeSettings)?.focus();
-  };
+  const bindControlEvents = () => {
+    elements.apiBase?.addEventListener('change', (event) => persistPreferences({ apiBase: event.target.value.trim() || '/api/v1/cognitive' }));
+    elements.wsBase?.addEventListener('change', (event) => persistPreferences({ wsBase: event.target.value.trim() || '/ws/cognitive-stream' }));
+    elements.languagePreference?.addEventListener('change', (event) => persistPreferences({ language: event.target.value }));
+    elements.fontScale?.addEventListener('change', (event) => persistPreferences({ fontScale: event.target.value }));
+    elements.runtimeMode?.addEventListener('change', (event) => persistPreferences({ runtimeMode: event.target.value }));
+    elements.environmentTarget?.addEventListener('change', (event) => persistPreferences({ environmentTarget: event.target.value }));
 
-  const closeSettingsPanel = () => {
-    if (!elements.settingsPanel) return;
-    elements.settingsPanel.hidden = true;
-    elements.settingsToggle?.setAttribute('aria-expanded', 'false');
-    elements.settingsToggle?.focus();
-  };
+    elements.reducedMotionToggle?.addEventListener('change', (event) => {
+      const reducedMotion = event.target.checked;
+      persistPreferences({ reducedMotion });
+      if (manifestationEngine?.setReducedMotion) manifestationEngine.setReducedMotion(reducedMotion);
+    });
 
-  const bindSettingsPanel = () => {
-    elements.settingsToggle?.addEventListener('click', () => {
-      if (elements.settingsPanel?.hidden) {
-        openSettingsPanel();
-      } else {
-        closeSettingsPanel();
+    elements.voiceEnabledToggle?.addEventListener('change', (event) => {
+      persistPreferences({ voiceEnabled: event.target.checked });
+      if (runtime.voiceInitialized) {
+        runtime.voiceInitialized = false;
+        initVoice();
       }
     });
 
-    elements.closeSettings?.addEventListener('click', closeSettingsPanel);
-    documentRef.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape' && !elements.settingsPanel?.hidden) closeSettingsPanel();
-    });
-  };
+    elements.telemetryToggle?.addEventListener('change', (event) => persistPreferences({ telemetryVisible: event.target.checked }));
+    elements.governorToggle?.addEventListener('change', (event) => persistPreferences({ governorVisible: event.target.checked }));
+    elements.manifestationToggle?.addEventListener('change', (event) => persistPreferences({ manifestationEnabled: event.target.checked }));
+    elements.developerToolsToggle?.addEventListener('change', (event) => persistPreferences({ developerEnabled: event.target.checked }));
 
-  const bindSettings = () => {
-    const byId = (id) => documentRef.getElementById(id);
-
-    byId('api-base')?.addEventListener('change', (event) => {
-      settings.apiBase = event.target.value.trim() || '/api';
-      persistSettings();
-    });
-    byId('ws-base')?.addEventListener('change', (event) => {
-      settings.wsBase = event.target.value.trim() || DEFAULT_ADAPTER.websocketPath;
-      persistSettings();
-    });
-    byId('voice-enabled-toggle')?.addEventListener('change', (event) => {
-      settings.voiceEnabled = event.target.checked;
-      persistSettings();
+    elements.connectButton?.addEventListener('click', async () => {
+      await ensureInteractionRuntime();
+      connectWS(preferences.wsBase);
     });
 
-    byId('btn-connect')?.addEventListener('click', async () => {
-      await startRuntime();
-      connectWS(settings.wsBase);
-    });
-
-    byId('export-session')?.addEventListener('click', () => {
-      const payload = { exportedAt: new Date().toISOString(), settings, trail: sessionAudit };
+    elements.exportButton?.addEventListener('click', () => {
+      const payload = { exportedAt: new Date().toISOString(), sessionId, preferences, trail: sessionAudit };
       const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
       const link = documentRef.createElement('a');
@@ -414,52 +493,44 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
       URL.revokeObjectURL(url);
     });
 
-    elements.runtimeInitButton?.addEventListener('click', () => {
-      startRuntime();
+    elements.clearSessionButton?.addEventListener('click', () => {
+      sessionAudit.length = 0;
+      setFallback('');
+      setStatus('Session cleared');
+    });
+
+    elements.dangerResetButton?.addEventListener('click', () => {
+      const confirmed = globalThis.confirm?.('Confirm dangerous reset?') ?? false;
+      if (!confirmed) return;
+      pushSessionEvent({ session_id: sessionId, transport: 'dangerous_reset_confirmed' });
+      setStatus('Runtime reset queued');
     });
   };
 
-  const startRuntime = async () => {
-    if (runtime.started) return;
-    runtime.started = true;
-    documentRef.documentElement.classList.add('runtime-active');
-    setStatus('Runtime initialized');
-
-    initVoice();
-    connectWS(settings.wsBase);
-
-    if (!runtime.animationStarted) {
-      manifestationEngine.resize();
-      const raf = deps.raf ?? globalThis.requestAnimationFrame;
-      raf?.(manifestationEngine.render);
-      runtime.animationStarted = true;
-    }
-  };
-
   const bootstrap = () => {
+    workspace.bind();
     bindInputEvents();
-    bindSettings();
-    bindSettingsPanel();
+    bindControlEvents();
 
-    setStatus('Surface ready');
-    setConnection('DISCONNECTED');
+    setStatus('');
     setFallback('');
-    persistSettings();
+    setConnection('DISCONNECTED');
+    hydrateControls();
+    writeDiagnostics();
 
     if (typeof globalThis.addEventListener === 'function') {
-      globalThis.addEventListener('resize', manifestationEngine.resize);
+      globalThis.addEventListener('resize', () => manifestationEngine?.resize?.());
     }
-
-    const bootLanguage = languageLayer.resolveLanguage('');
-    settings.sessionLanguageMemory = bootLanguage;
   };
 
   return {
     bootstrap,
-    openSettingsPanel,
-    closeSettingsPanel,
+    openSettingsWorkspace: (pane) => workspace.open(pane),
+    closeSettingsWorkspace: () => workspace.close(),
     startRuntime,
     getRuntimeSnapshot: () => ({ ...runtime }),
+    getHomeState: () => ({ ...homeState }),
+    getWorkspaceLayoutMode: workspace.getLayoutMode,
   };
 }
 

--- a/docs/clean_first_use_surface.md
+++ b/docs/clean_first_use_surface.md
@@ -16,9 +16,15 @@ No dashboard, HUD, debug panel, scholar panel, lineage panel, runtime console, c
 - `clean-first-surface.js`
   - App bootstrap and orchestration.
   - Settings Workspace wiring, persistence, and session audit export.
-  - Compatibility adapter mapping (`/api/intent` + `/ws/cognitive-stream`).
-  - Deferred runtime bootstrap; WebSocket, voice, and manifestation rendering remain inactive until Settings initializes runtime.
-  - Settings drawer keyboard/mouse dismissal behavior.
+  - Compatibility adapter mapping (`/api/v1/cognitive/emit`, `/api/v1/cognitive/validate`, `/ws/cognitive-stream`).
+  - Deferred runtime bootstrap; WebSocket, voice, and manifestation rendering remain inactive until Settings opens the Interaction pane (or user action).
+  - Settings workspace orchestration and audit export wiring.
+- `first_use_surface/settings-store.js`
+  - Session-safe persistence for workspace preferences and active pane migration.
+  - Whitelisted persistence only (no raw token/key fields).
+- `first_use_surface/settings-workspace.js`
+  - Dialog open/close lifecycle, focus trap, Escape support, and pane navigation.
+  - Responsive layout mode (`sheet` on desktop, `fullscreen` on mobile).
 - `first_use_surface/light-manifestation.js`
   - Luminous text renderer with glyph-sampling particle halo.
   - Calm ambient particle field.
@@ -30,7 +36,7 @@ No dashboard, HUD, debug panel, scholar panel, lineage panel, runtime console, c
   - Optional local rule-based detector layer (pluggable).
 - `clean-first-surface.js` intent transport
   - `adaptIntentRequest(intent, sessionId)` maps to compatibility payload `{ prompt, session_id, model, temperature }`.
-  - `emitIntent(intent)` sends to `${apiBase}/intent`.
+  - `emitIntent(intent)` sends to `${apiBase}/emit` where `apiBase` defaults to `/api/v1/cognitive`.
   - `adaptIntentResponse(payload)` normalizes backend response into the existing frontend stream shape.
 
 ## Language detection strategy
@@ -43,9 +49,18 @@ Resolution order:
 4. Deterministic language choice with confidence-based rules.
 5. Session language memory update.
 
-## Settings as a single advanced-control surface
+## Settings workspace information architecture
 
-All advanced controls are kept inside Settings Workspace:
+All runtime controls are kept inside a seven-pane Settings Workspace:
+
+- Interaction
+- Connectivity
+- Accessibility
+- Runtime
+- Output/Audit
+- Security
+- Developer
+
 
 - API/WS base paths.
 - Runtime mode and telemetry options.

--- a/first_use_surface/settings-store.js
+++ b/first_use_surface/settings-store.js
@@ -1,0 +1,84 @@
+const SETTINGS_STORAGE_KEY = 'aetherium:settings-workspace:v1';
+
+export const SETTINGS_PANES = Object.freeze([
+  'interaction',
+  'connectivity',
+  'accessibility',
+  'runtime',
+  'output',
+  'security',
+  'developer',
+]);
+
+const DEFAULT_PREFERENCES = Object.freeze({
+  activePane: 'interaction',
+  language: 'auto',
+  fontScale: 'md',
+  reducedMotion: false,
+  apiBase: '/api/v1/cognitive',
+  wsBase: '/ws/cognitive-stream',
+  environmentTarget: 'default',
+  runtimeMode: 'calm',
+  telemetryVisible: true,
+  governorVisible: false,
+  manifestationEnabled: true,
+  voiceEnabled: true,
+  developerEnabled: false,
+});
+
+function safeJsonParse(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function normalizePane(value) {
+  return SETTINGS_PANES.includes(value) ? value : DEFAULT_PREFERENCES.activePane;
+}
+
+function normalizePreferences(input = {}) {
+  return {
+    activePane: normalizePane(input.activePane),
+    language: input.language ?? DEFAULT_PREFERENCES.language,
+    fontScale: input.fontScale ?? DEFAULT_PREFERENCES.fontScale,
+    reducedMotion: Boolean(input.reducedMotion ?? DEFAULT_PREFERENCES.reducedMotion),
+    apiBase: input.apiBase ?? DEFAULT_PREFERENCES.apiBase,
+    wsBase: input.wsBase ?? DEFAULT_PREFERENCES.wsBase,
+    environmentTarget: input.environmentTarget ?? DEFAULT_PREFERENCES.environmentTarget,
+    runtimeMode: input.runtimeMode ?? DEFAULT_PREFERENCES.runtimeMode,
+    telemetryVisible: Boolean(input.telemetryVisible ?? DEFAULT_PREFERENCES.telemetryVisible),
+    governorVisible: Boolean(input.governorVisible ?? DEFAULT_PREFERENCES.governorVisible),
+    manifestationEnabled: Boolean(input.manifestationEnabled ?? DEFAULT_PREFERENCES.manifestationEnabled),
+    voiceEnabled: Boolean(input.voiceEnabled ?? DEFAULT_PREFERENCES.voiceEnabled),
+    developerEnabled: Boolean(input.developerEnabled ?? DEFAULT_PREFERENCES.developerEnabled),
+  };
+}
+
+export function createSettingsStore(storage = globalThis.localStorage) {
+  const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+  const seed = normalizePreferences({ reducedMotion });
+
+  const read = () => {
+    const raw = storage?.getItem(SETTINGS_STORAGE_KEY);
+    if (!raw) return seed;
+    const parsed = safeJsonParse(raw);
+    if (!parsed) return seed;
+    return normalizePreferences({ ...seed, ...parsed });
+  };
+
+  const write = (next) => {
+    const normalized = normalizePreferences(next);
+    storage?.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(normalized));
+    return normalized;
+  };
+
+  return {
+    key: SETTINGS_STORAGE_KEY,
+    defaults: seed,
+    load: read,
+    save: write,
+    merge: (patch) => write({ ...read(), ...patch }),
+  };
+}

--- a/first_use_surface/settings-workspace.js
+++ b/first_use_surface/settings-workspace.js
@@ -20,7 +20,7 @@ export function createSettingsWorkspace(documentRef, config = {}) {
       dialog.querySelectorAll(
         'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
       )
-    ).filter((el) => !el.hasAttribute('hidden'));
+    ).filter((el) => !el.hasAttribute('hidden') && el.getClientRects().length > 0);
   };
 
   const applyViewportMode = () => {

--- a/first_use_surface/settings-workspace.js
+++ b/first_use_surface/settings-workspace.js
@@ -1,0 +1,137 @@
+import { SETTINGS_PANES } from './settings-store.js';
+
+function isDesktopViewport(win = globalThis) {
+  return (win.innerWidth || 0) >= 800;
+}
+
+export function createSettingsWorkspace(documentRef, config = {}) {
+  const shell = documentRef.getElementById('settings-workspace');
+  const dialog = documentRef.getElementById('settings-dialog');
+  const toggleButton = documentRef.getElementById('settings-toggle');
+  const closeButton = documentRef.getElementById('close-settings');
+  const paneButtons = Array.from(documentRef.querySelectorAll('[data-pane-target]'));
+  const paneBodies = Array.from(documentRef.querySelectorAll('[data-pane-body]'));
+
+  let lastFocused = null;
+
+  const getFocusable = () => {
+    if (!dialog) return [];
+    return Array.from(
+      dialog.querySelectorAll(
+        'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter((el) => !el.hasAttribute('hidden'));
+  };
+
+  const applyViewportMode = () => {
+    if (!dialog) return;
+    dialog.dataset.layout = isDesktopViewport(config.windowRef) ? 'sheet' : 'fullscreen';
+  };
+
+  const activatePane = (paneId, { focus = false } = {}) => {
+    const target = SETTINGS_PANES.includes(paneId) ? paneId : SETTINGS_PANES[0];
+
+    paneButtons.forEach((button) => {
+      const active = button.dataset.paneTarget === target;
+      button.setAttribute('aria-selected', String(active));
+      button.tabIndex = active ? 0 : -1;
+      if (active && focus) button.focus();
+    });
+
+    paneBodies.forEach((panel) => {
+      panel.hidden = panel.dataset.paneBody !== target;
+    });
+
+    config.onPaneActivated?.(target);
+  };
+
+  const open = (requestedPane) => {
+    if (!shell || !dialog) return;
+    lastFocused = documentRef.activeElement;
+    shell.hidden = false;
+    toggleButton?.setAttribute('aria-expanded', 'true');
+    applyViewportMode();
+
+    const initialPane = requestedPane || config.getLastPane?.() || SETTINGS_PANES[0];
+    activatePane(initialPane);
+
+    const preferredFocus = dialog.querySelector('[data-autofocus]') || getFocusable()[0];
+    preferredFocus?.focus();
+    config.onOpened?.(initialPane);
+  };
+
+  const close = () => {
+    if (!shell) return;
+    shell.hidden = true;
+    toggleButton?.setAttribute('aria-expanded', 'false');
+    (lastFocused || toggleButton)?.focus();
+    config.onClosed?.();
+  };
+
+  const onDialogKeydown = (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      const focusable = getFocusable();
+      if (!focusable.length) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && documentRef.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && documentRef.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+      return;
+    }
+
+    const activeButton = documentRef.activeElement;
+    if (activeButton?.dataset?.paneTarget && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+      event.preventDefault();
+      const current = paneButtons.indexOf(activeButton);
+      const delta = event.key === 'ArrowDown' ? 1 : -1;
+      const nextIndex = (current + delta + paneButtons.length) % paneButtons.length;
+      const nextButton = paneButtons[nextIndex];
+      const pane = nextButton.dataset.paneTarget;
+      activatePane(pane, { focus: true });
+    }
+  };
+
+  const bind = () => {
+    toggleButton?.addEventListener('click', () => {
+      if (shell?.hidden) {
+        open();
+      } else {
+        close();
+      }
+    });
+
+    closeButton?.addEventListener('click', close);
+
+    paneButtons.forEach((button) => {
+      button.addEventListener('click', () => activatePane(button.dataset.paneTarget));
+    });
+
+    dialog?.addEventListener('keydown', onDialogKeydown);
+
+    const win = config.windowRef ?? globalThis;
+    if (typeof win.addEventListener === 'function') {
+      win.addEventListener('resize', applyViewportMode);
+    }
+  };
+
+  return {
+    bind,
+    open,
+    close,
+    activatePane,
+    isOpen: () => Boolean(shell && !shell.hidden),
+    getLayoutMode: () => dialog?.dataset.layout || 'sheet',
+  };
+}

--- a/index.html
+++ b/index.html
@@ -11,111 +11,135 @@
   <body>
     <canvas id="manifestation-canvas" aria-hidden="true"></canvas>
 
-    <main class="first-surface" aria-label="Aetherium light-native surface">
+    <main class="first-surface" aria-label="Aetherium blank entry surface">
       <button
         id="settings-toggle"
         class="icon-btn"
         type="button"
-        aria-label="เปิดการตั้งค่า"
-        aria-controls="settings-panel"
+        aria-label="Open settings workspace"
+        aria-controls="settings-workspace"
         aria-expanded="false"
       >
         ⚙
       </button>
     </main>
 
-    <aside id="settings-panel" class="settings" aria-label="Settings" hidden>
-      <header class="settings-header">
-        <h2>Settings</h2>
-        <button id="close-settings" class="icon-btn" type="button" aria-label="ปิดการตั้งค่า">✕</button>
-      </header>
+    <div id="settings-workspace" class="workspace-shell" hidden>
+      <section
+        id="settings-dialog"
+        class="workspace-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-title"
+      >
+        <header class="workspace-header">
+          <h2 id="settings-title">Settings Workspace</h2>
+          <button id="close-settings" class="icon-btn" type="button" aria-label="Close settings workspace">✕</button>
+        </header>
 
-      <section>
-        <h3>Runtime Workspace</h3>
-        <button id="init-runtime" type="button" class="settings-inline-btn">Initialize runtime</button>
-        <p id="workspace-note">Runtime, voice, and network are deferred until initialization.</p>
-      </section>
+        <div class="workspace-layout">
+          <nav class="workspace-nav" aria-label="Workspace panes">
+            <button type="button" class="pane-tab" data-pane-target="interaction" aria-selected="true">Interaction</button>
+            <button type="button" class="pane-tab" data-pane-target="connectivity" aria-selected="false">Connectivity</button>
+            <button type="button" class="pane-tab" data-pane-target="accessibility" aria-selected="false">Accessibility</button>
+            <button type="button" class="pane-tab" data-pane-target="runtime" aria-selected="false">Runtime</button>
+            <button type="button" class="pane-tab" data-pane-target="output" aria-selected="false">Output / Audit</button>
+            <button type="button" class="pane-tab" data-pane-target="security" aria-selected="false">Security</button>
+            <button type="button" class="pane-tab" data-pane-target="developer" aria-selected="false">Developer</button>
+          </nav>
 
-      <section>
-        <h3>Interaction</h3>
-        <p id="ambient-status" class="ambient-status" aria-live="polite">พร้อมฟัง</p>
-        <p id="readable-fallback" class="readable-fallback" aria-live="polite"></p>
-        <form id="composer" class="composer" aria-label="Composer">
-          <label class="sr-only" for="intent-input">พิมพ์ข้อความ</label>
-          <input
-            id="intent-input"
-            name="intent"
-            autocomplete="off"
-            placeholder="พิมพ์ข้อความของคุณ…"
-            enterkeyhint="send"
-          />
-          <button
-            id="voice-btn"
-            class="icon-btn"
-            type="button"
-            aria-label="เปิดหรือปิดการป้อนข้อความด้วยเสียง"
-            aria-pressed="false"
-          >
-            🎙
-          </button>
-          <button id="send-btn" type="submit" class="send-btn">ส่ง</button>
-        </form>
-      </section>
+          <div class="workspace-content">
+            <section class="pane" data-pane-body="interaction">
+              <h3>Interaction</h3>
+              <p id="ambient-status" class="pane-status" aria-live="polite"></p>
+              <p id="readable-fallback" class="pane-status" aria-live="polite"></p>
+              <form id="composer" class="composer" aria-label="Intent composer">
+                <label class="sr-only" for="intent-input">Intent</label>
+                <input id="intent-input" name="intent" autocomplete="off" placeholder="Type an intent" enterkeyhint="send" data-autofocus />
+                <button
+                  id="voice-btn"
+                  class="icon-btn"
+                  type="button"
+                  aria-label="Toggle voice input"
+                  aria-pressed="false"
+                >
+                  🎙
+                </button>
+                <button id="send-btn" type="submit" class="send-btn">Send</button>
+              </form>
+              <button id="clear-session" type="button" class="settings-inline-btn">Clear session</button>
+            </section>
 
-      <section>
-        <h3>Connection</h3>
-        <label>API Base <input id="api-base" type="text" value="/api" /></label>
-        <label>WS Base <input id="ws-base" type="text" value="/ws/cognitive-stream" /></label>
-        <label>WS URL <input id="cfg-ws" type="text" value="/ws/cognitive-stream" /></label>
-        <button id="btn-connect" type="button" class="settings-inline-btn">Reconnect WS</button>
-        <p id="connection-status" class="ambient-status" aria-live="polite">DISCONNECTED</p>
-      </section>
+            <section class="pane" data-pane-body="connectivity" hidden>
+              <h3>Connectivity</h3>
+              <label>API Base <input id="api-base" type="text" value="/api/v1/cognitive" /></label>
+              <label>WS Base <input id="ws-base" type="text" value="/ws/cognitive-stream" /></label>
+              <label>Target
+                <select id="environment-target">
+                  <option value="default">Default</option>
+                  <option value="staging">Staging</option>
+                  <option value="local">Local</option>
+                </select>
+              </label>
+              <button id="btn-connect" type="button" class="settings-inline-btn">Reconnect</button>
+              <p id="connection-status" class="pane-status" aria-live="polite">DISCONNECTED</p>
+            </section>
 
-      <section>
-        <h3>Runtime</h3>
-        <label>Mode
-          <select id="runtime-mode">
-            <option value="calm">Calm</option>
-            <option value="adaptive">Adaptive</option>
-            <option value="deterministic">Deterministic</option>
-          </select>
-        </label>
-        <label><input id="telemetry-toggle" type="checkbox" checked /> Telemetry</label>
-        <label><input id="lineage-toggle" type="checkbox" /> Lineage / Replay tools</label>
-        <label><input id="scholar-toggle" type="checkbox" /> Scholar / Search layer</label>
-        <label><input id="governor-toggle" type="checkbox" /> Governor / Debug info</label>
-        <label><input id="devtools-toggle" type="checkbox" /> Developer tools</label>
-      </section>
+            <section class="pane" data-pane-body="accessibility" hidden>
+              <h3>Accessibility</h3>
+              <label><input id="reduced-motion-toggle" type="checkbox" /> Reduced motion</label>
+              <label>Language
+                <select id="language-preference">
+                  <option value="auto">Auto</option>
+                  <option value="th">ไทย</option>
+                  <option value="en">English</option>
+                </select>
+              </label>
+              <label>Font scale
+                <select id="font-scale">
+                  <option value="sm">Small</option>
+                  <option value="md" selected>Medium</option>
+                  <option value="lg">Large</option>
+                </select>
+              </label>
+              <label><input id="voice-enabled-toggle" type="checkbox" checked /> Voice enabled</label>
+              <button id="voice-capture" type="button" class="settings-inline-btn" aria-label="Start voice capture">Start voice capture</button>
+            </section>
 
-      <section>
-        <h3>Language &amp; Voice</h3>
-        <label>Preferred Language
-          <select id="language-preference">
-            <option value="auto">Auto</option>
-            <option value="th">ไทย</option>
-            <option value="en">English</option>
-          </select>
-        </label>
-        <label><input id="local-detector-toggle" type="checkbox" checked /> Use local language detector</label>
-        <label>Local model profile
-          <select id="local-model-profile">
-            <option value="none">None (heuristics only)</option>
-            <option value="tiny-rules" selected>Tiny rules (short text)</option>
-          </select>
-        </label>
-        <label><input id="reduced-motion-toggle" type="checkbox" /> Reduced motion</label>
-        <label><input id="voice-enabled-toggle" type="checkbox" checked /> Enable voice input</label>
-        <button id="voice-capture" type="button" class="settings-inline-btn" aria-label="Start voice capture">
-          Start voice capture
-        </button>
-      </section>
+            <section class="pane" data-pane-body="runtime" hidden>
+              <h3>Runtime</h3>
+              <label>Manifestation mode
+                <select id="runtime-mode">
+                  <option value="calm">Calm</option>
+                  <option value="adaptive">Adaptive</option>
+                  <option value="deterministic">Deterministic</option>
+                </select>
+              </label>
+              <label><input id="governor-toggle" type="checkbox" /> Governor visibility</label>
+              <label><input id="telemetry-toggle" type="checkbox" checked /> Telemetry visibility</label>
+              <label><input id="manifestation-toggle" type="checkbox" checked /> Manifestation enabled</label>
+            </section>
 
-      <section>
-        <h3>Export &amp; Tools</h3>
-        <button id="export-session" type="button">Export session audit (JSON)</button>
-        <p id="settings-note">Advanced controls live here only by design.</p>
+            <section class="pane" data-pane-body="output" hidden>
+              <h3>Output / Audit</h3>
+              <button id="export-session" type="button">Export session audit (JSON)</button>
+            </section>
+
+            <section class="pane" data-pane-body="security" hidden>
+              <h3>Security</h3>
+              <p id="token-state" class="pane-status">Session ticket: ephemeral</p>
+              <button id="danger-reset" type="button" class="settings-inline-btn">Dangerous reset</button>
+            </section>
+
+            <section class="pane" data-pane-body="developer" hidden>
+              <h3>Developer</h3>
+              <label><input id="developer-tools-toggle" type="checkbox" /> Enable diagnostics</label>
+              <pre id="dev-diagnostics" class="diagnostics" aria-live="polite"></pre>
+            </section>
+          </div>
+        </div>
       </section>
-    </aside>
+    </div>
 
     <script type="module" src="./clean-first-surface.js"></script>
   </body>

--- a/tests/blank_home_settings_workspace.test.js
+++ b/tests/blank_home_settings_workspace.test.js
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
+
+import { createApp } from '../clean-first-surface.js';
+
+const html = fs.readFileSync(path.resolve('index.html'), 'utf8');
+const stubManifestation = () => ({
+  manifestText: vi.fn(),
+  resize: vi.fn(),
+  render: vi.fn(),
+  setReducedMotion: vi.fn(),
+});
+
+function setupDom({ width = 1280 } = {}) {
+  const dom = new JSDOM(html, { url: 'http://localhost:4173' });
+
+  global.window = dom.window;
+  global.document = dom.window.document;
+  Object.defineProperty(dom.window, 'innerWidth', { value: width, configurable: true });
+  Object.defineProperty(globalThis, 'localStorage', { value: dom.window.localStorage, configurable: true });
+  Object.defineProperty(globalThis, 'matchMedia', {
+    value: () => ({ matches: false, addListener: () => {}, removeListener: () => {} }),
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, 'requestAnimationFrame', { value: vi.fn(), configurable: true });
+
+  return dom;
+}
+
+describe('blank home semantics', () => {
+  it('keeps first view free of greeting/composer/runtime text and exposes only settings trigger', () => {
+    const dom = setupDom();
+    const main = dom.window.document.querySelector('main.first-surface');
+
+    expect(main.querySelectorAll('button')).toHaveLength(1);
+    expect(main.querySelector('#settings-toggle')).toBeTruthy();
+    expect(main.textContent.trim()).toBe('⚙');
+  });
+});
+
+describe('settings workspace behavior', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('traps focus, supports escape close, and returns focus to launcher', () => {
+    const dom = setupDom();
+    const app = createApp(dom.window.document, { manifestationFactory: stubManifestation, windowRef: dom.window });
+    app.bootstrap();
+
+    const openButton = dom.window.document.getElementById('settings-toggle');
+    openButton.focus();
+    app.openSettingsWorkspace();
+
+    const dialog = dom.window.document.getElementById('settings-dialog');
+    expect(dialog.contains(dom.window.document.activeElement)).toBe(true);
+
+    dialog.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(dom.window.document.getElementById('settings-workspace').hidden).toBe(true);
+    expect(dom.window.document.activeElement.id).toBe('settings-toggle');
+  });
+
+  it('uses fullscreen workspace layout on mobile viewport', () => {
+    const dom = setupDom({ width: 480 });
+    const app = createApp(dom.window.document, { manifestationFactory: stubManifestation, windowRef: dom.window });
+    app.bootstrap();
+    app.openSettingsWorkspace();
+
+    expect(app.getWorkspaceLayoutMode()).toBe('fullscreen');
+  });
+});
+
+describe('deferred runtime policy', () => {
+  it('keeps websocket and voice initialization deferred before workspace interaction', async () => {
+    const dom = setupDom();
+    const wsCtor = vi.fn(() => ({ close: vi.fn() }));
+    Object.defineProperty(globalThis, 'WebSocket', { value: wsCtor, configurable: true });
+
+    const app = createApp(dom.window.document, {
+      manifestationFactory: stubManifestation,
+      socketFactory: wsCtor,
+      windowRef: dom.window,
+    });
+    app.bootstrap();
+
+    expect(app.getRuntimeSnapshot().started).toBe(false);
+    expect(wsCtor).not.toHaveBeenCalled();
+
+    app.openSettingsWorkspace('connectivity');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(app.getRuntimeSnapshot().started).toBe(false);
+    expect(wsCtor).not.toHaveBeenCalled();
+
+    app.openSettingsWorkspace('interaction');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(app.getRuntimeSnapshot().started).toBe(true);
+    expect(wsCtor).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/clean_first_surface_workspace.test.js
+++ b/tests/clean_first_surface_workspace.test.js
@@ -1,110 +1,22 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import fs from 'node:fs';
-import path from 'node:path';
-import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
 
 import {
   adaptIntentRequest,
   adaptIntentResponse,
-  createApp,
+  createDefaultHomeShellState,
   resolveCompatibilityEndpoints,
 } from '../clean-first-surface.js';
-
-const html = fs.readFileSync(path.resolve('index.html'), 'utf8');
-const stubManifestation = () => ({
-  manifestText: vi.fn(),
-  resize: vi.fn(),
-  render: vi.fn(),
-  setReducedMotion: vi.fn(),
-});
-
-describe('blank entry surface', () => {
-  it('keeps homepage main surface to a single settings trigger', () => {
-    const dom = new JSDOM(html);
-    const { document } = dom.window;
-
-    const main = document.querySelector('main.first-surface');
-    const mainButtons = Array.from(main.querySelectorAll('button'));
-    expect(mainButtons).toHaveLength(1);
-    expect(mainButtons[0].id).toBe('settings-toggle');
-  });
-});
-
-describe('settings focus management', () => {
-  it('focuses workspace control on open and returns focus to trigger on close', () => {
-    const dom = new JSDOM(html, { url: 'http://localhost:4173' });
-    global.window = dom.window;
-    global.document = dom.window.document;
-    Object.defineProperty(globalThis, 'localStorage', { value: dom.window.localStorage, configurable: true });
-    Object.defineProperty(globalThis, 'matchMedia', {
-      value: () => ({ matches: false, addListener: () => {}, removeListener: () => {} }),
-      configurable: true,
-    });
-    Object.defineProperty(globalThis, 'requestAnimationFrame', { value: vi.fn(), configurable: true });
-    Object.defineProperty(globalThis, 'WebSocket', { value: class {
-      constructor() {}
-      close() {}
-    }, configurable: true });
-
-    const app = createApp(dom.window.document, { manifestationFactory: stubManifestation });
-    app.bootstrap();
-
-    app.openSettingsPanel();
-    expect(dom.window.document.activeElement.id).toBe('init-runtime');
-
-    app.closeSettingsPanel();
-    expect(dom.window.document.activeElement.id).toBe('settings-toggle');
-  });
-});
-
-describe('deferred runtime', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('does not initialize websocket or animation until runtime starts', async () => {
-    const dom = new JSDOM(html, { url: 'http://localhost:4173' });
-    global.window = dom.window;
-    global.document = dom.window.document;
-    Object.defineProperty(globalThis, 'localStorage', { value: dom.window.localStorage, configurable: true });
-    Object.defineProperty(globalThis, 'matchMedia', {
-      value: () => ({ matches: false, addListener: () => {}, removeListener: () => {} }),
-      configurable: true,
-    });
-
-    const raf = vi.fn();
-    Object.defineProperty(globalThis, 'requestAnimationFrame', { value: raf, configurable: true });
-
-    const wsCtor = vi.fn(() => ({ close: vi.fn() }));
-    Object.defineProperty(globalThis, 'WebSocket', { value: wsCtor, configurable: true });
-
-    const app = createApp(dom.window.document, {
-      manifestationFactory: stubManifestation,
-      socketFactory: wsCtor,
-      raf,
-    });
-    app.bootstrap();
-
-    expect(wsCtor).not.toHaveBeenCalled();
-    expect(raf).not.toHaveBeenCalled();
-    expect(app.getRuntimeSnapshot().started).toBe(false);
-
-    await app.startRuntime();
-
-    expect(wsCtor).toHaveBeenCalledTimes(1);
-    expect(raf).toHaveBeenCalledTimes(1);
-    expect(app.getRuntimeSnapshot().started).toBe(true);
-  });
-});
+import { createSettingsStore } from '../first_use_surface/settings-store.js';
 
 describe('compatibility adapter', () => {
-  it('maps frontend intent payload and resolves compatibility endpoint', () => {
+  it('maps intent payload to cognitive emit endpoint', () => {
     const request = adaptIntentRequest('hello world', 's1');
     expect(request.prompt).toBe('hello world');
     expect(request.session_id).toBe('s1');
 
-    const endpoints = resolveCompatibilityEndpoints({ apiBase: '/api', wsBase: '/ws/cognitive-stream' });
-    expect(endpoints.intentUrl).toBe('/api/intent');
+    const endpoints = resolveCompatibilityEndpoints({ apiBase: '/api/v1/cognitive', wsBase: '/ws/cognitive-stream' });
+    expect(endpoints.emitUrl).toBe('/api/v1/cognitive/emit');
+    expect(endpoints.validateUrl).toBe('/api/v1/cognitive/validate');
     expect(endpoints.wsUrl).toBe('/ws/cognitive-stream');
   });
 
@@ -123,5 +35,41 @@ describe('compatibility adapter', () => {
     expect(adapted.visual.energy).toBe(0.8);
     expect(adapted.visual.color_palette.primary).toBe('#111111');
     expect(adapted.visual.flow).toBe(1);
+  });
+});
+
+describe('home shell state', () => {
+  it('creates the canonical blank-entry state model', () => {
+    const state = createDefaultHomeShellState('interaction', true);
+
+    expect(state.settingsOpen).toBe(false);
+    expect(state.runtimeHydrated).toBe(false);
+    expect(state.gatewayConnected).toBe(false);
+    expect(state.voiceReady).toBe(false);
+    expect(state.manifestationReady).toBe(false);
+    expect(state.activePane).toBe('interaction');
+    expect(state.reducedMotion).toBe(true);
+  });
+});
+
+describe('settings store safety', () => {
+  it('stores workspace preferences without persisting raw token fields', () => {
+    const storage = {
+      data: new Map(),
+      getItem(key) {
+        return this.data.has(key) ? this.data.get(key) : null;
+      },
+      setItem(key, value) {
+        this.data.set(key, value);
+      },
+    };
+
+    const store = createSettingsStore(storage);
+    store.save({ activePane: 'security', voiceEnabled: false, token: 'raw-secret' });
+
+    const persisted = JSON.parse(storage.getItem(store.key));
+    expect(persisted.activePane).toBe('security');
+    expect(persisted.voiceEnabled).toBe(false);
+    expect(persisted.token).toBeUndefined();
   });
 });

--- a/tests/first_use_surface_input_events.test.js
+++ b/tests/first_use_surface_input_events.test.js
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
 
 import {
   markCompositionEnd,
@@ -7,6 +10,7 @@ import {
   shouldSubmitOnEnter,
 } from '../first_use_surface/input-event-policy.js';
 import { routeLightResponse } from '../first_use_surface/response-orchestrator.js';
+import { createSettingsWorkspace } from '../first_use_surface/settings-workspace.js';
 
 describe('input IME enter policy', () => {
   it('does not submit while composition is active', () => {
@@ -66,5 +70,21 @@ describe('response orchestrator language adaptation', () => {
     const response = routeLightResponse('hello สวัสดี', 'en');
 
     expect(response.status).not.toBe('Adapting to your preferred language');
+  });
+});
+
+describe('workspace pane keyboard controls', () => {
+  it('moves pane focus with ArrowDown', () => {
+    const html = fs.readFileSync(path.resolve('index.html'), 'utf8');
+    const dom = new JSDOM(html, { url: 'http://localhost:4173' });
+    const workspace = createSettingsWorkspace(dom.window.document, { windowRef: dom.window });
+    workspace.bind();
+    workspace.open('interaction');
+
+    const first = dom.window.document.querySelector('[data-pane-target="interaction"]');
+    first.focus();
+    first.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+    expect(dom.window.document.activeElement.dataset.paneTarget).toBe('connectivity');
   });
 });


### PR DESCRIPTION
### Motivation
- Make the homepage a strict blank-entry surface exposing only a single Settings trigger and defer all runtime/resource-heavy subsystems until the user intentionally interacts via Settings.
- Move all interaction, connectivity, runtime, voice and developer controls into an isolated Settings Workspace to preserve the governor-first contract boundary and reduce first-paint side effects.
- Provide a small compatibility adapter and workspace state model so the frontend aligns with the backend contract routes without persisting raw secrets in browser storage.

### Description
- Reworked the first-use surface to a blank entry shell: `index.html` now shows only the settings trigger and a hidden pane-based Settings Workspace (7 panes: Interaction, Connectivity, Accessibility, Runtime, Output/Audit, Security, Developer). 
- Introduced a workspace state/store and controller: new `first_use_surface/settings-store.js` implements whitelist normalization/persistence and `first_use_surface/settings-workspace.js` implements dialog lifecycle, focus trap, Escape-to-close and keyboard pane navigation.
- Migrated orchestration into a workspace-aware app controller: `clean-first-surface.js` now uses a `createSettingsStore` and `createSettingsWorkspace`, defers runtime boot (manifestation/WS/voice) and only initializes connectivity when the Interaction pane or user action requires it; added a simple `homeState` model and diagnostic payload.
- Compatibility adapter and payload path updates: adapter defaults updated to `/api/v1/cognitive/emit` and `/api/v1/cognitive/validate`, and WS to `/ws/cognitive-stream`; `adaptIntentRequest`/`adaptIntentResponse` preserved to normalize backend responses to the frontend stream contract.
- UX/CSS updates: `clean-first-surface.css` adjusted to deep-void blank surface, reduced-motion support, responsive sheet/fullscreen workspace layout and accessible focus styles.
- Tests and docs: added `tests/blank_home_settings_workspace.test.js`, updated `tests/clean_first_surface_workspace.test.js` and `tests/first_use_surface_input_events.test.js` to cover blank-home semantics, focus management, deferred runtime policy, adapter behavior and keyboard pane navigation; updated `README.md` and `docs/clean_first_use_surface.md` to document the new product boundary and runtime flow.

### Testing
- Ran focused frontend unit/integration suites with Vitest: `npx vitest run tests/blank_home_settings_workspace.test.js tests/clean_first_surface_workspace.test.js tests/first_use_surface_input_events.test.js` — all selected tests passed.
- Ran lint and type check: `npm run lint` and `npm run typecheck` — both completed successfully in this environment after installing dev deps.
- Ran gateway tests: `cd api_gateway && pytest -q` — backend test suite passed (`29 passed`).
- Ran broader repo test command: `npm test` — this failed due to pre-existing unrelated repository test/config issues (some test files report "No test suite found" and an ES module/CommonJS mismatch in unrelated tests), not caused by these frontend changes.
- Ran contract checker: `python3 tools/contracts/contract_checker.py` — failed due to a missing import in the runtime environment (`ModuleNotFoundError: tools.contracts.runtime_drift_guard`), which appears to be an existing repo environment/config issue rather than a change introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e85c1096908320ada8223ecbe83950)