### PR TITLE
[first-surface] Enforce canonical browser transport only for cognitive emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ Core contracts/schemas in this repo include:
 ### Intent-to-light flow (first-use surface)
 1. User enters through a blank awakening surface and opens the Settings Workspace operational sanctum.
 2. Interaction pane activation lazily starts runtime connectivity (WS/voice/manifestation).
-3. User submits text from the Interaction composer.
+3. User submits text from the Interaction composer; browser transport emits through canonical cognitive routes only (`/api/v1/cognitive/*` + `/ws/cognitive-stream`).
 4. Language layer resolves language deterministically:
    - explicit setting → browser locale → char heuristics → optional local detector → session memory
 5. Response orchestrator maps intent class (greeting/question/etc.) to deterministic text+mood.
 6. Manifestation engine renders mood/text into the light scene.
 7. Session audit trail appends event metadata (optional export from Settings).
+
+Auth note: if canonical emit responds `401/403`, the surface marks Security/Connectivity state as **Session ticket required** and does not downgrade to legacy `/api/intent` browser fallback.
 
 ### Gateway/governor integration flow (full stack)
 1. Emit payload is validated against contract.

--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -34,7 +34,6 @@ export function resolveCompatibilityEndpoints(preferences) {
   return {
     emitUrl: `${apiBase}/generate`,
     validateUrl: `${apiBase}/validate`,
-    legacyIntentUrl: `${new URL(apiBase, globalThis.location?.href || 'http://localhost').origin}/api/intent`,
     wsUrl: preferences.wsBase || '/ws/cognitive-stream',
   };
 }
@@ -122,6 +121,7 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     statusText: documentRef.getElementById('ambient-status'),
     fallbackText: documentRef.getElementById('readable-fallback'),
     connectionStatus: documentRef.getElementById('connection-status'),
+    tokenState: documentRef.getElementById('token-state'),
     apiBase: documentRef.getElementById('api-base'),
     wsBase: documentRef.getElementById('ws-base'),
     languagePreference: documentRef.getElementById('language-preference'),
@@ -177,6 +177,11 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
   const setConnection = (state) => {
     if (!elements.connectionStatus) return;
     elements.connectionStatus.textContent = CONNECTION_STATES[state] ?? CONNECTION_STATES.DISCONNECTED;
+  };
+
+  const setSessionTicketState = (text = 'Session ticket: ephemeral') => {
+    if (!elements.tokenState) return;
+    elements.tokenState.textContent = text;
   };
 
   const writeDiagnostics = () => {
@@ -372,24 +377,20 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     try {
       const endpoints = resolveCompatibilityEndpoints(preferences);
       const fetchImpl = deps.fetchImpl ?? fetch;
-      let response = await fetchImpl(endpoints.emitUrl, {
+      const response = await fetchImpl(endpoints.emitUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(adaptGenerateRequest(intent)),
         signal: controller.signal,
       });
-
-      if (response.status === 401 || response.status === 403 || response.status === 422 || response.status === 404) {
-        response = await fetchImpl(endpoints.legacyIntentUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(adaptIntentRequest(intent, sessionId)),
-          signal: controller.signal,
-        });
+      if (response.status === 401 || response.status === 403) {
+        setSessionTicketState('Session ticket required');
+        setConnection('DISCONNECTED');
+        throw new Error('Session ticket required');
       }
-
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
+      setSessionTicketState('Session ticket: active');
       const payload = await response.json();
       const adapted = adaptIntentResponse(payload);
       ensureManifestation().manifestText(adapted.text || intent, 'request');

--- a/docs/clean_first_use_surface.md
+++ b/docs/clean_first_use_surface.md
@@ -16,7 +16,8 @@ No dashboard, HUD, debug panel, scholar panel, lineage panel, runtime console, c
 - `clean-first-surface.js`
   - App bootstrap and orchestration.
   - Settings Workspace wiring, persistence, and session audit export.
-  - Compatibility adapter mapping (`/api/v1/cognitive/generate`, `/api/v1/cognitive/validate`, `/ws/cognitive-stream`) with fallback to `/api/intent`.
+  - Browser-side transport mapping uses canonical routes only (`/api/v1/cognitive/generate`, `/api/v1/cognitive/validate`, `/ws/cognitive-stream`).
+  - Legacy `/api/intent` remains backend-adapter scope only and is not exposed for browser direct-call fallback.
   - Deferred runtime bootstrap; WebSocket, voice, and manifestation rendering remain inactive until Settings opens the Interaction pane (or user action).
   - Settings workspace orchestration and audit export wiring.
 - `first_use_surface/settings-store.js`
@@ -35,8 +36,8 @@ No dashboard, HUD, debug panel, scholar panel, lineage panel, runtime console, c
   - Browser-locale + character-range baseline detection.
   - Optional local rule-based detector layer (pluggable).
 - `clean-first-surface.js` intent transport
-  - `adaptIntentRequest(intent, sessionId)` maps to compatibility payload `{ prompt, session_id, model, temperature }`.
   - `emitIntent(intent)` sends to `${apiBase}/generate` where `apiBase` defaults to `/api/v1/cognitive`.
+  - Auth failures from canonical routes (401/403) are surfaced as `Session ticket required` in Security + Connectivity state instead of falling back to non-canonical endpoints.
   - `adaptIntentResponse(payload)` normalizes backend response into the existing frontend stream shape.
 
 ## Language detection strategy

--- a/tests/blank_home_settings_workspace.test.js
+++ b/tests/blank_home_settings_workspace.test.js
@@ -114,16 +114,11 @@ describe('compatibility adapter behavior', () => {
     expect(endpoints.wsUrl).toBe('/ws/cognitive-stream');
   });
 
-  it('falls back to legacy intent endpoint when canonical route rejects unsigned request', async () => {
+  it('keeps browser adapter on canonical cognitive routes when request rejects unsigned session', async () => {
     const dom = setupDom();
     const fetchImpl = vi
       .fn()
-      .mockResolvedValueOnce({ ok: false, status: 401 })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({ text: 'compatibility response', intent_vector: {}, visual_manifestation: {} }),
-      });
+      .mockResolvedValueOnce({ ok: false, status: 401 });
 
     const app = createApp(dom.window.document, {
       manifestationFactory: stubManifestation,
@@ -142,6 +137,8 @@ describe('compatibility adapter behavior', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(fetchImpl.mock.calls[0][0]).toBe('/api/v1/cognitive/generate');
-    expect(fetchImpl.mock.calls[1][0]).toBe('/api/intent');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls.every(([url]) => String(url).startsWith('/api/v1/cognitive/'))).toBe(true);
+    expect(dom.window.document.getElementById('token-state').textContent).toBe('Session ticket required');
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent the frontend from falling back to a legacy, non-canonical endpoint and ensure browser-side transport uses only the canonical cognitive routes for security and clarity.
- Surface explicit behavior for auth failures so the UI and connectivity/security panes show a clear action state instead of silently downgrading to a legacy path.
- Keep compatibility adapter semantics constrained to backend adapters while aligning the first-use surface with deny-by-default transport behavior.

### Description
- Removed the `legacyIntentUrl` exposure from `resolveCompatibilityEndpoints()` so browser code no longer exposes `/api/intent` and only resolves canonical routes (`/api/v1/cognitive/*` and WS).
- Changed `emitIntent()` to post only to the canonical `emitUrl` and to fail-fast on auth errors (`401`/`403`) instead of calling a legacy fallback. 
- Added `tokenState` wiring and `setSessionTicketState()` to surface auth state in the Security/Connectivity pane and set connection to `DISCONNECTED` when auth fails. 
- Updated tests and docs: modified `tests/blank_home_settings_workspace.test.js` to expect a single canonical request and to assert the `Session ticket required` UI state, and updated `docs/clean_first_use_surface.md` and `README.md` to state that browser-side transport uses canonical routes only.

### Testing
- Ran lint with `npm run lint` and it completed successfully. 
- Ran unit tests with `npx vitest run tests/blank_home_settings_workspace.test.js` and the test file passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f0878aa0832892ebf54b5a9bfa42)