### PR TITLE
[security] Add ephemeral WS ticket issuance and enforcement

### DIFF
--- a/api_gateway/README.md
+++ b/api_gateway/README.md
@@ -6,9 +6,12 @@
 
 - `POST /api/v1/cognitive/emit`
 - `POST /api/v1/cognitive/validate`
+- `POST /api/v1/auth/session` (issue short-lived signed WS ticket)
+- `POST /api/v1/auth/session/refresh` (refresh short-lived signed WS ticket)
+- `GET /api/v1/auth/session/audit` (ticket issuance + privileged WS action audit)
 - `POST /api/v1/cognitive/variations/generate` (generate 4–8 variation branches with lineage metadata)
 - `GET /health`
-- `WS /ws/cognitive-stream` *(served by `ws_gateway`, not by this FastAPI process)*
+- `WS /ws/cognitive-stream` (requires valid `ticket` query parameter)
 
 ### Required Headers
 - `X-API-Key`

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -554,8 +554,12 @@ def _verify_ticket(ticket: str) -> Dict[str, Any]:
     if not hmac.compare_digest(signature, expected):
         raise HTTPException(status_code=401, detail="Invalid session ticket signature")
 
-    payload = json.loads(payload_raw.decode("utf-8"))
-    expires_at = datetime.fromtimestamp(float(payload.get("exp", 0)), tz=timezone.utc)
+    try:
+        payload = json.loads(payload_raw.decode("utf-8"))
+        expires_at = datetime.fromtimestamp(float(payload.get("exp", 0)), tz=timezone.utc)
+    except Exception as exc:
+        raise HTTPException(status_code=401, detail="Malformed session ticket payload") from exc
+
     if expires_at <= datetime.now(timezone.utc):
         raise HTTPException(status_code=401, detail="Session ticket expired")
 

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -924,8 +924,8 @@ async def cognitive_stream(websocket: WebSocket) -> None:
     try:
         while True:
             payload = await websocket.receive_json()
-            if payload.get("type") != "dsl_submission":
-                await websocket.send_json({"status": "error", "detail": "Invalid message type"})
+            if not isinstance(payload, dict) or payload.get("type") != "dsl_submission":
+                await websocket.send_json({"status": "error", "detail": "Invalid message format or type"})
                 continue
 
             requires_operator = bool(payload.get("requires_operator"))

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -10,7 +10,11 @@ import re
 import socket
 import uuid
 import hashlib
-from datetime import datetime, timezone
+import hmac
+import base64
+import json
+import secrets
+from datetime import datetime, timezone, timedelta
 from statistics import mean
 from typing import Any, Dict, List, Literal, Optional, Union
 from urllib.parse import urlparse
@@ -102,6 +106,27 @@ class LegacyIntentRequest(BaseModel):
     session_id: Optional[str] = None
     model: str = Field(default="gpt-4o")
     temperature: float = Field(default=0.4, ge=0.0, le=2.0)
+
+
+class SessionTicketIssueRequest(BaseModel):
+    session_id: str = Field(..., min_length=1)
+    role: Literal["viewer", "operator"] = "viewer"
+    scope: Literal["cognitive:stream", "cognitive:stream:privileged"] = "cognitive:stream"
+
+
+class SessionTicketRefreshRequest(BaseModel):
+    ticket: str = Field(..., min_length=1)
+
+
+class SessionTicketResponse(BaseModel):
+    ticket: str
+    ticket_id: str
+    session_id: str
+    role: str
+    scope: str
+    state: Literal["issued", "renew_required"]
+    expires_at: str
+    ttl_seconds: int
 
 class GenerateResponse(BaseModel):
     text: str
@@ -313,6 +338,11 @@ REQUIRED_PIPELINE_ORDER = [
     "telemetry_log",
 ]
 
+TICKET_SECRET = os.getenv("SESSION_TICKET_SECRET", "aetherium-dev-ticket-secret").encode("utf-8")
+SESSION_TICKET_TTL_SECONDS = int(os.getenv("SESSION_TICKET_TTL_SECONDS", "60"))
+ALLOWED_WS_SCOPES = {"cognitive:stream", "cognitive:stream:privileged"}
+TICKET_AUDIT_TRAIL: deque[Dict[str, Any]] = deque(maxlen=2000)
+
 
 # --- In-memory State and Concurrency ---
 
@@ -487,6 +517,78 @@ def _ensure_api_key(x_api_key: str | None) -> None:
 
 def _extract_ws_api_key(websocket: WebSocket) -> str | None:
     return websocket.headers.get("x-api-key") or websocket.query_params.get("api_key")
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
+
+
+def _b64url_decode(raw: str) -> bytes:
+    padding = "=" * (-len(raw) % 4)
+    return base64.urlsafe_b64decode(raw + padding)
+
+
+def _audit_ticket_event(event: str, metadata: Dict[str, Any]) -> None:
+    TICKET_AUDIT_TRAIL.append({
+        "event": event,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        **metadata,
+    })
+
+
+def _sign_ticket(payload: Dict[str, Any]) -> str:
+    serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    signature = hmac.new(TICKET_SECRET, serialized, hashlib.sha256).digest()
+    return f"{_b64url_encode(serialized)}.{_b64url_encode(signature)}"
+
+
+def _verify_ticket(ticket: str) -> Dict[str, Any]:
+    try:
+        encoded_payload, encoded_sig = ticket.split(".", maxsplit=1)
+        payload_raw = _b64url_decode(encoded_payload)
+        signature = _b64url_decode(encoded_sig)
+    except Exception as exc:
+        raise HTTPException(status_code=401, detail="Malformed session ticket") from exc
+
+    expected = hmac.new(TICKET_SECRET, payload_raw, hashlib.sha256).digest()
+    if not hmac.compare_digest(signature, expected):
+        raise HTTPException(status_code=401, detail="Invalid session ticket signature")
+
+    payload = json.loads(payload_raw.decode("utf-8"))
+    expires_at = datetime.fromtimestamp(float(payload.get("exp", 0)), tz=timezone.utc)
+    if expires_at <= datetime.now(timezone.utc):
+        raise HTTPException(status_code=401, detail="Session ticket expired")
+
+    scope = payload.get("scope")
+    if scope not in ALLOWED_WS_SCOPES:
+        raise HTTPException(status_code=403, detail="Session ticket scope is not allowed")
+    return payload
+
+
+def _issue_ticket(session_id: str, role: str, scope: str) -> SessionTicketResponse:
+    now = datetime.now(timezone.utc)
+    expires = now + timedelta(seconds=SESSION_TICKET_TTL_SECONDS)
+    ticket_id = secrets.token_hex(8)
+    payload = {
+        "tid": ticket_id,
+        "sid": session_id,
+        "role": role,
+        "scope": scope,
+        "iat": now.timestamp(),
+        "exp": expires.timestamp(),
+    }
+    ticket = _sign_ticket(payload)
+    _audit_ticket_event("ticket_issued", {"ticket_id": ticket_id, "session_id": session_id, "role": role, "scope": scope})
+    return SessionTicketResponse(
+        ticket=ticket,
+        ticket_id=ticket_id,
+        session_id=session_id,
+        role=role,
+        scope=scope,
+        state="issued",
+        expires_at=expires.isoformat(),
+        ttl_seconds=SESSION_TICKET_TTL_SECONDS,
+    )
 
 async def _metrics_snapshot() -> dict[str, Any]:
     async with METRICS_LOCK:
@@ -772,21 +874,75 @@ def resolve_voice_model(language: str = "en-US", region: str = "us") -> dict[str
     model = _resolve_voice_model(language, region)
     return {"language": language, "region": region, "model": model}
 
+@app.post("/api/v1/auth/session", response_model=SessionTicketResponse)
+async def issue_session_ticket(
+    request: SessionTicketIssueRequest,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+) -> SessionTicketResponse:
+    _ensure_api_key(x_api_key)
+    return _issue_ticket(request.session_id, request.role, request.scope)
+
+
+@app.post("/api/v1/auth/session/refresh", response_model=SessionTicketResponse)
+async def refresh_session_ticket(
+    request: SessionTicketRefreshRequest,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+) -> SessionTicketResponse:
+    _ensure_api_key(x_api_key)
+    payload = _verify_ticket(request.ticket)
+    return _issue_ticket(payload["sid"], payload["role"], payload["scope"])
+
+
+@app.get("/api/v1/auth/session/audit")
+async def session_ticket_audit_log(
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+) -> dict[str, Any]:
+    _ensure_api_key(x_api_key)
+    return {"count": len(TICKET_AUDIT_TRAIL), "events": list(TICKET_AUDIT_TRAIL)}
+
+
 # --- WebSocket Endpoints ---
 
 @app.websocket("/ws/cognitive-stream")
 async def cognitive_stream(websocket: WebSocket) -> None:
-    api_key = _extract_ws_api_key(websocket)
-    if not api_key:
-        await websocket.close(code=1008, reason="Missing API Key")
+    ticket = websocket.query_params.get("ticket")
+    if not ticket:
+        await websocket.close(code=1008, reason="Missing session ticket")
         return
-    await websocket.accept()
+
+    try:
+        ticket_payload = _verify_ticket(ticket)
+    except HTTPException as exc:
+        await websocket.close(code=1008, reason=str(exc.detail))
+        return
+
+    await websocket.accept(subprotocol="aetherium-ticket-v1")
     try:
         while True:
             payload = await websocket.receive_json()
             if payload.get("type") != "dsl_submission":
                 await websocket.send_json({"status": "error", "detail": "Invalid message type"})
                 continue
+
+            requires_operator = bool(payload.get("requires_operator"))
+            role = ticket_payload.get("role", "viewer")
+            scope = ticket_payload.get("scope", "")
+            if requires_operator and (role != "operator" or scope != "cognitive:stream:privileged"):
+                _audit_ticket_event("privileged_ws_action_rejected", {
+                    "ticket_id": ticket_payload.get("tid"),
+                    "session_id": ticket_payload.get("sid"),
+                    "required_role": "operator",
+                    "actual_role": role,
+                })
+                await websocket.send_json({"status": "error", "detail": "Insufficient role for privileged action"})
+                continue
+
+            if requires_operator:
+                _audit_ticket_event("privileged_ws_action_accepted", {
+                    "ticket_id": ticket_payload.get("tid"),
+                    "session_id": ticket_payload.get("sid"),
+                    "action": payload.get("action", "unspecified"),
+                })
             await websocket.send_json({"status": "accepted", "echo": payload})
     except WebSocketDisconnect:
         pass

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
+from . import main
 from .main import app
 
 
@@ -54,16 +55,57 @@ def test_websocket_stream_missing_key(client: TestClient) -> None:
             pass
 
 
-def test_websocket_stream_with_query_key(client: TestClient) -> None:
-    with client.websocket_connect("/ws/cognitive-stream?api_key=test-key") as websocket:
+def _issue_ticket(client: TestClient, role: str = "viewer", scope: str = "cognitive:stream") -> str:
+    response = client.post(
+        "/api/v1/auth/session",
+        json={"session_id": "s1", "role": role, "scope": scope},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert response.status_code == 200
+    return response.json()["ticket"]
+
+
+def test_websocket_stream_with_valid_ticket(client: TestClient) -> None:
+    ticket = _issue_ticket(client)
+    with client.websocket_connect(f"/ws/cognitive-stream?ticket={ticket}") as websocket:
         websocket.send_json({"type": "dsl_submission", "payload": "..."})
         response = websocket.receive_json()
         assert response["status"] == "accepted"
 
 
-def test_websocket_stream_with_header_key(client: TestClient) -> None:
-    with client.websocket_connect("/ws/cognitive-stream", headers={"X-API-Key": "test-key"}) as websocket:
-        websocket.send_json({"type": "dsl_submission", "payload": "..."})
+def test_websocket_stream_rejects_invalid_ticket(client: TestClient) -> None:
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/ws/cognitive-stream?ticket=bad-ticket"):
+            pass
+
+
+def test_websocket_stream_rejects_expired_ticket(client: TestClient) -> None:
+    expired_ticket = main._sign_ticket(
+        {
+            "tid": "expired1",
+            "sid": "s1",
+            "role": "viewer",
+            "scope": "cognitive:stream",
+            "iat": 1,
+            "exp": 1,
+        }
+    )
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect(f"/ws/cognitive-stream?ticket={expired_ticket}"):
+            pass
+
+
+def test_websocket_stream_privileged_action_requires_operator_role(client: TestClient) -> None:
+    viewer_ticket = _issue_ticket(client, role="viewer", scope="cognitive:stream")
+    with client.websocket_connect(f"/ws/cognitive-stream?ticket={viewer_ticket}") as websocket:
+        websocket.send_json({"type": "dsl_submission", "payload": "...", "requires_operator": True, "action": "danger_reset"})
+        response = websocket.receive_json()
+        assert response["status"] == "error"
+        assert "Insufficient role" in response["detail"]
+
+    operator_ticket = _issue_ticket(client, role="operator", scope="cognitive:stream:privileged")
+    with client.websocket_connect(f"/ws/cognitive-stream?ticket={operator_ticket}") as websocket:
+        websocket.send_json({"type": "dsl_submission", "payload": "...", "requires_operator": True, "action": "danger_reset"})
         response = websocket.receive_json()
         assert response["status"] == "accepted"
 

--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -35,6 +35,8 @@ export function resolveCompatibilityEndpoints(preferences) {
     emitUrl: `${apiBase}/generate`,
     validateUrl: `${apiBase}/validate`,
     wsUrl: preferences.wsBase || '/ws/cognitive-stream',
+    authSessionUrl: '/api/v1/auth/session',
+    authSessionRefreshUrl: '/api/v1/auth/session/refresh',
   };
 }
 
@@ -164,6 +166,11 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     voiceSupported: false,
     recognition: null,
   };
+  const sessionTicket = {
+    value: '',
+    expiresAtMs: 0,
+    state: 'renew required',
+  };
 
   const homeState = createDefaultHomeShellState(preferences.activePane, preferences.reducedMotion);
 
@@ -203,9 +210,57 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     elements.connectionStatus.textContent = CONNECTION_STATES[state] ?? CONNECTION_STATES.DISCONNECTED;
   };
 
-  const setSessionTicketState = (text = 'Session ticket: ephemeral') => {
+  const setSessionTicketState = (text = 'Session ticket: renew required') => {
     if (!elements.tokenState) return;
     elements.tokenState.textContent = text;
+  };
+
+  const isSessionTicketValid = () => {
+    return Boolean(sessionTicket.value) && sessionTicket.expiresAtMs > Date.now();
+  };
+
+  const syncTicketPaneState = () => {
+    if (!sessionTicket.value) {
+      setSessionTicketState('Session ticket: renew required');
+      return;
+    }
+    if (!isSessionTicketValid()) {
+      sessionTicket.state = 'renew required';
+      setSessionTicketState('Session ticket: renew required');
+      return;
+    }
+    const secondsLeft = Math.max(0, Math.floor((sessionTicket.expiresAtMs - Date.now()) / 1000));
+    sessionTicket.state = 'issued';
+    setSessionTicketState(`Session ticket: issued (${secondsLeft}s left)`);
+  };
+
+  const issueSessionTicket = async ({ refresh = false } = {}) => {
+    const endpoints = resolveCompatibilityEndpoints(preferences);
+    const fetchImpl = deps.fetchImpl ?? fetch;
+    const url = refresh ? endpoints.authSessionRefreshUrl : endpoints.authSessionUrl;
+    const body = refresh
+      ? { ticket: sessionTicket.value }
+      : { session_id: sessionId, role: sessionRole, scope: sessionRole === 'operator' ? 'cognitive:stream:privileged' : 'cognitive:stream' };
+
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(deps.apiKey ? { 'X-API-Key': deps.apiKey } : {}) },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      sessionTicket.value = '';
+      sessionTicket.expiresAtMs = 0;
+      sessionTicket.state = 'renew required';
+      syncTicketPaneState();
+      throw new Error(`ticket bootstrap failed (${response.status})`);
+    }
+
+    const payload = await response.json();
+    sessionTicket.value = payload.ticket || '';
+    sessionTicket.expiresAtMs = payload.expires_at ? Date.parse(payload.expires_at) : 0;
+    sessionTicket.state = payload.state || 'issued';
+    syncTicketPaneState();
   };
 
   const writeDiagnostics = () => {
@@ -275,11 +330,14 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     pushSessionEvent({ session_id: sessionId, transport: 'ws_state', payload: adapted });
   };
 
-  const connectWS = (url) => {
+  const connectWS = async (url) => {
     if (!runtime.started) return;
 
     const target = resolveWsUrl(url);
     if (!target) return;
+    if (!isSessionTicketValid()) {
+      await issueSessionTicket({ refresh: Boolean(sessionTicket.value) });
+    }
 
     if (runtime.socket) {
       runtime.socket.close();
@@ -288,7 +346,9 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
 
     setConnection('RECONNECTING');
     const socketFactory = deps.socketFactory ?? ((wsUrl) => new WebSocket(wsUrl));
-    const socket = socketFactory(target);
+    const wsTarget = new URL(target);
+    wsTarget.searchParams.set('ticket', sessionTicket.value);
+    const socket = socketFactory(wsTarget.toString(), ['aetherium-ticket-v1']);
     runtime.socket = socket;
 
     socket.onopen = () => {
@@ -304,6 +364,7 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
       homeState.gatewayConnected = false;
       runtime.socket = null;
       setConnection('DISCONNECTED');
+      syncTicketPaneState();
       writeDiagnostics();
     };
 
@@ -311,6 +372,7 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
       runtime.wsConnected = false;
       homeState.gatewayConnected = false;
       setConnection('DISCONNECTED');
+      syncTicketPaneState();
       writeDiagnostics();
     };
 
@@ -385,7 +447,7 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     ensureLanguageLayer();
 
     setStatus('Runtime initialized');
-    connectWS(preferences.wsBase);
+    await connectWS(preferences.wsBase);
 
     initVoice();
 
@@ -413,13 +475,16 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
         signal: controller.signal,
       });
       if (response.status === 401 || response.status === 403) {
-        setSessionTicketState('Session ticket required');
+        sessionTicket.value = '';
+        sessionTicket.expiresAtMs = 0;
+        sessionTicket.state = 'renew required';
+        syncTicketPaneState();
         setConnection('DISCONNECTED');
         throw new Error('Session ticket required');
       }
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
-      setSessionTicketState('Session ticket: active');
+      syncTicketPaneState();
       const payload = await response.json();
       const adapted = adaptIntentResponse(payload);
       ensureManifestation().manifestText(adapted.text || intent, 'request');
@@ -565,7 +630,7 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
       elements.reconnectConfirmButton.disabled = true;
       auditRuntimeChange('reconnectAction', 'armed', 'confirmed');
       await ensureInteractionRuntime();
-      connectWS(preferences.wsBase);
+      await connectWS(preferences.wsBase);
     });
 
     elements.exportButton?.addEventListener('click', () => {
@@ -626,6 +691,7 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     setStatus('');
     setFallback('');
     setConnection('DISCONNECTED');
+    syncTicketPaneState();
     hydrateControls();
     workspace.applyRoleGuards(sessionRole);
     writeDiagnostics();

--- a/docs/clean_first_use_surface.md
+++ b/docs/clean_first_use_surface.md
@@ -16,7 +16,7 @@ No dashboard, HUD, debug panel, scholar panel, lineage panel, runtime console, c
 - `clean-first-surface.js`
   - App bootstrap and orchestration.
   - Settings Workspace wiring, persistence, and session audit export.
-  - Browser-side transport mapping uses canonical routes only (`/api/v1/cognitive/generate`, `/api/v1/cognitive/validate`, `/ws/cognitive-stream`).
+  - Browser-side transport mapping uses canonical routes only (`/api/v1/cognitive/generate`, `/api/v1/cognitive/validate`, `/api/v1/auth/session`, `/api/v1/auth/session/refresh`, `/ws/cognitive-stream`).
   - Legacy `/api/intent` remains backend-adapter scope only and is not exposed for browser direct-call fallback.
   - Deferred runtime bootstrap; WebSocket, voice, and manifestation rendering remain inactive until Settings opens the Interaction pane (or user action).
   - Settings workspace orchestration and audit export wiring.
@@ -36,6 +36,9 @@ No dashboard, HUD, debug panel, scholar panel, lineage panel, runtime console, c
   - Browser-locale + character-range baseline detection.
   - Optional local rule-based detector layer (pluggable).
 - `clean-first-surface.js` intent transport
+  - Runtime performs ticket bootstrap (`/api/v1/auth/session`) before WebSocket connect; it renews via `/api/v1/auth/session/refresh` when needed.
+  - WS connect attaches short-lived ticket as query (`?ticket=<signed_ephemeral_ticket>`) and negotiates `aetherium-ticket-v1` subprotocol.
+  - Security pane reflects live ticket state: `issued`, TTL countdown, or `renew required`.
   - `emitIntent(intent)` sends to `${apiBase}/generate` where `apiBase` defaults to `/api/v1/cognitive`.
   - Auth failures from canonical routes (401/403) are surfaced as `Session ticket required` in Security + Connectivity state instead of falling back to non-canonical endpoints.
   - `adaptIntentResponse(payload)` normalizes backend response into the existing frontend stream shape.

--- a/tests/blank_home_settings_workspace.test.js
+++ b/tests/blank_home_settings_workspace.test.js
@@ -25,6 +25,17 @@ function setupDom({ width = 1280 } = {}) {
     configurable: true,
   });
   Object.defineProperty(globalThis, 'requestAnimationFrame', { value: vi.fn(), configurable: true });
+  Object.defineProperty(globalThis, 'fetch', {
+    value: vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ticket: 'signed-ticket',
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+        state: 'issued',
+      }),
+    }),
+    configurable: true,
+  });
 
   return dom;
 }
@@ -74,11 +85,20 @@ describe('deferred runtime policy', () => {
   it('keeps websocket and voice initialization deferred before workspace interaction', async () => {
     const dom = setupDom();
     const wsCtor = vi.fn(() => ({ close: vi.fn() }));
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ticket: 'signed-ticket',
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+        state: 'issued',
+      }),
+    });
     Object.defineProperty(globalThis, 'WebSocket', { value: wsCtor, configurable: true });
 
     const app = createApp(dom.window.document, {
       manifestationFactory: stubManifestation,
       socketFactory: wsCtor,
+      fetchImpl,
       windowRef: dom.window,
     });
     app.bootstrap();
@@ -101,6 +121,31 @@ describe('deferred runtime policy', () => {
     expect(app.getRuntimeSnapshot().voiceInitialized).toBe(true);
     expect(wsCtor).toHaveBeenCalledTimes(1);
   });
+
+  it('shows live ticket state in the security pane', async () => {
+    const dom = setupDom();
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ticket: 'signed-ticket',
+        expires_at: new Date(Date.now() + 45_000).toISOString(),
+        state: 'issued',
+      }),
+    });
+    const wsCtor = vi.fn(() => ({ close: vi.fn() }));
+
+    const app = createApp(dom.window.document, {
+      manifestationFactory: stubManifestation,
+      socketFactory: wsCtor,
+      fetchImpl,
+      windowRef: dom.window,
+    });
+    app.bootstrap();
+    app.openSettingsWorkspace('interaction');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(dom.window.document.getElementById('token-state').textContent).toContain('issued');
+  });
 });
 
 describe('compatibility adapter behavior', () => {
@@ -118,6 +163,14 @@ describe('compatibility adapter behavior', () => {
     const dom = setupDom();
     const fetchImpl = vi
       .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ticket: 'signed-ticket',
+          expires_at: new Date(Date.now() + 60_000).toISOString(),
+          state: 'issued',
+        }),
+      })
       .mockResolvedValueOnce({ ok: false, status: 401 });
 
     const app = createApp(dom.window.document, {
@@ -136,8 +189,8 @@ describe('compatibility adapter behavior', () => {
     form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(fetchImpl.mock.calls[0][0]).toBe('/api/v1/cognitive/generate');
-    expect(fetchImpl.mock.calls[1][0]).toBe('http://localhost/api/intent');
+    expect(fetchImpl.mock.calls[0][0]).toBe('/api/v1/auth/session');
+    expect(fetchImpl.mock.calls[1][0]).toBe('/api/v1/cognitive/generate');
   });
 });
 
@@ -145,11 +198,20 @@ describe('runtime audit and role guard', () => {
   it('creates audit entries for runtime-critical toggles and reconnect action', async () => {
     const dom = setupDom();
     const wsCtor = vi.fn(() => ({ close: vi.fn() }));
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ticket: 'signed-ticket',
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+        state: 'issued',
+      }),
+    });
     Object.defineProperty(globalThis, 'WebSocket', { value: wsCtor, configurable: true });
 
     const app = createApp(dom.window.document, {
       manifestationFactory: stubManifestation,
       socketFactory: wsCtor,
+      fetchImpl,
       windowRef: dom.window,
     });
     app.bootstrap();

--- a/tests/clean_first_surface_workspace.test.js
+++ b/tests/clean_first_surface_workspace.test.js
@@ -65,11 +65,12 @@ describe('settings store safety', () => {
     };
 
     const store = createSettingsStore(storage);
-    store.save({ activePane: 'security', voiceEnabled: false, token: 'raw-secret' });
+    store.save({ activePane: 'security', voiceEnabled: false, token: 'raw-secret', session_ticket: 'signed-blob' });
 
     const persisted = JSON.parse(storage.getItem(store.key));
     expect(persisted.activePane).toBe('security');
     expect(persisted.voiceEnabled).toBe(false);
     expect(persisted.token).toBeUndefined();
+    expect(persisted.session_ticket).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Motivation
- Protect the realtime websocket transport by introducing short-lived, signed session tickets and surface ticket state to the frontend Security pane. 
- Ensure privileged websocket actions require an operator role and privileged scope and provide audit trails for issuance and privileged attempts. 

### Description
- Backend: added ticket primitives and endpoints in `api_gateway/main.py` including `POST /api/v1/auth/session`, `POST /api/v1/auth/session/refresh`, and `GET /api/v1/auth/session/audit`, HMAC signing/verification, TTL/secret configuration (`SESSION_TICKET_SECRET`, `SESSION_TICKET_TTL_SECONDS`), and websocket enforcement that validates ticket signature, expiry, scope, and role before accepting a connection and before privileged actions. 
- Frontend: updated `clean-first-surface.js` to bootstrap/refresh ephemeral tickets before connecting to `/ws/cognitive-stream`, attach tickets via a query parameter and negotiate `aetherium-ticket-v1` subprotocol, and display live ticket state (issued / TTL countdown / renew required) in the Security pane. 
- Tests: added/updated backend tests (`api_gateway/test_api.py`) for valid, invalid, and expired tickets and privileged-action role checks, and frontend tests (`tests/clean_first_surface_workspace.test.js`, `tests/blank_home_settings_workspace.test.js`) to validate ticket bootstrap behavior and that raw key/token-like fields are not persisted. 
- Docs: updated `docs/clean_first_use_surface.md` and `api_gateway/README.md` to describe the new auth/session endpoints and WS ticket flow. 

### Testing
- Ran `cd api_gateway && pytest -q api_gateway/test_api.py` and all targeted backend tests passed (`10 passed`). 
- Ran `npm run test -- tests/clean_first_surface_workspace.test.js tests/blank_home_settings_workspace.test.js` and frontend unit tests passed (`2 files, 13 tests passed`). 
- Ran `npm run lint` and linter completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fc2b02a48328af20066c8d592821)