### PR TITLE
[tests] Expand settings workspace and API compatibility coverage

### DIFF
--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -141,11 +141,9 @@ def test_cognitive_canonical_routes_are_compatible(client: TestClient, monkeypat
     assert generate_response.status_code == 200
     assert generate_response.json()["text"] == "light-presence-ready"
 
-    payload_path = Path(__file__).with_name("sample_emit_payload.json")
-    emit_payload = json.loads(payload_path.read_text(encoding="utf-8"))
     validate_response = client.post(
         "/api/v1/cognitive/validate",
-        json=emit_payload,
+        json=valid_emit_payload,
         headers={"X-API-Key": "test-key"},
     )
     assert validate_response.status_code == 200

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -128,7 +128,7 @@ def test_compatibility_intent_adapter(client: TestClient) -> None:
 
 
 def test_cognitive_canonical_routes_are_compatible(client: TestClient, monkeypatch: pytest.MonkeyPatch, valid_emit_payload: dict) -> None:
-    async def _stub_model(**_: str) -> str:
+    async def _stub_model(**_) -> str:
         return "light-presence-ready"
 
     monkeypatch.setattr(main, "invoke_generative_model", _stub_model)

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -127,7 +127,7 @@ def test_compatibility_intent_adapter(client: TestClient) -> None:
     assert "visual_manifestation" in payload
 
 
-def test_cognitive_canonical_routes_are_compatible(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cognitive_canonical_routes_are_compatible(client: TestClient, monkeypatch: pytest.MonkeyPatch, valid_emit_payload: dict) -> None:
     async def _stub_model(**_: str) -> str:
         return "light-presence-ready"
 

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -125,3 +125,56 @@ def test_compatibility_intent_adapter(client: TestClient) -> None:
     assert payload["text"] == "please focus and breathe"
     assert "intent_vector" in payload
     assert "visual_manifestation" in payload
+
+
+def test_cognitive_canonical_routes_are_compatible(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _stub_model(**_: str) -> str:
+        return "light-presence-ready"
+
+    monkeypatch.setattr(main, "invoke_generative_model", _stub_model)
+
+    generate_response = client.post(
+        "/api/v1/cognitive/generate",
+        json={"prompt": "manifest", "model": "gpt-4o", "temperature": 0.4},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert generate_response.status_code == 200
+    assert generate_response.json()["text"] == "light-presence-ready"
+
+    payload_path = Path(__file__).with_name("sample_emit_payload.json")
+    emit_payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    validate_response = client.post(
+        "/api/v1/cognitive/validate",
+        json=emit_payload,
+        headers={"X-API-Key": "test-key"},
+    )
+    assert validate_response.status_code == 200
+    assert validate_response.json()["status"] == "success"
+
+
+def test_ws_ticket_issue_refresh_and_stream_flow(client: TestClient) -> None:
+    issue_response = client.post(
+        "/api/v1/auth/session",
+        json={"session_id": "compat-session-2", "role": "viewer", "scope": "cognitive:stream"},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert issue_response.status_code == 200
+    issued = issue_response.json()
+    assert issued["state"] == "issued"
+    assert issued["ticket"]
+
+    refresh_response = client.post(
+        "/api/v1/auth/session/refresh",
+        json={"ticket": issued["ticket"]},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert refresh_response.status_code == 200
+    refreshed = refresh_response.json()
+    assert refreshed["state"] == "issued"
+    assert refreshed["ticket"] != issued["ticket"]
+
+    with client.websocket_connect(f"/ws/cognitive-stream?ticket={refreshed['ticket']}") as websocket:
+        websocket.send_json({"type": "dsl_submission", "payload": "compatibility-check"})
+        response = websocket.receive_json()
+        assert response["status"] == "accepted"
+        assert response["echo"]["payload"] == "compatibility-check"

--- a/tests/blank_home_settings_workspace.test.js
+++ b/tests/blank_home_settings_workspace.test.js
@@ -47,6 +47,12 @@ describe('blank home semantics', () => {
 
     expect(main.querySelectorAll('button')).toHaveLength(1);
     expect(main.querySelector('#settings-toggle')).toBeTruthy();
+    expect(main.querySelector('#composer')).toBeNull();
+    expect(main.querySelector('#readable-fallback')).toBeNull();
+    expect(main.querySelector('#ambient-status')).toBeNull();
+    expect(main.textContent).not.toContain('Hello');
+    expect(main.textContent).not.toContain('Ready');
+    expect(main.textContent).not.toContain('Runtime');
     expect(main.textContent.trim()).toBe('⚙');
   });
 });
@@ -108,6 +114,13 @@ describe('deferred runtime policy', () => {
     expect(wsCtor).not.toHaveBeenCalled();
 
     app.openSettingsWorkspace('connectivity');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(app.getRuntimeSnapshot().started).toBe(false);
+    expect(app.getRuntimeSnapshot().voiceInitialized).toBe(false);
+    expect(wsCtor).not.toHaveBeenCalled();
+
+    app.openSettingsWorkspace('security');
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(app.getRuntimeSnapshot().started).toBe(false);

--- a/tests/first_use_surface_input_events.test.js
+++ b/tests/first_use_surface_input_events.test.js
@@ -87,4 +87,71 @@ describe('workspace pane keyboard controls', () => {
 
     expect(dom.window.document.activeElement.dataset.paneTarget).toBe('connectivity');
   });
+
+  it('moves pane focus with ArrowUp and wraps to previous pane', () => {
+    const html = fs.readFileSync(path.resolve('index.html'), 'utf8');
+    const dom = new JSDOM(html, { url: 'http://localhost:4173' });
+    const workspace = createSettingsWorkspace(dom.window.document, { windowRef: dom.window });
+    workspace.bind();
+    workspace.open('interaction');
+
+    const first = dom.window.document.querySelector('[data-pane-target="interaction"]');
+    first.focus();
+    first.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+
+    expect(dom.window.document.activeElement.dataset.paneTarget).toBe('developer');
+  });
+
+  it('closes on Escape and returns focus to the launcher button', () => {
+    const html = fs.readFileSync(path.resolve('index.html'), 'utf8');
+    const dom = new JSDOM(html, { url: 'http://localhost:4173' });
+    const workspace = createSettingsWorkspace(dom.window.document, { windowRef: dom.window });
+    workspace.bind();
+
+    const launcher = dom.window.document.getElementById('settings-toggle');
+    launcher.focus();
+    workspace.open('interaction');
+
+    const dialog = dom.window.document.getElementById('settings-dialog');
+    dialog.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(dom.window.document.getElementById('settings-workspace').hidden).toBe(true);
+    expect(dom.window.document.activeElement.id).toBe('settings-toggle');
+  });
+});
+
+describe('workspace accessibility behavior', () => {
+  it('loops focus inside modal when tabbing forward/backward', () => {
+    const html = fs.readFileSync(path.resolve('index.html'), 'utf8');
+    const dom = new JSDOM(html, { url: 'http://localhost:4173' });
+    dom.window.HTMLElement.prototype.getClientRects = () => [{ width: 1, height: 1 }];
+    const workspace = createSettingsWorkspace(dom.window.document, { windowRef: dom.window });
+    workspace.bind();
+    workspace.open('interaction');
+
+    const dialog = dom.window.document.getElementById('settings-dialog');
+    const focusable = Array.from(
+      dialog.querySelectorAll(
+        'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter((el) => !el.hasAttribute('hidden') && el.getClientRects().length > 0);
+    const firstFocusable = focusable[0];
+    const lastFocusable = focusable[focusable.length - 1];
+
+    lastFocusable.focus();
+    dialog.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(dom.window.document.activeElement.id).toBe(firstFocusable.id);
+
+    firstFocusable.focus();
+    dialog.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }));
+    expect(dom.window.document.activeElement.id).toBe(lastFocusable.id);
+  });
+
+  it('exposes an accessible launcher name for settings workspace trigger', () => {
+    const html = fs.readFileSync(path.resolve('index.html'), 'utf8');
+    const dom = new JSDOM(html, { url: 'http://localhost:4173' });
+    const launcher = dom.window.document.getElementById('settings-toggle');
+
+    expect(launcher.getAttribute('aria-label')).toBe('Open settings workspace');
+  });
 });

--- a/tests/settings_security_runtime.test.js
+++ b/tests/settings_security_runtime.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
+
+import { createApp } from '../clean-first-surface.js';
+import { createSettingsStore } from '../first_use_surface/settings-store.js';
+
+const html = fs.readFileSync(path.resolve('index.html'), 'utf8');
+
+const stubManifestation = () => ({
+  manifestText: vi.fn(),
+  resize: vi.fn(),
+  render: vi.fn(),
+  setReducedMotion: vi.fn(),
+});
+
+function setupDom() {
+  const dom = new JSDOM(html, { url: 'http://localhost:4173' });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  Object.defineProperty(globalThis, 'localStorage', { value: dom.window.localStorage, configurable: true });
+  Object.defineProperty(globalThis, 'matchMedia', {
+    value: () => ({ matches: false, addListener: () => {}, removeListener: () => {} }),
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, 'requestAnimationFrame', { value: vi.fn(), configurable: true });
+  return dom;
+}
+
+describe('settings security/runtime controls', () => {
+  it('does not persist raw token or API key-like fields in localStorage', () => {
+    const storage = {
+      data: new Map(),
+      getItem(key) {
+        return this.data.has(key) ? this.data.get(key) : null;
+      },
+      setItem(key, value) {
+        this.data.set(key, value);
+      },
+    };
+    const store = createSettingsStore(storage);
+
+    store.save({
+      activePane: 'security',
+      token: 'raw-secret-token',
+      api_key: 'raw-api-key',
+      session_ticket: 'signed-session-ticket',
+      wsBase: '/ws/cognitive-stream',
+    });
+
+    const persisted = JSON.parse(storage.getItem(store.key));
+    expect(persisted.activePane).toBe('security');
+    expect(persisted.wsBase).toBe('/ws/cognitive-stream');
+    expect(persisted.token).toBeUndefined();
+    expect(persisted.api_key).toBeUndefined();
+    expect(persisted.session_ticket).toBeUndefined();
+  });
+
+  it('requires explicit confirm step before dangerous reset audit event is emitted', () => {
+    const dom = setupDom();
+    const app = createApp(dom.window.document, { manifestationFactory: stubManifestation, windowRef: dom.window });
+    app.bootstrap();
+    app.openSettingsWorkspace('security');
+
+    const armDangerReset = dom.window.document.getElementById('danger-reset');
+    const confirmDangerReset = dom.window.document.getElementById('danger-reset-confirm');
+    const role = dom.window.document.getElementById('session-role');
+    role.value = 'operator';
+    role.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+    confirmDangerReset.click();
+    expect(app.getSessionAudit().filter((entry) => entry.control === 'dangerousReset')).toHaveLength(0);
+
+    armDangerReset.click();
+    confirmDangerReset.click();
+    expect(app.getSessionAudit().filter((entry) => entry.control === 'dangerousReset')).toHaveLength(1);
+  });
+
+  it('creates runtime audit event when runtime mode override is changed', () => {
+    const dom = setupDom();
+    const app = createApp(dom.window.document, { manifestationFactory: stubManifestation, windowRef: dom.window });
+    app.bootstrap();
+    app.openSettingsWorkspace('runtime');
+
+    const runtimeMode = dom.window.document.getElementById('runtime-mode');
+    runtimeMode.value = 'adaptive';
+    runtimeMode.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+    const events = app.getSessionAudit().filter((entry) => entry.control === 'runtimeMode');
+    expect(events).toHaveLength(1);
+    expect(events[0].old_value).toBe('calm');
+    expect(events[0].new_value).toBe('adaptive');
+  });
+});


### PR DESCRIPTION
### Motivation
- Strengthen regression coverage around the settings workspace, accessibility, and security-sensitive runtime controls to prevent accidental runtime starts and secret persistence. 
- Add compatibility and end-to-end checks for the canonical cognitive API surface and websocket ticket flows to protect adapter/route expectations.

### Description
- Added explicit negative assertions to `tests/blank_home_settings_workspace.test.js` to verify the first view contains only the settings launcher and not the composer, readable fallback, ambient status, or greeting/runtime text, and extended deferred runtime checks so opening non-interaction panes does not start the runtime.  
- Expanded keyboard and accessibility tests in `tests/first_use_surface_input_events.test.js` to cover `ArrowUp`/`ArrowDown` pane navigation, `Escape` closing and focus return, modal focus loop (Tab/Shift+Tab), and verification of the launcher `aria-label`.  
- Added `tests/settings_security_runtime.test.js` to assert that raw tokens/API-key-like fields are not persisted to localStorage, dangerous reset requires the explicit arm+confirm flow before emitting audit events, and runtime mode overrides emit audit entries.  
- Extended API integration tests in `api_gateway/test_api.py` to exercise `/api/v1/cognitive/generate` and `/api/v1/cognitive/validate` compatibility and to validate WS ticket issue/refresh and the ticket-gated `/ws/cognitive-stream` message flow.

### Testing
- Ran the selected frontend unit tests with `npm run test -- tests/blank_home_settings_workspace.test.js tests/first_use_surface_input_events.test.js tests/settings_security_runtime.test.js` and all tests passed.  
- Ran backend integration suite with `cd api_gateway && pytest -q test_api.py` which completed successfully (`12 passed`).  
- Ran linting with `npm run lint` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e902e07ccc8328a156d0a4595f70a6)