### PR TITLE
[security] Patch protobufjs lockfile to 7.5.5 for CVE-2026-41242

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "three": "^0.169.0",
         "xstate": "^5.19.2"
       },
+      "overrides": {
+        "protobufjs": "7.5.5"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/node": "^22.7.4",
@@ -4256,9 +4259,8 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "three": "^0.169.0",
     "xstate": "^5.19.2"
   },
+  "overrides": {
+    "protobufjs": "7.5.5"
+  },
   "devDependencies": {
     "@eslint/js": "^9.12.0",
     "@types/node": "^22.7.4",


### PR DESCRIPTION
### Motivation
- Remediate an advisory (CVE-2026-41242) in the transitive `protobufjs` dependency that can lead to descriptor-driven arbitrary code execution during protobuf-to-JS compilation.

### Description
- Add an npm `overrides` entry to `package.json` to pin `protobufjs` to `7.5.5` for deterministic, secure transitive resolution.  
- Update `package-lock.json` metadata and the `node_modules/protobufjs` lockfile entry to reference `7.5.5` instead of the vulnerable `7.5.4` so the lockfile matches the override intent.

### Testing
- Ran `npm run lint` which completed successfully.  
- Ran the full JS test suite via `npm test`; the run surfaced pre-existing repository test issues (Vitest reported a few failing suites due to missing test-suite files / ESM/CommonJS mismatch) that are unrelated to this dependency patch.  
- Ran targeted frontend tests with `npx vitest run tests/blank_home_settings_workspace.test.js tests/clean_first_surface_workspace.test.js tests/settings_security_runtime.test.js` which passed.  
- Ran backend tests with `cd api_gateway && pytest -q` which passed (`33 passed`).  
- `python3 tools/contracts/contract_checker.py` failed in this environment due to a missing module in the repository test harness (`ModuleNotFoundError: tools.contracts.runtime_drift_guard`) and is not caused by this dependency change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91b805f9083209f00393ae3f52611)