### PR TITLE
[api_gateway] Enforce API key validation from environment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ optics.color_mode := monochrome | palette | source_radiance
 
 ---
 
+## API key setup
+
+Protected gateway endpoints require `X-API-Key` and validate it against environment configuration in the API process:
+
+- `AETHERIUM_API_KEY` for a single key deployment.
+- `AETHERIUM_API_KEY_ALLOWLIST` for comma-separated multi-key allowlist support (for staged rotation/migration).
+
+When both are present, the effective allowlist is the union of both values. If neither is configured, the gateway rejects protected endpoint requests (fail closed).
+
 ## Local development & checks
 
 ### Recommended minimum before PR

--- a/api_gateway/README.md
+++ b/api_gateway/README.md
@@ -21,6 +21,7 @@ For a quick development server, you can use `uvicorn` directly. This mode is con
 
 ```bash
 # An API key is required for protected endpoints
+export AETHERIUM_API_KEY=demo-key
 export OPENAI_API_KEY=demo-key
 # Optional for Google model calls:
 export GEMINI_API_KEY=demo-key
@@ -34,6 +35,15 @@ For an environment that more closely resembles production, use the provided shel
 ```bash
 ./api_gateway/start_cognitive_api.sh
 ```
+
+### API Key Configuration
+
+Protected HTTP endpoints validate `X-API-Key` against runtime configuration:
+
+- `AETHERIUM_API_KEY`: single expected key.
+- `AETHERIUM_API_KEY_ALLOWLIST`: optional comma-separated allowlist for multi-key rollout.
+
+If both are set, keys are merged. If neither is set, the gateway fails closed and rejects protected endpoint requests.
 
 ### Validate Example
 ```bash
@@ -52,6 +62,7 @@ curl -X POST http://localhost:8080/api/v1/cognitive/validate \
 
 ```bash
 # ต้องมี API key สำหรับเรียกใช้งาน endpoint ที่ป้องกันสิทธิ์
+export AETHERIUM_API_KEY=demo-key
 export OPENAI_API_KEY=demo-key
 # หากต้องเรียก Google model ให้ตั้งเพิ่ม
 export GEMINI_API_KEY=demo-key

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -70,7 +70,7 @@ MODEL_PROVIDER_MAP = {
 
 AETHERIUM_API_KEY_ENV = "AETHERIUM_API_KEY"
 AETHERIUM_API_KEY_ALLOWLIST_ENV = "AETHERIUM_API_KEY_ALLOWLIST"
-EXPECTED_API_KEYS: frozenset[str] = frozenset()
+EXPECTED_API_KEYS: Optional[frozenset[str]] = None
 
 
 def _parse_api_key_allowlist(raw: str) -> set[str]:

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -534,7 +534,7 @@ def _infer_intent_from_text(text: str) -> tuple[IntentVector, VisualManifestatio
     return intent, visual
 
 def _ensure_api_key(x_api_key: str | None) -> None:
-    configured_keys = EXPECTED_API_KEYS or _load_expected_api_keys()
+    configured_keys = EXPECTED_API_KEYS if EXPECTED_API_KEYS is not None else _load_expected_api_keys()
 
     if not configured_keys:
         logger.error(

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -68,6 +68,23 @@ MODEL_PROVIDER_MAP = {
     "claude-3-opus": "anthropic",
 }
 
+AETHERIUM_API_KEY_ENV = "AETHERIUM_API_KEY"
+AETHERIUM_API_KEY_ALLOWLIST_ENV = "AETHERIUM_API_KEY_ALLOWLIST"
+EXPECTED_API_KEYS: frozenset[str] = frozenset()
+
+
+def _parse_api_key_allowlist(raw: str) -> set[str]:
+    return {key.strip() for key in raw.split(",") if key.strip()}
+
+
+def _load_expected_api_keys() -> frozenset[str]:
+    primary_key = os.getenv(AETHERIUM_API_KEY_ENV, "").strip()
+    allowlist_raw = os.getenv(AETHERIUM_API_KEY_ALLOWLIST_ENV, "")
+    keys = _parse_api_key_allowlist(allowlist_raw)
+    if primary_key:
+        keys.add(primary_key)
+    return frozenset(keys)
+
 
 # --- Pydantic Models ---
 
@@ -277,9 +294,14 @@ logger = logging.getLogger("api-gateway")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global r, nc
-    if not os.getenv("AETHERIUM_API_KEY"):
-        logger.error("AETHERIUM_API_KEY is not configured; protected endpoints will fail closed")
+    global r, nc, EXPECTED_API_KEYS
+    EXPECTED_API_KEYS = _load_expected_api_keys()
+    if not EXPECTED_API_KEYS:
+        logger.error(
+            "No API key configured via %s or %s; protected endpoints will fail closed",
+            AETHERIUM_API_KEY_ENV,
+            AETHERIUM_API_KEY_ALLOWLIST_ENV,
+        )
     try:
         r = redis.from_url(REDIS_URL, decode_responses=True)
         nc = await nats.connect(NATS_URL)
@@ -512,8 +534,21 @@ def _infer_intent_from_text(text: str) -> tuple[IntentVector, VisualManifestatio
     return intent, visual
 
 def _ensure_api_key(x_api_key: str | None) -> None:
+    configured_keys = EXPECTED_API_KEYS or _load_expected_api_keys()
+
+    if not configured_keys:
+        logger.error(
+            "Rejecting request: no configured API keys in %s/%s",
+            AETHERIUM_API_KEY_ENV,
+            AETHERIUM_API_KEY_ALLOWLIST_ENV,
+        )
+        raise HTTPException(status_code=503, detail="API key validation is not configured")
+
     if not x_api_key:
         raise HTTPException(status_code=401, detail="missing X-API-Key")
+
+    if x_api_key not in configured_keys:
+        raise HTTPException(status_code=403, detail="invalid X-API-Key")
 
 def _extract_ws_api_key(websocket: WebSocket) -> str | None:
     return websocket.headers.get("x-api-key") or websocket.query_params.get("api_key")

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
+
+os.environ.setdefault("AETHERIUM_API_KEY", "test-key")
 
 from . import main
 from .main import app
@@ -22,6 +25,14 @@ def valid_emit_payload() -> dict:
     return json.loads(payload_path.read_text(encoding="utf-8"))
 
 
+@pytest.fixture
+def api_key_header(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    key = os.getenv("AETHERIUM_API_KEY", "test-key")
+    monkeypatch.setenv("AETHERIUM_API_KEY", key)
+    main.EXPECTED_API_KEYS = main._load_expected_api_keys()
+    return {"X-API-Key": key}
+
+
 def test_health_check(client: TestClient) -> None:
     response = client.get("/health")
     assert response.status_code == 200
@@ -34,13 +45,22 @@ def test_emit_missing_api_key(client: TestClient, valid_emit_payload: dict) -> N
     assert "missing X-API-Key" in response.text
 
 
-def test_emit_invalid_payload(client: TestClient) -> None:
+def test_emit_invalid_payload(client: TestClient, api_key_header: dict[str, str]) -> None:
     response = client.post(
         "/api/v1/cognitive/emit",
         json={},
-        headers={"X-API-Key": "test-key"},
+        headers=api_key_header,
     )
     assert response.status_code == 422
+
+
+
+
+def test_emit_invalid_api_key_rejected(client: TestClient, valid_emit_payload: dict, api_key_header: dict[str, str]) -> None:
+    invalid_headers = {"X-API-Key": f"{api_key_header['X-API-Key']}-invalid"}
+    response = client.post("/api/v1/cognitive/emit", json=valid_emit_payload, headers=invalid_headers)
+    assert response.status_code == 403
+    assert "invalid X-API-Key" in response.text
 
 
 def test_validate_missing_api_key(client: TestClient, valid_emit_payload: dict) -> None:
@@ -55,18 +75,18 @@ def test_websocket_stream_missing_key(client: TestClient) -> None:
             pass
 
 
-def _issue_ticket(client: TestClient, role: str = "viewer", scope: str = "cognitive:stream") -> str:
+def _issue_ticket(client: TestClient, api_key_header: dict[str, str], role: str = "viewer", scope: str = "cognitive:stream") -> str:
     response = client.post(
         "/api/v1/auth/session",
         json={"session_id": "s1", "role": role, "scope": scope},
-        headers={"X-API-Key": "test-key"},
+        headers=api_key_header,
     )
     assert response.status_code == 200
     return response.json()["ticket"]
 
 
-def test_websocket_stream_with_valid_ticket(client: TestClient) -> None:
-    ticket = _issue_ticket(client)
+def test_websocket_stream_with_valid_ticket(client: TestClient, api_key_header: dict[str, str]) -> None:
+    ticket = _issue_ticket(client, api_key_header)
     with client.websocket_connect(f"/ws/cognitive-stream?ticket={ticket}") as websocket:
         websocket.send_json({"type": "dsl_submission", "payload": "..."})
         response = websocket.receive_json()
@@ -95,15 +115,15 @@ def test_websocket_stream_rejects_expired_ticket(client: TestClient) -> None:
             pass
 
 
-def test_websocket_stream_privileged_action_requires_operator_role(client: TestClient) -> None:
-    viewer_ticket = _issue_ticket(client, role="viewer", scope="cognitive:stream")
+def test_websocket_stream_privileged_action_requires_operator_role(client: TestClient, api_key_header: dict[str, str]) -> None:
+    viewer_ticket = _issue_ticket(client, api_key_header, role="viewer", scope="cognitive:stream")
     with client.websocket_connect(f"/ws/cognitive-stream?ticket={viewer_ticket}") as websocket:
         websocket.send_json({"type": "dsl_submission", "payload": "...", "requires_operator": True, "action": "danger_reset"})
         response = websocket.receive_json()
         assert response["status"] == "error"
         assert "Insufficient role" in response["detail"]
 
-    operator_ticket = _issue_ticket(client, role="operator", scope="cognitive:stream:privileged")
+    operator_ticket = _issue_ticket(client, api_key_header, role="operator", scope="cognitive:stream:privileged")
     with client.websocket_connect(f"/ws/cognitive-stream?ticket={operator_ticket}") as websocket:
         websocket.send_json({"type": "dsl_submission", "payload": "...", "requires_operator": True, "action": "danger_reset"})
         response = websocket.receive_json()
@@ -127,7 +147,7 @@ def test_compatibility_intent_adapter(client: TestClient) -> None:
     assert "visual_manifestation" in payload
 
 
-def test_cognitive_canonical_routes_are_compatible(client: TestClient, monkeypatch: pytest.MonkeyPatch, valid_emit_payload: dict) -> None:
+def test_cognitive_canonical_routes_are_compatible(client: TestClient, monkeypatch: pytest.MonkeyPatch, valid_emit_payload: dict, api_key_header: dict[str, str]) -> None:
     async def _stub_model(**_) -> str:
         return "light-presence-ready"
 
@@ -136,7 +156,7 @@ def test_cognitive_canonical_routes_are_compatible(client: TestClient, monkeypat
     generate_response = client.post(
         "/api/v1/cognitive/generate",
         json={"prompt": "manifest", "model": "gpt-4o", "temperature": 0.4},
-        headers={"X-API-Key": "test-key"},
+        headers=api_key_header,
     )
     assert generate_response.status_code == 200
     assert generate_response.json()["text"] == "light-presence-ready"
@@ -144,17 +164,17 @@ def test_cognitive_canonical_routes_are_compatible(client: TestClient, monkeypat
     validate_response = client.post(
         "/api/v1/cognitive/validate",
         json=valid_emit_payload,
-        headers={"X-API-Key": "test-key"},
+        headers=api_key_header,
     )
     assert validate_response.status_code == 200
     assert validate_response.json()["status"] == "success"
 
 
-def test_ws_ticket_issue_refresh_and_stream_flow(client: TestClient) -> None:
+def test_ws_ticket_issue_refresh_and_stream_flow(client: TestClient, api_key_header: dict[str, str]) -> None:
     issue_response = client.post(
         "/api/v1/auth/session",
         json={"session_id": "compat-session-2", "role": "viewer", "scope": "cognitive:stream"},
-        headers={"X-API-Key": "test-key"},
+        headers=api_key_header,
     )
     assert issue_response.status_code == 200
     issued = issue_response.json()
@@ -164,7 +184,7 @@ def test_ws_ticket_issue_refresh_and_stream_flow(client: TestClient) -> None:
     refresh_response = client.post(
         "/api/v1/auth/session/refresh",
         json={"ticket": issued["ticket"]},
-        headers={"X-API-Key": "test-key"},
+        headers=api_key_header,
     )
     assert refresh_response.status_code == 200
     refreshed = refresh_response.json()


### PR DESCRIPTION
### Motivation
- Bind gateway authentication to real runtime configuration so protected endpoints validate against configured keys instead of header presence-only checks. 
- Support multi-key rollout/rotation by allowing an allowlist via environment configuration. 
- Fail closed when no API key is configured to prevent accidental unauthenticated operation.

### Description
- Load keys from environment via `AETHERIUM_API_KEY` and `AETHERIUM_API_KEY_ALLOWLIST` into `EXPECTED_API_KEYS` using `_load_expected_api_keys()`, and initialize this set at startup in the `lifespan` handler. 
- Harden `_ensure_api_key` to return `401` when the header is missing, `403` when the provided `X-API-Key` is not in the configured set, and `503` (fail-closed) when no keys are configured, with clear logs. 
- Update tests in `api_gateway/test_api.py` to set `AETHERIUM_API_KEY` for the test process, add an `api_key_header` fixture that sources the valid key from env, and add a new test case asserting invalid keys are rejected (`403`). 
- Document the new configuration and allowlist in `api_gateway/README.md` and the repository `README.md` with examples for `AETHERIUM_API_KEY` and `AETHERIUM_API_KEY_ALLOWLIST`.

### Testing
- Ran the gateway test suite with `cd api_gateway && pytest -q`, which passed: `34 passed`.
- Ran frontend lint via `npm run lint`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9472facf48328a7b573e2368e0595)