### PR TITLE
[interaction] Support image attachments in chat composer and cognitive generate flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Core contracts/schemas in this repo include:
 ### Intent-to-light flow (first-use surface)
 1. User enters through a blank awakening surface and opens the Settings Workspace operational sanctum.
 2. Interaction pane activation lazily starts runtime connectivity (WS/voice/manifestation).
-3. User submits text from the Interaction composer; browser transport emits through canonical cognitive routes only (`/api/v1/cognitive/*` + `/ws/cognitive-stream`).
+3. User submits text (and optionally an attached image for multimodal analysis) from the Interaction composer; browser transport emits through canonical cognitive routes only (`/api/v1/cognitive/*` + `/ws/cognitive-stream`).
 4. Language layer resolves language deterministically:
    - explicit setting → browser locale → char heuristics → optional local detector → session memory
 5. Response orchestrator maps intent class (greeting/question/etc.) to deterministic text+mood.

--- a/api_gateway/main.py
+++ b/api_gateway/main.py
@@ -100,6 +100,13 @@ class GenerateRequest(BaseModel):
     prompt: str
     model: str = Field(default="gemini-1.5-pro")
     temperature: float = Field(default=0.7, ge=0.0, le=2.0)
+    image: Optional["ImageAttachment"] = None
+
+
+class ImageAttachment(BaseModel):
+    data_url: str = Field(..., min_length=16)
+    mime_type: str = Field(default="image/jpeg")
+    filename: Optional[str] = None
 
 class LegacyIntentRequest(BaseModel):
     prompt: str
@@ -417,17 +424,39 @@ def _is_blocked_proxy_target(hostname: str) -> bool:
 
 # --- Generative Model Invocation ---
 
-async def invoke_generative_model(prompt: str, model: str, temperature: float) -> str:
+def _extract_image_payload(image: ImageAttachment | None) -> tuple[bytes | None, str | None]:
+    if not image:
+        return None, None
+    if not image.data_url.startswith("data:"):
+        raise HTTPException(status_code=422, detail="image.data_url must be a valid data URL")
+    try:
+        header, encoded = image.data_url.split(",", 1)
+        if ";base64" not in header:
+            raise ValueError("missing base64 marker")
+        mime = header[5:].split(";", 1)[0] or image.mime_type
+        binary = base64.b64decode(encoded, validate=True)
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=f"invalid image attachment: {exc}") from exc
+    if len(binary) > 5 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="image attachment exceeds 5MB limit")
+    return binary, mime
+
+
+async def invoke_generative_model(prompt: str, model: str, temperature: float, image: ImageAttachment | None = None) -> str:
     provider = MODEL_PROVIDER_MAP.get(model)
     if not provider:
         raise HTTPException(status_code=400, detail=f"Unsupported model: {model}")
+    image_bytes, image_mime = _extract_image_payload(image)
 
     if provider == "google":
         api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
         if not api_key:
             raise HTTPException(status_code=500, detail="Google API key (GEMINI_API_KEY or GOOGLE_API_KEY) is not set")
         url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
-        payload = {"contents": [{"parts": [{"text": prompt}]}]}
+        parts: list[dict[str, Any]] = [{"text": prompt or "Analyze this image and provide key observations."}]
+        if image_bytes and image_mime:
+            parts.append({"inline_data": {"mime_type": image_mime, "data": base64.b64encode(image_bytes).decode("utf-8")}})
+        payload = {"contents": [{"parts": parts}]}
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(url, json=payload)
             response.raise_for_status()
@@ -439,9 +468,13 @@ async def invoke_generative_model(prompt: str, model: str, temperature: float) -
             raise HTTPException(status_code=500, detail="OPENAI_API_KEY is not set")
         url = "https://api.openai.com/v1/chat/completions"
         headers = {"Authorization": f"Bearer {api_key}"}
+        content: list[dict[str, Any]] = [{"type": "text", "text": prompt or "Analyze this image and summarize it."}]
+        if image_bytes and image_mime:
+            image_data_url = f"data:{image_mime};base64,{base64.b64encode(image_bytes).decode('utf-8')}"
+            content.append({"type": "image_url", "image_url": {"url": image_data_url}})
         payload = {
             "model": model,
-            "messages": [{"role": "user", "content": prompt}],
+            "messages": [{"role": "user", "content": content}],
             "temperature": temperature,
         }
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -728,7 +761,8 @@ async def generate_text(
         generated_text = await invoke_generative_model(
             prompt=request.prompt,
             model=request.model,
-            temperature=request.temperature
+            temperature=request.temperature,
+            image=request.image,
         )
         
         intent_vec, visual_manifest = _infer_intent_from_text(generated_text)

--- a/api_gateway/test_api.py
+++ b/api_gateway/test_api.py
@@ -150,6 +150,34 @@ def test_cognitive_canonical_routes_are_compatible(client: TestClient, monkeypat
     assert validate_response.json()["status"] == "success"
 
 
+def test_cognitive_generate_supports_image_attachment(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _stub_model(**kwargs) -> str:
+        captured.update(kwargs)
+        return "image-aware-response"
+
+    monkeypatch.setattr(main, "invoke_generative_model", _stub_model)
+
+    response = client.post(
+        "/api/v1/cognitive/generate",
+        json={
+            "prompt": "analyze this",
+            "model": "gpt-4o",
+            "temperature": 0.4,
+            "image": {
+                "data_url": "data:image/png;base64,aGVsbG8=",
+                "mime_type": "image/png",
+                "filename": "sample.png",
+            },
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert response.status_code == 200
+    assert response.json()["text"] == "image-aware-response"
+    assert captured["image"].mime_type == "image/png"
+
+
 def test_ws_ticket_issue_refresh_and_stream_flow(client: TestClient) -> None:
     issue_response = client.post(
         "/api/v1/auth/session",

--- a/clean-first-surface.css
+++ b/clean-first-surface.css
@@ -134,7 +134,7 @@ body {
 
 .composer {
   display: grid;
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: 1fr auto auto auto;
   gap: 8px;
 }
 

--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -57,6 +57,15 @@ function adaptGenerateRequest(intent) {
   };
 }
 
+function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(new Error('Unable to read attached image'));
+    reader.readAsDataURL(file);
+  });
+}
+
 export function adaptIntentResponse(payload) {
   const state = payload?.intent_vector?.category || payload?.state || 'calm';
   const visual = payload?.visual_manifestation;
@@ -114,11 +123,16 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
   let sessionRole = 'viewer';
   const sessionAudit = [];
   const inputRuntime = { isComposing: false, lastCompositionEndAt: -Infinity };
+  const imageRuntime = { file: null, dataUrl: '' };
 
   const elements = {
     canvas: documentRef.getElementById('manifestation-canvas'),
     form: documentRef.getElementById('composer'),
     input: documentRef.getElementById('intent-input'),
+    imageInput: documentRef.getElementById('intent-image-input'),
+    attachImageButton: documentRef.getElementById('attach-image-btn'),
+    clearImageButton: documentRef.getElementById('clear-image-btn'),
+    imageAttachmentStatus: documentRef.getElementById('image-attachment-status'),
     sendButton: documentRef.getElementById('send-btn'),
     voiceButton: documentRef.getElementById('voice-btn'),
     statusText: documentRef.getElementById('ambient-status'),
@@ -319,6 +333,35 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
   const applySubmissionState = (busy) => {
     if (elements.input) elements.input.disabled = busy;
     if (elements.sendButton) elements.sendButton.disabled = busy;
+    if (elements.attachImageButton) elements.attachImageButton.disabled = busy;
+    if (elements.clearImageButton) elements.clearImageButton.disabled = busy;
+  };
+
+  const setImageAttachmentStatus = (text = '') => {
+    if (elements.imageAttachmentStatus) elements.imageAttachmentStatus.textContent = text;
+  };
+
+  const clearImageAttachment = () => {
+    imageRuntime.file = null;
+    imageRuntime.dataUrl = '';
+    if (elements.imageInput) elements.imageInput.value = '';
+    if (elements.clearImageButton) elements.clearImageButton.hidden = true;
+    setImageAttachmentStatus('');
+  };
+
+  const setImageAttachment = async (file) => {
+    if (!file) {
+      clearImageAttachment();
+      return;
+    }
+    if (!file.type.startsWith('image/')) {
+      clearImageAttachment();
+      throw new Error('Unsupported attachment. Please choose an image file.');
+    }
+    imageRuntime.file = file;
+    imageRuntime.dataUrl = await readFileAsDataUrl(file);
+    if (elements.clearImageButton) elements.clearImageButton.hidden = false;
+    setImageAttachmentStatus(`Attached image: ${file.name}`);
   };
 
   const handleIncomingState = (payload) => {
@@ -461,7 +504,7 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     writeDiagnostics();
   };
 
-  const emitIntent = async (intent) => {
+  const emitIntent = async (intent, imagePayload = null) => {
     const controller = new AbortController();
     const timeoutId = globalThis.setTimeout(() => controller.abort(), DEFAULT_INTENT_TIMEOUT_MS);
 
@@ -471,7 +514,10 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
       const response = await fetchImpl(endpoints.emitUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(adaptGenerateRequest(intent)),
+        body: JSON.stringify({
+          ...adaptGenerateRequest(intent),
+          image: imagePayload,
+        }),
         signal: controller.signal,
       });
       if (response.status === 401 || response.status === 403) {
@@ -501,14 +547,27 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
 
   const submitIntent = async (intent) => {
     const text = intent.trim();
-    if (!text) return;
+    const imagePayload = imageRuntime.dataUrl
+      ? {
+          data_url: imageRuntime.dataUrl,
+          mime_type: imageRuntime.file?.type || 'image/*',
+          filename: imageRuntime.file?.name || 'upload',
+        }
+      : null;
+    if (!text && !imagePayload) return;
 
     applySubmissionState(true);
     try {
       await ensureInteractionRuntime();
-      await emitIntent(text);
-      pushSessionEvent({ session_id: sessionId, intent: text, transport: 'intent_posted' });
+      await emitIntent(text, imagePayload);
+      pushSessionEvent({
+        session_id: sessionId,
+        intent: text,
+        transport: 'intent_posted',
+        metadata: { image_attached: Boolean(imagePayload), image_name: imagePayload?.filename || null },
+      });
       if (elements.input) elements.input.value = '';
+      clearImageAttachment();
     } catch (error) {
       const message = `Transport error: ${error.message}`;
       setStatus(message);
@@ -565,6 +624,23 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
       if (!shouldSubmitOnEnter(event, inputRuntime)) return;
       event.preventDefault();
       elements.form?.requestSubmit();
+    });
+
+    elements.attachImageButton?.addEventListener('click', () => {
+      elements.imageInput?.click();
+    });
+
+    elements.imageInput?.addEventListener('change', async (event) => {
+      const file = event.target.files?.[0];
+      try {
+        await setImageAttachment(file || null);
+      } catch (error) {
+        setStatus(error.message || 'Attachment failed');
+      }
+    });
+
+    elements.clearImageButton?.addEventListener('click', () => {
+      clearImageAttachment();
     });
   };
 

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
               <form id="composer" class="composer" aria-label="Intent composer">
                 <label class="sr-only" for="intent-input">Intent</label>
                 <input id="intent-input" name="intent" autocomplete="off" placeholder="Type an intent" enterkeyhint="send" data-autofocus />
+                <input id="intent-image-input" name="intent-image" type="file" accept="image/*" class="sr-only" />
                 <button
                   id="voice-btn"
                   class="icon-btn"
@@ -65,8 +66,11 @@
                 >
                   🎙
                 </button>
+                <button id="attach-image-btn" class="icon-btn" type="button" aria-label="Attach image for analysis">🖼</button>
                 <button id="send-btn" type="submit" class="send-btn">Send</button>
               </form>
+              <p id="image-attachment-status" class="pane-status" aria-live="polite"></p>
+              <button id="clear-image-btn" type="button" class="settings-inline-btn" hidden>Remove attached image</button>
               <button id="clear-session" type="button" class="settings-inline-btn">Clear session</button>
             </section>
 


### PR DESCRIPTION
### Motivation
- Enable users to attach images in the Interaction composer so the AI can analyze images alongside text for multimodal responses. 
- Keep the canonical cognitive routes (`/api/v1/cognitive/*`) as the single transport and extend them to accept optional image payloads while preserving backward compatibility. 

### Description
- Frontend: added file input, attach/remove buttons, and attachment status to the Interaction composer in `index.html` and adjusted layout in `clean-first-surface.css`. 
- Frontend: implemented `readFileAsDataUrl`, `setImageAttachment`, `clearImageAttachment`, and wiring in `clean-first-surface.js` to read images as data URLs, validate image type, include image payload with emit, and clear attachment after send. 
- Backend: extended `GenerateRequest` with an optional `image` object (`ImageAttachment`) and added `_extract_image_payload` plus image-aware `invoke_generative_model` handling in `api_gateway/main.py` to validate data URLs, enforce a 5MB limit, and attach inline image data to provider payloads for Google and OpenAI translation. 
- Tests & docs: added an API test that verifies image passthrough behavior (`api_gateway/test_api.py`) and updated `README.md` runtime flow to note optional multimodal input. 

### Testing
- Ran frontend lint with `npm run lint` which completed successfully. 
- Ran backend test suite with `cd api_gateway && pytest -q` which passed (`34 passed`). 
- Ran the frontend unit tests for the composer (`npm test -- --run tests/clean_first_surface_workspace.test.js`) which passed (`1 file, 4 tests`). 
- Ran `python3 tools/contracts/contract_checker.py` which failed due to a preexisting repo import error (`ModuleNotFoundError: tools.contracts.runtime_drift_guard`); this is unrelated to the changes and preexisted in CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93a7ac4248320a8b7705b6869a279)