### PR TITLE
[aeth] Add Phase A world-model curriculum and control contract scaffold

### DIFF
--- a/contracts/aeth-control.schema.json
+++ b/contracts/aeth-control.schema.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aetherium.dev/schemas/aeth-control.schema.json",
+  "title": "AETH Control Contract",
+  "description": "Deterministic, governor-ready AETH control contract for light-particle runtime handoff (renderer not implemented in Phase A).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "meta",
+    "context",
+    "presence8d",
+    "rules",
+    "transitions",
+    "outputs",
+    "governor_assumptions",
+    "determinism"
+  ],
+  "properties": {
+    "contract_version": {
+      "type": "string",
+      "pattern": "^aeth-control/v[0-9]+\\.[0-9]+$"
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "profile", "rule_mode"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "profile": {
+          "type": "string",
+          "enum": ["nominal", "safe_mode", "diagnostic"]
+        },
+        "rule_mode": {
+          "type": "string",
+          "enum": ["first_match", "priority"]
+        }
+      }
+    },
+    "context": {
+      "type": "object",
+      "description": "Declared context keys only. Values must be deterministic at evaluation time.",
+      "additionalProperties": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "number" },
+          { "type": "integer" },
+          { "type": "boolean" }
+        ]
+      }
+    },
+    "presence8d": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spatial_coherence",
+        "temporal_stability",
+        "intent_confidence",
+        "energy_budget",
+        "interaction_readiness",
+        "novelty_pressure",
+        "safety_margin",
+        "counterfactual_depth"
+      ],
+      "properties": {
+        "spatial_coherence": { "$ref": "#/$defs/unitFloat" },
+        "temporal_stability": { "$ref": "#/$defs/unitFloat" },
+        "intent_confidence": { "$ref": "#/$defs/unitFloat" },
+        "energy_budget": { "$ref": "#/$defs/unitFloat" },
+        "interaction_readiness": { "$ref": "#/$defs/unitFloat" },
+        "novelty_pressure": { "$ref": "#/$defs/unitFloat" },
+        "safety_margin": { "$ref": "#/$defs/unitFloat" },
+        "counterfactual_depth": { "$ref": "#/$defs/unitFloat" }
+      }
+    },
+    "rules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "when", "then"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "priority": { "type": "integer", "minimum": 0 },
+          "when": {
+            "type": "string",
+            "description": "Context-aware deterministic predicate expression."
+          },
+          "then": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "set_profile": {
+                "type": "string",
+                "enum": ["nominal", "safe_mode", "diagnostic"]
+              },
+              "set_transition": {
+                "type": "string",
+                "minLength": 1
+              },
+              "cap_output": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "max_intensity": { "$ref": "#/$defs/unitFloat" },
+                  "max_particles": { "type": "integer", "minimum": 0 }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "transitions": {
+      "type": "object",
+      "description": "Deterministic transition DSL lowered to structured form.",
+      "additionalProperties": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["when", "to"],
+          "properties": {
+            "when": { "type": "string", "minLength": 1 },
+            "to": { "type": "string", "minLength": 1 },
+            "else": { "type": "string", "minLength": 1 }
+          }
+        }
+      },
+      "minProperties": 1
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tick_ms", "channels"],
+      "properties": {
+        "tick_ms": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "channels": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "mode", "params"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "mode": {
+                "type": "string",
+                "enum": ["steady", "pulse", "orbit", "vortex"]
+              },
+              "params": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["intensity", "particle_count"],
+                "properties": {
+                  "intensity": { "$ref": "#/$defs/unitFloat" },
+                  "particle_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100000
+                  },
+                  "period_ticks": { "type": "integer", "minimum": 1 },
+                  "phase_deg": { "type": "number", "minimum": 0, "maximum": 360 }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "governor_assumptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pipeline", "deny_by_default", "safe_mode_available"],
+      "properties": {
+        "pipeline": {
+          "type": "array",
+          "const": [
+            "validate",
+            "transition",
+            "profile_map",
+            "clamp",
+            "fallback",
+            "policy_block",
+            "capability_gate",
+            "telemetry_log"
+          ]
+        },
+        "deny_by_default": { "type": "boolean", "const": true },
+        "safe_mode_available": { "type": "boolean", "const": true }
+      }
+    },
+    "determinism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["precision_dp", "allow_randomness", "requires_replay_hash"],
+      "properties": {
+        "precision_dp": { "type": "integer", "const": 4 },
+        "allow_randomness": { "type": "boolean", "const": false },
+        "requires_replay_hash": { "type": "boolean", "const": true }
+      }
+    }
+  },
+  "$defs": {
+    "unitFloat": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    }
+  }
+}

--- a/contracts/aeth-control.schema.json
+++ b/contracts/aeth-control.schema.json
@@ -19,7 +19,7 @@
   "properties": {
     "contract_version": {
       "type": "string",
-      "pattern": "^aeth-control/v[0-9]+\\.[0-9]+$"
+      "pattern": "^aeth-control/v[0-9]+(\\.[0-9]+){1,2}$"
     },
     "meta": {
       "type": "object",

--- a/docs/aeth/aeth_language_spec.md
+++ b/docs/aeth/aeth_language_spec.md
@@ -1,0 +1,145 @@
+# AETH Visual Contract Language (VCL) — Draft Spec v0.1
+
+## 1) Definition
+
+**AETH is a Visual Contract Language (VCL)** for deterministic, governable control of light/particle behaviors. AETH source expresses intent as constrained contracts that can be validated before any runtime actuation.
+
+- Primary objective: deterministic control semantics.
+- Safety objective: governor-first deny-by-default enforcement.
+- Runtime objective (future): compile contracts to downstream renderer control packets.
+
+## 2) Design Principles
+
+1. **Contract-first:** every emitted control value must be schema-valid.
+2. **Deterministic by construction:** no implicit randomness.
+3. **Context-aware:** state transitions depend on explicit context keys only.
+4. **Safe defaults:** unknown capability => reject or safe-mode fallback.
+5. **Replayable:** same input/context must produce same output trace.
+
+## 3) File Structure
+
+An `.aeth` file is UTF-8 text with ordered sections:
+
+1. `meta` — id/version/profile.
+2. `context` — declared context keys + bounded values.
+3. `presence8d` — normalized world-model dimensions.
+4. `rules` — context-aware policy/guard rules.
+5. `transitions` — deterministic transition DSL.
+6. `outputs` — contract payload projections.
+
+## 4) Core Grammar (informal EBNF)
+
+```ebnf
+program        = meta_block, context_block, presence_block, rules_block, transitions_block, outputs_block ;
+meta_block     = "meta", "{", meta_entry*, "}" ;
+context_block  = "context", "{", context_entry*, "}" ;
+presence_block = "presence8d", "{", dimension_entry{8}, "}" ;
+rules_block    = "rules", "{", rule_entry*, "}" ;
+transitions_block = "transitions", "{", transition_entry+, "}" ;
+outputs_block  = "outputs", "{", output_entry+, "}" ;
+
+rule_entry     = "rule", ident, ":", condition, "=>", action, ";" ;
+condition      = predicate, { ("and"|"or"), predicate } ;
+predicate      = key, comparator, value ;
+
+transition_entry = "state", ident, "{", step+, "}" ;
+step           = "when", condition, "->", target, ["else", target], ";" ;
+target         = ident | "safe_mode" | "halt" ;
+```
+
+## 5) Type System
+
+- Scalars: `int`, `float`, `bool`, `string`.
+- Compound: `vec3`, `range[min,max]`, `enum[...]`.
+- Deterministic temporal types:
+  - `tick_ms` (integer, fixed).
+  - `duration_ticks` (integer, non-negative).
+
+No runtime-generated random types are permitted in Phase A.
+
+## 6) 8D Presence IR Binding
+
+The `presence8d` block must define exactly 8 normalized dimensions (`0.0` to `1.0`):
+
+1. `spatial_coherence`
+2. `temporal_stability`
+3. `intent_confidence`
+4. `energy_budget`
+5. `interaction_readiness`
+6. `novelty_pressure`
+7. `safety_margin`
+8. `counterfactual_depth`
+
+Compiler target: canonical IR object with numeric precision fixed to 4 decimal places.
+
+## 7) Context-Aware Rule Syntax
+
+Rules are evaluated top-down, deterministic order, first-match or priority-resolved mode (must be declared in `meta.rule_mode`).
+
+### Rule Example
+
+```aeth
+rule risk_downgrade: context.risk_score > 0.70 and presence8d.safety_margin < 0.40 => set profile = "safe_mode";
+rule low_confidence_halt: context.model_confidence < 0.35 => set transition = "halt";
+```
+
+### Rule Constraints
+
+- Rule conditions can only reference declared `context` keys and `presence8d` dimensions.
+- Side effects allowed in Phase A:
+  - set profile
+  - set transition target
+  - set output cap values
+- Arbitrary mutation is forbidden.
+
+## 8) Transition DSL
+
+Transitions define deterministic state progression.
+
+### Transition Example
+
+```aeth
+state nominal {
+  when context.event == "observe" and context.model_confidence >= 0.60 -> focus;
+  when context.event == "alert" -> safe_mode else halt;
+}
+
+state focus {
+  when context.tick < 120 -> focus;
+  when context.tick >= 120 -> settle;
+}
+```
+
+### Transition Rules
+
+- Must be acyclic or explicitly bounded by tick/duration guard.
+- Each state must have at least one terminal path (`safe_mode`, `halt`, or terminal state).
+- Branch predicates must be mutually resolvable by deterministic ordering.
+
+## 9) Governor Validation Assumptions
+
+AETH compilation assumes governor pipeline:
+
+`validate -> transition -> profile_map -> clamp -> fallback -> policy_block -> capability_gate -> telemetry_log`
+
+Validation assumptions:
+
+1. Input source is untrusted.
+2. Schema and semantic checks run before capability invocation.
+3. Missing bounds invoke clamp or reject (policy-defined).
+4. Unsupported capabilities fail closed.
+5. Safe mode is always available as fallback profile.
+
+## 10) Determinism Constraints (Phase A)
+
+- No wall-clock dependence inside contract logic.
+- No hidden randomness.
+- All ordering explicit.
+- Floats canonicalized (4 decimal digits) before hashing.
+- Replay hash computed from normalized IR + transition trace.
+
+## 11) Out of Scope
+
+- Renderer/shader implementation.
+- Non-deterministic generative motion.
+- Multi-agent synchronization protocols.

--- a/docs/aeth/research_curriculum.md
+++ b/docs/aeth/research_curriculum.md
@@ -1,0 +1,144 @@
+# AETH Phase A Research Curriculum
+
+## Purpose
+
+Phase A establishes a deterministic research scaffold for **AETH (Aetherium Visual Contract Language)** focused on AI world-model curriculum and light-particle control contracts. This phase is documentation and fixtures only; renderer implementation is explicitly out of scope.
+
+## Scope Boundaries (Phase A)
+
+- In scope: language spec draft, 8D world-model IR framing, contract schema, deterministic fixtures, and evaluation protocol.
+- Out of scope: shader runtime, visual renderer execution, adaptive optimization loops, non-deterministic sampling.
+
+## Learning Objectives
+
+By the end of Phase A, a model/pipeline should be able to:
+
+1. Parse AETH documents into deterministic intermediate structures.
+2. Map scene instructions into an **8D Presence IR** for governance.
+3. Apply context-aware rules and transition DSL blocks without ambiguity.
+4. Validate output against governor assumptions and deny-by-default safety policy.
+5. Produce repeatable, testable control artifacts for downstream runtimes.
+
+## Curriculum Modules
+
+### Module 1 — Spatial Reasoning
+
+**Goal:** encode and reason about position, orientation, and region semantics in 3D scene space.
+
+- Topics:
+  - Absolute and relative anchors (`origin`, `anchor`, `region`).
+  - Deterministic transform ordering (`translate -> rotate -> scale`).
+  - Bounded movement corridors.
+- Exercises:
+  - Convert natural-language scene intent into explicit anchor/offset tuples.
+  - Verify no frame exceeds velocity/position clamp.
+- Deterministic checks:
+  - Position vectors must be finite numeric triples.
+  - Region IDs must resolve from known symbol table.
+
+### Module 2 — Visual Reasoning
+
+**Goal:** express light/particle appearance constraints as contracts, not free-form styling.
+
+- Topics:
+  - Palette references, emissive intensity bounds, alpha envelopes.
+  - Layering priorities and occlusion-safe ordering.
+  - Snapshot invariants for visual signatures.
+- Exercises:
+  - Encode a pulse pattern with fixed period and bounded intensity.
+  - Compare expected and actual visual contract deltas.
+- Deterministic checks:
+  - Color tokens must resolve to canonical palette values.
+  - Oscillation parameters require explicit period/phase.
+
+### Module 3 — Physics Reasoning
+
+**Goal:** define controllable motion under constrained pseudo-physics suitable for governance.
+
+- Topics:
+  - Kinematic state representation (velocity, acceleration, damping).
+  - Force field abstractions with hard caps.
+  - Collision response classes (`absorb`, `deflect`, `halt`).
+- Exercises:
+  - Author a stable vortex profile with deterministic timestep.
+  - Demonstrate bounded energy over finite horizon.
+- Deterministic checks:
+  - Timestep (`dt_ms`) must be declared and constant per transition block.
+  - Integration mode restricted to approved enum set.
+
+### Module 4 — Counterfactual Reasoning
+
+**Goal:** represent alternative transitions and safety fallbacks without branching ambiguity.
+
+- Topics:
+  - Guarded transitions (`when`, `unless`, `fallback`).
+  - Counterfactual branch IDs and replay determinism.
+  - Evidence tagging for why a branch was selected.
+- Exercises:
+  - Model `safe_mode` activation on confidence drop.
+  - Replay branch decisions from telemetry log.
+- Deterministic checks:
+  - Branch predicates may only reference declared context keys.
+  - Fallback path required for high-risk classes.
+
+### Module 5 — Safety Reasoning
+
+**Goal:** enforce governor-first safety policy for any visual control signal.
+
+- Topics:
+  - Deny-by-default capability gates.
+  - Context risk scoring and policy block semantics.
+  - Safe-mode profile remapping.
+- Exercises:
+  - Build a rule set that blocks unsafe emission amplitude.
+  - Validate warning and downgrade telemetry events.
+- Deterministic checks:
+  - Every executable transition has an associated risk class.
+  - Unsupported capabilities fail closed with explicit reason.
+
+## Evaluation Framework
+
+### A. Parsing and Contract Fidelity
+
+- **Pass criteria:** all fixtures parse to canonical AST/IR with no nondeterministic fields.
+- **Metrics:** parse success rate, unresolved token count, schema conformance rate.
+
+### B. World-Model Alignment (8D)
+
+- **Pass criteria:** each generated control state maps all required 8D dimensions.
+- **Metrics:** dimensional completeness %, normalization violations, clamp interventions.
+
+### C. Transition Determinism
+
+- **Pass criteria:** identical input/context yields identical transition sequence.
+- **Metrics:** replay hash match rate, branch consistency score.
+
+### D. Safety/Governor Compliance
+
+- **Pass criteria:** unsafe or underspecified control requests are downgraded or blocked.
+- **Metrics:** policy violation catch rate, false-allow count (target: 0).
+
+### E. Curriculum Progression
+
+- **Pass criteria:** module competency thresholds met before advancing.
+- **Metrics:** per-module rubric score (0-4), cumulative readiness index.
+
+## Rubric (0-4)
+
+- **0:** Missing/invalid representation.
+- **1:** Partial representation with major ambiguity.
+- **2:** Structurally valid but unstable under replay.
+- **3:** Deterministic and policy-compliant for standard cases.
+- **4:** Deterministic, policy-compliant, and robust across edge cases.
+
+## Phase A Deliverables
+
+- AETH language specification draft.
+- 8D Presence IR documentation.
+- AETH control contract schema.
+- Deterministic `.aeth` fixture examples for normal + warning/safe-mode paths.
+- Compiler README documenting intended compile pipeline (spec only, no runtime renderer).
+
+## Non-Implementation Note
+
+Phase A intentionally avoids renderer implementation. Any mention of rendering is strictly contract/output intent for future phases.

--- a/docs/aeth/world_model_8d.md
+++ b/docs/aeth/world_model_8d.md
@@ -1,0 +1,96 @@
+# AETH World Model — 8D Presence IR
+
+## Purpose
+
+The **8D Presence IR** is the canonical intermediate representation for world-model state used by AETH governor validation and transition decisions.
+
+It is designed to be:
+
+- bounded (`0.0` to `1.0` per dimension),
+- interpretable,
+- deterministic under replay,
+- independent from renderer implementation.
+
+## Dimension Definitions
+
+| Dimension | Key | Meaning | Typical Clamp |
+|---|---|---|---|
+| D1 | `spatial_coherence` | Structural consistency of scene geometry/anchors. | `[0.10, 0.95]` |
+| D2 | `temporal_stability` | Smoothness and continuity across ticks. | `[0.10, 0.98]` |
+| D3 | `intent_confidence` | Confidence that control signal matches validated intent. | `[0.00, 1.00]` |
+| D4 | `energy_budget` | Fraction of allowed emission/motion energy budget. | `[0.00, 0.85]` |
+| D5 | `interaction_readiness` | Readiness for user/event interaction response. | `[0.00, 1.00]` |
+| D6 | `novelty_pressure` | Pressure toward exploratory pattern variation. | `[0.00, 0.70]` |
+| D7 | `safety_margin` | Distance from policy or physiological risk thresholds. | `[0.20, 1.00]` |
+| D8 | `counterfactual_depth` | Depth of evaluated alternative branches. | `[0.00, 0.80]` |
+
+## Canonical IR Shape
+
+```json
+{
+  "presence8d": {
+    "spatial_coherence": 0.8200,
+    "temporal_stability": 0.7600,
+    "intent_confidence": 0.9100,
+    "energy_budget": 0.4300,
+    "interaction_readiness": 0.6800,
+    "novelty_pressure": 0.2200,
+    "safety_margin": 0.8700,
+    "counterfactual_depth": 0.3400
+  },
+  "normalization": {
+    "precision_dp": 4,
+    "range": [0.0, 1.0]
+  }
+}
+```
+
+## Derivation Guidance (Phase A)
+
+Each dimension should be computed from deterministic upstream features:
+
+- fixed feature list,
+- fixed transform ordering,
+- explicit coefficient table,
+- explicit clamp range.
+
+No stochastic estimators are allowed in Phase A.
+
+## Rule Interaction Model
+
+Rules can read 8D fields directly:
+
+- If `safety_margin < 0.40`, force safe profile remap.
+- If `energy_budget > 0.80`, cap particle amplitude.
+- If `counterfactual_depth < 0.20` and risk high, halt exploratory transitions.
+
+## Transition Use
+
+Transitions may branch using 8D thresholds, e.g.:
+
+- Stable trajectory if `temporal_stability >= 0.70`.
+- De-escalate if `intent_confidence < 0.50`.
+- Lock novelty if `novelty_pressure > 0.65`.
+
+## Governor Assumptions
+
+The IR enters governor at `validate` stage and is rechecked after `clamp` stage.
+
+Required invariants:
+
+1. all 8 keys present,
+2. all numeric finite,
+3. all values normalized to `[0,1]`,
+4. precision canonicalized to 4 decimals,
+5. checksum/replay hash deterministic.
+
+## Evaluation Criteria for 8D Quality
+
+- **Completeness:** 8/8 dimensions present.
+- **Stability:** repeated compile over same input yields exact float strings.
+- **Safety utility:** safety-trigger scenarios correctly modify profile or transitions.
+- **Counterfactual utility:** alternative branches represented without nondeterministic tie-breaks.
+
+## Phase A Constraint
+
+8D Presence IR is a contract surface only. It does not execute rendering behavior.

--- a/tests/fixtures/aeth/thinking_vortex.aeth
+++ b/tests/fixtures/aeth/thinking_vortex.aeth
@@ -1,0 +1,56 @@
+meta {
+  id: "thinking_vortex";
+  version: "0.1.0";
+  profile: "nominal";
+  rule_mode: "first_match";
+}
+
+context {
+  event: "observe";
+  model_confidence: 0.8600;
+  risk_score: 0.1800;
+  tick: 0;
+}
+
+presence8d {
+  spatial_coherence: 0.8200;
+  temporal_stability: 0.7600;
+  intent_confidence: 0.9100;
+  energy_budget: 0.4300;
+  interaction_readiness: 0.6800;
+  novelty_pressure: 0.2200;
+  safety_margin: 0.8700;
+  counterfactual_depth: 0.3400;
+}
+
+rules {
+  rule risk_downgrade: context.risk_score > 0.7000 => set profile = "safe_mode";
+  rule low_confidence_halt: context.model_confidence < 0.3500 => set transition = "halt";
+}
+
+transitions {
+  state nominal {
+    when context.event == "observe" and context.model_confidence >= 0.6000 -> focus;
+    when context.event == "alert" -> safe_mode else halt;
+  }
+
+  state focus {
+    when context.tick < 120 -> focus;
+    when context.tick >= 120 -> settle;
+  }
+
+  state settle {
+    when context.tick >= 180 -> halt;
+  }
+}
+
+outputs {
+  tick_ms: 16;
+  channel primary {
+    mode: vortex;
+    intensity: 0.5400;
+    particle_count: 2800;
+    period_ticks: 48;
+    phase_deg: 90;
+  }
+}

--- a/tests/fixtures/aeth/warning_safe_mode.aeth
+++ b/tests/fixtures/aeth/warning_safe_mode.aeth
@@ -1,0 +1,51 @@
+meta {
+  id: "warning_safe_mode";
+  version: "0.1.0";
+  profile: "nominal";
+  rule_mode: "first_match";
+}
+
+context {
+  event: "alert";
+  model_confidence: 0.3200;
+  risk_score: 0.8100;
+  tick: 0;
+}
+
+presence8d {
+  spatial_coherence: 0.5800;
+  temporal_stability: 0.4200;
+  intent_confidence: 0.3300;
+  energy_budget: 0.7900;
+  interaction_readiness: 0.5100;
+  novelty_pressure: 0.6600;
+  safety_margin: 0.2800;
+  counterfactual_depth: 0.1400;
+}
+
+rules {
+  rule risk_downgrade: context.risk_score > 0.7000 and presence8d.safety_margin < 0.4000 => set profile = "safe_mode";
+  rule low_confidence_halt: context.model_confidence < 0.3500 => set transition = "safe_mode";
+}
+
+transitions {
+  state nominal {
+    when context.event == "alert" -> safe_mode else halt;
+  }
+
+  state safe_mode {
+    when context.tick < 60 -> safe_mode;
+    when context.tick >= 60 -> halt;
+  }
+}
+
+outputs {
+  tick_ms: 16;
+  channel warning {
+    mode: pulse;
+    intensity: 0.2200;
+    particle_count: 900;
+    period_ticks: 24;
+    phase_deg: 0;
+  }
+}

--- a/tools/aeth_compiler/README.md
+++ b/tools/aeth_compiler/README.md
@@ -1,0 +1,71 @@
+# AETH Compiler (Phase A Scaffold)
+
+## Status
+
+This directory defines the intended compile pipeline and interfaces for AETH language processing in Phase A.
+
+**Renderer implementation is intentionally not included.**
+
+## Purpose
+
+Compile `.aeth` Visual Contract Language files into deterministic, governor-ready control artifacts:
+
+1. Parse AETH source.
+2. Normalize to canonical AST.
+3. Lower to 8D Presence IR + transition graph.
+4. Validate against `contracts/aeth-control.schema.json`.
+5. Emit deterministic JSON artifact + replay hash.
+
+## Planned Pipeline
+
+`lex -> parse -> ast_normalize -> semantic_validate -> lower_presence8d -> lower_transitions -> schema_validate -> governor_preflight -> emit`
+
+### Stage Notes
+
+- `lex/parse`:
+  - Deterministic token stream.
+  - Stable parse errors with line/column.
+- `ast_normalize`:
+  - Canonical key ordering.
+  - Default expansion only from explicit spec defaults.
+- `semantic_validate`:
+  - Context key resolution.
+  - Rule/action constraints.
+  - Transition boundedness checks.
+- `lower_presence8d`:
+  - Exactly 8 required dimensions.
+  - Float precision canonicalized to 4 decimals.
+- `schema_validate`:
+  - Must pass `aeth-control.schema.json`.
+- `governor_preflight`:
+  - Enforce assumptions about deny-by-default and safe mode fallback.
+
+## Compiler Assumptions
+
+- Input is untrusted.
+- No non-deterministic operators are accepted.
+- Any unknown capability must fail closed.
+- All output must be replayable from source + context.
+
+## Determinism Contract
+
+For identical `(source, context, compiler_version)` tuple, compiler must produce identical:
+
+- normalized AST hash,
+- emitted contract JSON bytes,
+- replay hash.
+
+## Fixture Usage
+
+Phase A fixture examples are under:
+
+- `tests/fixtures/aeth/thinking_vortex.aeth`
+- `tests/fixtures/aeth/warning_safe_mode.aeth`
+
+These examples are deterministic and can be used for parser/semantic smoke tests.
+
+## Future (Out of Scope for Phase A)
+
+- Runtime renderer packet streaming.
+- Live telemetry-backed adaptive remapping.
+- Multi-agent synchronized scene arbitration.


### PR DESCRIPTION
### Motivation

- Establish a Phase A research scaffold that treats AETH as a Visual Contract Language (VCL) for deterministic, governor-first control of light/particle behaviors.
- Provide a canonical 8D Presence IR, context-aware rule syntax, and a deterministic transition DSL to enable repeatable parser/validator/compile workflows.
- Capture governor validation assumptions and deny-by-default safety constraints while explicitly keeping renderer implementation out of scope.

### Description

- Add language and curriculum documentation under `docs/aeth/` including `research_curriculum.md`, `aeth_language_spec.md`, and `world_model_8d.md` that define objectives, grammar, 8D binding, and evaluation criteria.
- Add a strict JSON Schema at `contracts/aeth-control.schema.json` describing the contract shape, required 8D fields, rule/transition structures, governor assumptions, and determinism constraints (4dp precision, no randomness, replay-hash requirement).
- Add a compiler scaffold README at `tools/aeth_compiler/README.md` describing the planned deterministic pipeline (`lex -> parse -> ast_normalize -> semantic_validate -> lower_presence8d -> lower_transitions -> schema_validate -> governor_preflight -> emit`) and compiler assumptions.
- Add deterministic `.aeth` fixture examples under `tests/fixtures/aeth/` (`thinking_vortex.aeth` and `warning_safe_mode.aeth`) for parser/semantic smoke tests and future validator/compile unit tests.

### Testing

- Ran `npm run lint` in the repository and it completed successfully.
- Validated the added JSON schema with `python3 -m json.tool contracts/aeth-control.schema.json` and it parsed successfully.
- No runtime or renderer tests were run because this change is documentation, schema, and fixture scaffolding only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfc53daa883209cba2700f8c23b56)