### PR TITLE
[frontend] Render chat responses as particle glyphs

### DIFF
--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -559,7 +559,9 @@ export function createApp(documentRef = globalThis.document, deps = {}) {
     applySubmissionState(true);
     try {
       await ensureInteractionRuntime();
+      setStatus('Generating manifestation...');
       await emitIntent(text, imagePayload);
+      setStatus('Response manifested');
       pushSessionEvent({
         session_id: sessionId,
         intent: text,

--- a/first_use_surface/light-manifestation.js
+++ b/first_use_surface/light-manifestation.js
@@ -26,30 +26,9 @@ function clampAlpha(alpha) {
   return Math.max(0, Math.min(1, alpha));
 }
 
-function wrapLines(context, text, maxWidth) {
-  const words = text.split(/\s+/).filter(Boolean);
-  if (words.length <= 1) return [text];
-
-  const lines = [];
-  let currentLine = words[0];
-
-  for (let i = 1; i < words.length; i += 1) {
-    const candidate = `${currentLine} ${words[i]}`;
-    if (context.measureText(candidate).width <= maxWidth) {
-      currentLine = candidate;
-    } else {
-      lines.push(currentLine);
-      currentLine = words[i];
-    }
-  }
-
-  lines.push(currentLine);
-  return lines.slice(0, 3);
-}
-
 export function createLightManifestation(canvas, reducedMotion) {
   const context = canvas.getContext('2d');
-  const particles = createParticleField(320);
+  const particles = createParticleField(460);
   const manifestation = {
     text: '',
     mood: 'greeting',
@@ -90,7 +69,7 @@ export function createLightManifestation(canvas, reducedMotion) {
 
     const imageData = offscreenContext.getImageData(0, 0, width, height).data;
     const points = [];
-    const step = options.reducedMotion ? 8 : 6;
+    const step = options.reducedMotion ? 7 : 5;
 
     for (let y = 0; y < height; y += step) {
       for (let x = 0; x < width; x += step) {
@@ -152,39 +131,30 @@ export function createLightManifestation(canvas, reducedMotion) {
       const alpha = options.reducedMotion ? 1 : clampAlpha(elapsed / 520);
       const palette = moodPalette(manifestation.mood);
       const centerY = height * 0.43;
-      const fontSize = Math.max(26, Math.min(58, width * 0.047));
-
-      if (!options.reducedMotion && manifestation.glyphPoints.length > 0) {
+      if (manifestation.glyphPoints.length > 0) {
         const glyphWidth = Math.max(420, Math.floor(width * 0.7));
         const glyphHeight = 160;
         const originX = (width - glyphWidth) * 0.5;
         const originY = centerY - glyphHeight * 0.5;
 
-        context.fillStyle = `rgba(${palette.glow},${clampAlpha(alpha * 0.85)})`;
+        context.fillStyle = `rgba(${palette.glow},${clampAlpha(alpha * 0.94)})`;
         manifestation.glyphPoints.forEach((point, index) => {
-          if (index % 2 !== 0) return;
-          const shimmer = Math.sin(ts * 0.007 + index * 0.11) * 0.7;
-          const radius = 1 + Math.max(0, shimmer);
+          if (index % (options.reducedMotion ? 3 : 2) !== 0) return;
+          const shimmer = options.reducedMotion ? 0.35 : Math.sin(ts * 0.007 + index * 0.11) * 0.8;
+          const radius = options.reducedMotion ? 1.2 : 1 + Math.max(0, shimmer);
           context.beginPath();
           context.arc(originX + point.x * glyphWidth, originY + point.y * glyphHeight, radius, 0, Math.PI * 2);
           context.fill();
         });
-      }
 
-      context.save();
-      context.textAlign = 'center';
-      context.textBaseline = 'middle';
-      context.font = `700 ${fontSize}px Inter, Sarabun, sans-serif`;
-      context.shadowColor = `rgba(${palette.glow},0.9)`;
-      context.shadowBlur = options.reducedMotion ? 0 : 22;
-      context.fillStyle = `rgba(${palette.core},${alpha})`;
-      const wrapped = wrapLines(context, manifestation.text, width * 0.72);
-      const lineHeight = fontSize * 1.15;
-      const top = centerY - ((wrapped.length - 1) * lineHeight) / 2;
-      wrapped.forEach((line, index) => {
-        context.fillText(line, width * 0.5, top + lineHeight * index);
-      });
-      context.restore();
+        context.fillStyle = `rgba(${palette.core},${clampAlpha(alpha * 0.48)})`;
+        manifestation.glyphPoints.forEach((point, index) => {
+          if (index % 6 !== 0) return;
+          context.beginPath();
+          context.arc(originX + point.x * glyphWidth, originY + point.y * glyphHeight, 2.3, 0, Math.PI * 2);
+          context.fill();
+        });
+      }
     }
 
     requestAnimationFrame(render);


### PR DESCRIPTION
### Motivation
- Replace readable text overlay with a light-native particle glyph manifestation so responses are expressed as assembled particles rather than drawn text.
- Improve perceptual responsiveness and glyph clarity so the UI behaves as a practical, usable manifestation runtime.

### Description
- Visual renderer: updated `first_use_surface/light-manifestation.js` to increase background particle density (320 → 460) and tighten glyph sampling (`step` from `8|6` to `7|5`) to produce clearer particle-formed letter shapes while preserving `reducedMotion` behavior.
- Removed direct canvas text overlay and line-wrapping (`fillText`/`wrapLines`) so output is exclusively represented by particle glyph points, and refined shimmer/radius logic with additional core-dot accents for improved readability.
- UX: added runtime submit-status updates in `clean-first-surface.js` (`setStatus('Generating manifestation...')` and `setStatus('Response manifested')`) to improve perceived responsiveness during intent submission.
- Scope: changes are frontend-only and touch `clean-first-surface.js` and `first_use_surface/light-manifestation.js`, with no API/schema/governor modifications.

### Testing
- Ran linting via `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ffd7f4d48320b067024069933539)