### PR TITLE
[gpu-sim] add two-level WGSL scan pass, tests, and telemetry

### DIFF
--- a/docs/runtime_gpu_scan.md
+++ b/docs/runtime_gpu_scan.md
@@ -1,0 +1,20 @@
+# GPU Scan Runtime Notes
+
+## Multi-pass prefix-sum layout
+
+`runtime/gpu-sim/passes/scan.pass.wgsl` now models a deterministic 2-level exclusive scan pipeline:
+
+1. `upsweep`: workgroup-local scan (shared memory) with padding and bounds checks.
+2. `scanBlockSums`: deterministic scan of per-block totals.
+3. `downsweep`: adds block offsets back to each local prefix and writes the sentinel total.
+
+The implementation treats non-divisible `cellCount` as a first-class case by zero-padding out-of-bounds lanes.
+
+## Telemetry
+
+`GpuSimulationEngine` records per-frame scan metrics:
+
+- `throughputCellsPerSecond`: cells processed / scan latency (PrefixSum pass).
+- `maxLatencyMs`: running max scan latency seen across frames.
+
+Use `getTelemetry()` to inspect current scan metrics for runtime diagnostics.

--- a/runtime/gpu-sim/engine.ts
+++ b/runtime/gpu-sim/engine.ts
@@ -26,6 +26,15 @@ export interface GpuUniformAdapterInput {
   deltaTime: number;
 }
 
+export interface ScanTelemetry {
+  throughputCellsPerSecond: number;
+  maxLatencyMs: number;
+}
+
+export interface GpuTelemetryFrame {
+  scan: ScanTelemetry;
+}
+
 export function mapIRToGpuUniforms(input: GpuUniformAdapterInput): GpuUniforms {
   return {
     deltaTime: input.deltaTime,
@@ -50,6 +59,13 @@ export class GpuSimulationEngine {
     'Swap',
   ];
 
+  private telemetry: GpuTelemetryFrame = {
+    scan: {
+      throughputCellsPerSecond: 0,
+      maxLatencyMs: 0,
+    },
+  };
+
   static isSupported(): boolean {
     return typeof navigator !== 'undefined' && 'gpu' in navigator;
   }
@@ -61,9 +77,26 @@ export class GpuSimulationEngine {
       deltaTime: ir.deltaTime,
     });
 
+    let scanLatencyMs = 0;
     for (const pass of GpuSimulationEngine.PASS_ORDER) {
+      if (pass === 'PrefixSum') {
+        const scanStart = performance.now();
+        this.dispatchPass(pass, uniforms);
+        scanLatencyMs = performance.now() - scanStart;
+        continue;
+      }
       this.dispatchPass(pass, uniforms);
     }
+
+    if (scanLatencyMs > 0) {
+      const throughput = uniforms.targetCount > 0 ? (uniforms.targetCount / scanLatencyMs) * 1000 : 0;
+      this.telemetry.scan.throughputCellsPerSecond = throughput;
+      this.telemetry.scan.maxLatencyMs = Math.max(this.telemetry.scan.maxLatencyMs, scanLatencyMs);
+    }
+  }
+
+  getTelemetry(): GpuTelemetryFrame {
+    return this.telemetry;
   }
 
   private dispatchPass(pass: GpuPassName, uniforms: GpuUniforms): void {

--- a/runtime/gpu-sim/passes/scan.pass.wgsl
+++ b/runtime/gpu-sim/passes/scan.pass.wgsl
@@ -1,13 +1,88 @@
+const WORKGROUP_SIZE: u32 = 256u;
+
 struct ScanParams {
   cellCount: u32,
+  blockCount: u32,
 };
 
 @group(0) @binding(0) var<storage, read> cellCounts: array<u32>;
 @group(0) @binding(1) var<storage, read_write> cellOffsetsStart: array<u32>;
-@group(0) @binding(2) var<uniform> params: ScanParams;
+@group(0) @binding(2) var<storage, read_write> blockSums: array<u32>;
+@group(0) @binding(3) var<storage, read_write> blockOffsets: array<u32>;
+@group(0) @binding(4) var<uniform> params: ScanParams;
+
+var<workgroup> sharedScan: array<u32, WORKGROUP_SIZE>;
+
+fn exclusive_prefix_from_inclusive(inclusiveValue: u32, originalValue: u32) -> u32 {
+  return inclusiveValue - originalValue;
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE)
+fn upsweep(
+  @builtin(local_invocation_id) lid: vec3<u32>,
+  @builtin(workgroup_id) wid: vec3<u32>,
+) {
+  let lane = lid.x;
+  let block = wid.x;
+  if (block >= params.blockCount) {
+    return;
+  }
+
+  let globalIndex = block * WORKGROUP_SIZE + lane;
+  let inBounds = globalIndex < params.cellCount;
+  sharedScan[lane] = select(0u, cellCounts[globalIndex], inBounds);
+  workgroupBarrier();
+
+  var offset: u32 = 1u;
+  loop {
+    if (offset >= WORKGROUP_SIZE) {
+      break;
+    }
+    var addend: u32 = 0u;
+    if (lane >= offset) {
+      addend = sharedScan[lane - offset];
+    }
+    workgroupBarrier();
+    sharedScan[lane] = sharedScan[lane] + addend;
+    workgroupBarrier();
+    offset = offset << 1u;
+  }
+
+  if (inBounds) {
+    cellOffsetsStart[globalIndex] = exclusive_prefix_from_inclusive(sharedScan[lane], cellCounts[globalIndex]);
+  }
+
+  if (lane == WORKGROUP_SIZE - 1u) {
+    blockSums[block] = sharedScan[lane];
+  }
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE)
+fn downsweep(
+  @builtin(local_invocation_id) lid: vec3<u32>,
+  @builtin(workgroup_id) wid: vec3<u32>,
+) {
+  let lane = lid.x;
+  let block = wid.x;
+  if (block >= params.blockCount) {
+    return;
+  }
+
+  let globalIndex = block * WORKGROUP_SIZE + lane;
+  if (globalIndex >= params.cellCount) {
+    return;
+  }
+
+  cellOffsetsStart[globalIndex] = cellOffsetsStart[globalIndex] + blockOffsets[block];
+
+  // Sentinel stores the total count for range end reads.
+  if (globalIndex + 1u == params.cellCount) {
+    cellOffsetsStart[params.cellCount] = cellOffsetsStart[globalIndex] + cellCounts[globalIndex];
+  }
+}
 
 @compute @workgroup_size(1)
-fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+fn scanBlockSums(@builtin(global_invocation_id) gid: vec3<u32>) {
   if (gid.x != 0u) {
     return;
   }
@@ -15,14 +90,17 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   var prefix: u32 = 0u;
   var i: u32 = 0u;
   loop {
-    if (i >= params.cellCount) {
+    if (i >= params.blockCount) {
       break;
     }
-    cellOffsetsStart[i] = prefix;
-    prefix = prefix + cellCounts[i];
+    // Reusing cellOffsetsStart as a host-visible buffer for block offsets is
+    // intentionally avoided to keep buffers ABI explicit.
+    // blockOffsets is read-only in GPU dispatch and produced by this pass in a
+    // dedicated bind group in host wiring.
+    // This shader body acts as contract for deterministic block-sum scan logic.
+    // Host wiring writes this prefix stream into blockOffsets.
+    blockOffsets[i] = prefix;
+    prefix = prefix + blockSums[i];
     i = i + 1u;
   }
-
-  // Sentinel stores the total count for range end reads.
-  cellOffsetsStart[params.cellCount] = prefix;
 }

--- a/tests/scan_multi_pass.test.js
+++ b/tests/scan_multi_pass.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const WORKGROUP_SIZE = 256;
+
+function cpuReferenceExclusiveScan(counts) {
+  const out = new Array(counts.length + 1).fill(0);
+  let prefix = 0;
+  for (let i = 0; i < counts.length; i += 1) {
+    out[i] = prefix;
+    prefix += counts[i];
+  }
+  out[counts.length] = prefix;
+  return out;
+}
+
+function twoLevelExclusiveScan(counts, workgroupSize = WORKGROUP_SIZE) {
+  const cellCount = counts.length;
+  const blockCount = Math.ceil(cellCount / workgroupSize);
+  const localOffsets = new Array(cellCount + 1).fill(0);
+  const blockSums = new Array(blockCount).fill(0);
+
+  for (let block = 0; block < blockCount; block += 1) {
+    const start = block * workgroupSize;
+    const end = Math.min(start + workgroupSize, cellCount);
+    let prefix = 0;
+    for (let i = start; i < end; i += 1) {
+      localOffsets[i] = prefix;
+      prefix += counts[i];
+    }
+    blockSums[block] = prefix;
+  }
+
+  const blockOffsets = new Array(blockCount).fill(0);
+  let blockPrefix = 0;
+  for (let block = 0; block < blockCount; block += 1) {
+    blockOffsets[block] = blockPrefix;
+    blockPrefix += blockSums[block];
+  }
+
+  for (let block = 0; block < blockCount; block += 1) {
+    const start = block * workgroupSize;
+    const end = Math.min(start + workgroupSize, cellCount);
+    for (let i = start; i < end; i += 1) {
+      localOffsets[i] += blockOffsets[block];
+    }
+  }
+  localOffsets[cellCount] = blockPrefix;
+  return localOffsets;
+}
+
+function makePatternedCounts(size, modulo) {
+  return Array.from({ length: size }, (_, i) => (i * 7 + 3) % modulo);
+}
+
+test('two-level scan matches CPU reference for deterministic vectors', () => {
+  const vectors = [
+    { name: 'small', counts: [0, 3, 1, 5, 0, 2, 9, 1] },
+    { name: 'medium-non-divisible', counts: makePatternedCounts(777, 11) },
+    { name: 'large-non-divisible', counts: makePatternedCounts(8193, 17) },
+  ];
+
+  for (const { name, counts } of vectors) {
+    const expected = cpuReferenceExclusiveScan(counts);
+    const actual = twoLevelExclusiveScan(counts);
+    assert.deepEqual(actual, expected, `vector ${name} mismatch`);
+  }
+});


### PR DESCRIPTION
### Motivation

- Implement a deterministic, scalable prefix-sum (exclusive scan) suitable for the GPU-sim pipeline to support multi-pass host/GPU wiring and non-divisible cell counts.
- Provide validation vectors to ensure algorithm correctness across small, medium, and large inputs and to catch regressions early.
- Expose basic scan performance telemetry to aid runtime diagnostics and benchmarking.

### Description

- Added a 2-level WGSL scan shader at `runtime/gpu-sim/passes/scan.pass.wgsl` implementing `upsweep` (workgroup-local scan), `scanBlockSums` (block totals scan), and `downsweep` (add block offsets back), with explicit padding and bounds checks for non-divisible `cellCount` and a sentinel total at `cellOffsetsStart[cellCount]`.
- Introduced new storage bindings for `blockSums` and `blockOffsets` and extended `ScanParams` with `blockCount` in the shader to support block-level aggregation.
- Extended `runtime/gpu-sim/engine.ts` to record per-frame scan telemetry via a `ScanTelemetry` structure, timing the `PrefixSum` pass and tracking `throughputCellsPerSecond` and a running `maxLatencyMs`, exposed via `getTelemetry()`.
- Added deterministic unit tests in `tests/scan_multi_pass.test.js` that compare a JavaScript two-level scan implementation to a CPU reference for small/medium/large vectors (including non-divisible sizes), and added documentation at `docs/runtime_gpu_scan.md` describing the multi-pass layout and telemetry.

### Testing

- Ran `npm run lint` which completed without lint errors.
- Ran `node --test tests/scan_multi_pass.test.js` which passed all test vectors (two-level scan matches CPU reference).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b0ca3d288320a0153625110226ca)