### PR TITLE
[frontend] Add lazy-mounted settings icon panel on first surface

### DIFF
--- a/clean-first-surface.css
+++ b/clean-first-surface.css
@@ -27,6 +27,62 @@ body {
   display: block;
 }
 
+.settings-icon-btn {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 10;
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.settings-panel {
+  position: fixed;
+  top: 66px;
+  right: 16px;
+  z-index: 10;
+  width: min(360px, calc(100vw - 24px));
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(5, 10, 20, 0.96);
+  backdrop-filter: blur(8px);
+}
+
+.settings-panel[hidden] { display: none; }
+
+.settings-panel h2 {
+  margin: 0 0 12px;
+  font-size: 0.95rem;
+}
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.settings-grid label {
+  display: grid;
+  gap: 4px;
+  font-size: 0.85rem;
+}
+
+.settings-grid input,
+.settings-grid select {
+  min-height: 36px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--ink);
+  padding: 0 10px;
+}
+
 .first-surface {
   position: fixed;
   inset: 0;

--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -1,4 +1,5 @@
 import { createParticleTextRenderer } from './first_use_surface/particle_text_renderer.js';
+import { createSettingsStore } from './first_use_surface/settings-store.js';
 
 const DEFAULT_COGNITIVE_API_BASE = '/api/v1/cognitive';
 
@@ -85,13 +86,105 @@ function bootstrap(doc = globalThis.document) {
 
   if (!canvas || !composer || !input) return;
 
+  const settingsButton = doc.getElementById('settings-icon-btn');
+  const settingsStore = createSettingsStore(globalThis.localStorage);
+  let settingsState = settingsStore.load();
+  let settingsPanel = null;
+
   const runtime = createParticleTextRenderer(canvas);
   const runtimeState = {
     sessionId: `session-${Date.now().toString(36)}`,
-    endpoints: { apiBase: DEFAULT_COGNITIVE_API_BASE, wsBase: '/ws/cognitive-stream' },
+    endpoints: { apiBase: settingsState.apiBase, wsBase: settingsState.wsBase },
     lastTransport: 'idle',
     lastSystemText: '',
   };
+
+  const updateSettings = (patch) => {
+    settingsState = settingsStore.merge(patch);
+    runtimeState.endpoints = {
+      apiBase: settingsState.apiBase,
+      wsBase: settingsState.wsBase,
+    };
+  };
+
+  const mountSettingsPanel = () => {
+    if (settingsPanel) return settingsPanel;
+
+    const panel = doc.createElement('section');
+    panel.id = 'settings-panel';
+    panel.className = 'settings-panel';
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-label', 'Settings');
+    panel.hidden = true;
+
+    panel.innerHTML = `
+      <h2>Settings</h2>
+      <div class="settings-grid">
+        <label>Language
+          <select id="settings-language">
+            <option value="auto">Auto</option>
+            <option value="th">ไทย</option>
+            <option value="en">English</option>
+            <option value="ja">日本語</option>
+            <option value="es">Español</option>
+          </select>
+        </label>
+        <label>Particle mode
+          <select id="settings-runtime-mode">
+            <option value="calm">Calm</option>
+            <option value="balanced">Balanced</option>
+            <option value="vivid">Vivid</option>
+          </select>
+        </label>
+        <label>Performance
+          <select id="settings-reduced-motion">
+            <option value="false">Normal</option>
+            <option value="true">Reduced motion</option>
+          </select>
+        </label>
+        <label>API base
+          <input id="settings-api-base" type="text" />
+        </label>
+        <label>WS path
+          <input id="settings-ws-base" type="text" />
+        </label>
+      </div>
+    `;
+
+    doc.body.append(panel);
+
+    const language = panel.querySelector('#settings-language');
+    const runtimeMode = panel.querySelector('#settings-runtime-mode');
+    const reducedMotion = panel.querySelector('#settings-reduced-motion');
+    const apiBase = panel.querySelector('#settings-api-base');
+    const wsBase = panel.querySelector('#settings-ws-base');
+
+    const syncPanelInputs = () => {
+      language.value = settingsState.language;
+      runtimeMode.value = settingsState.runtimeMode;
+      reducedMotion.value = String(settingsState.reducedMotion);
+      apiBase.value = settingsState.apiBase;
+      wsBase.value = settingsState.wsBase;
+    };
+
+    syncPanelInputs();
+
+    language.addEventListener('change', () => updateSettings({ language: language.value }));
+    runtimeMode.addEventListener('change', () => updateSettings({ runtimeMode: runtimeMode.value }));
+    reducedMotion.addEventListener('change', () => updateSettings({ reducedMotion: reducedMotion.value === 'true' }));
+    apiBase.addEventListener('change', () => updateSettings({ apiBase: apiBase.value || DEFAULT_COGNITIVE_API_BASE }));
+    wsBase.addEventListener('change', () => updateSettings({ wsBase: wsBase.value || '/ws/cognitive-stream' }));
+
+    settingsPanel = panel;
+    return settingsPanel;
+  };
+
+  settingsButton?.addEventListener('click', () => {
+    const panel = mountSettingsPanel();
+    const willOpen = panel.hidden;
+    panel.hidden = !willOpen;
+    settingsButton.setAttribute('aria-expanded', String(willOpen));
+  });
 
   composer.addEventListener('submit', async (event) => {
     event.preventDefault();

--- a/index.html
+++ b/index.html
@@ -10,6 +10,17 @@
   <body>
     <canvas id="manifestation-canvas" aria-hidden="true"></canvas>
 
+    <button
+      id="settings-icon-btn"
+      class="settings-icon-btn"
+      type="button"
+      aria-label="Open settings"
+      aria-controls="settings-panel"
+      aria-expanded="false"
+    >
+      ⚙
+    </button>
+
     <main class="first-surface" aria-label="Aetherium chat surface">
       <form id="composer" class="composer" aria-label="Chat composer">
         <label class="sr-only" for="intent-input">Message</label>


### PR DESCRIPTION
### Motivation
- Provide a non-intrusive settings affordance on the first surface without changing the initial composer-first view.
- Consolidate scattered configuration logic into a single settings store so runtime endpoints and user prefs are driven from one state path.
- Ensure the settings UI is lazy-mounted and never auto-opens, preserving the minimal first-view (chat input + send button) experience.

### Description
- Add a top-right settings icon button in `index.html` (`#settings-icon-btn`) that is outside the main `first-surface` so the first view remains the chat composer only.
- Implement a lazy-mounted settings panel in `clean-first-surface.js` that is created on first click and contains controls for language, particle mode, reduced-motion/performance, and connectivity (`apiBase` / `wsBase`).
- Integrate the existing `createSettingsStore` from `first_use_surface/settings-store.js` and hydrate runtime endpoint config (`apiBase`, `wsBase`) from the store; provide `updateSettings` to merge and persist changes.
- Add styling for the icon and panel in `clean-first-surface.css`, and ensure the panel stays hidden by default and toggles `aria-expanded` only on explicit user interaction.

### Testing
- Ran `npm run lint` which completed successfully.
- Attempted to run JS tests via `npx --yes tsx --test ...` but the environment failed to fetch `tsx` from the npm registry (HTTP 403), so those tests could not complete.
- No ABI/schema changes were made and no backend `pytest` or contract checker runs were performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f617020b9883208acbe9212ba63801)