### PR TITLE
[deps] Enforce patched PostCSS version to mitigate stringify XSS risk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,10 @@
       "engines": {
         "node": ">=20.11.0",
         "npm": ">=10.0.0"
+      },
+      "overrides": {
+        "postcss": "8.5.6",
+        "protobufjs": "7.5.5"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "npm": ">=10.0.0"
       },
       "overrides": {
-        "postcss": "8.5.6",
+        "postcss": "^8.5.6",
         "protobufjs": "7.5.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "overrides": {
     "protobufjs": "7.5.5",
-    "postcss": "8.5.6"
+    "postcss": "^8.5.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.12.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "xstate": "^5.19.2"
   },
   "overrides": {
-    "protobufjs": "7.5.5"
+    "protobufjs": "7.5.5",
+    "postcss": "8.5.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.12.0",


### PR DESCRIPTION
### Motivation
- Prevent a reported XSS risk in PostCSS CSS stringify where `</style>` could be emitted unescaped by ensuring dependency resolution uses a patched baseline. 
- Apply a non-breaking dependency hardening at install/lockfile level so the frontend dependency tree cannot regress to an unsafe PostCSS version.

### Description
- Added an `overrides` entry for `postcss: "8.5.6"` in `package.json` to pin a patched minimum for PostCSS. 
- Updated `package-lock.json` root `packages[''].overrides` to include the same `postcss: "8.5.6"` entry so the lockfile reflects the policy. 
- Confirmed the lockfile currently resolves `postcss@8.5.13`, which satisfies the enforced baseline and keeps the resolved tree at or above the patched version. 
- Changes are limited to dependency metadata and do not modify runtime code or schemas.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Verified lockfile overrides and resolved PostCSS version with a quick `node -e` check against `package-lock.json`, which showed the root overrides and `postcss` resolution. 
- Attempted `npm audit --omit=dev` but the environment returned `403 Forbidden` from the registry audit endpoint, so a full audit could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f621510dd0832099da66f205aeeaf3)