### PR TITLE
[runtime] Smooth particle morphing with easing and cursor bloom

### DIFF
--- a/clean-first-surface.js
+++ b/clean-first-surface.js
@@ -93,6 +93,7 @@ function bootstrap(doc = globalThis.document) {
   let settingsPanel = null;
 
   const runtime = createParticleTextRenderer(canvas);
+  runtime.setMorphDuration(settingsState.runtimeMode === 'vivid' ? 0.8 : (settingsState.runtimeMode === 'calm' ? 1.8 : 1.2));
   const runtimeState = {
     sessionId: `session-${Date.now().toString(36)}`,
     endpoints: { apiBase: settingsState.apiBase, wsBase: settingsState.wsBase },
@@ -171,7 +172,10 @@ function bootstrap(doc = globalThis.document) {
     syncPanelInputs();
 
     language.addEventListener('change', () => updateSettings({ language: language.value }));
-    runtimeMode.addEventListener('change', () => updateSettings({ runtimeMode: runtimeMode.value }));
+    runtimeMode.addEventListener('change', () => {
+      updateSettings({ runtimeMode: runtimeMode.value });
+      runtime.setMorphDuration(runtimeMode.value === 'vivid' ? 0.8 : (runtimeMode.value === 'calm' ? 1.8 : 1.2));
+    });
     reducedMotion.addEventListener('change', () => updateSettings({ reducedMotion: reducedMotion.value === 'true' }));
     apiBase.addEventListener('change', () => updateSettings({ apiBase: apiBase.value || DEFAULT_COGNITIVE_API_BASE }));
     wsBase.addEventListener('change', () => updateSettings({ wsBase: wsBase.value || '/ws/cognitive-stream' }));
@@ -203,6 +207,7 @@ function bootstrap(doc = globalThis.document) {
       systemReply = { text: fallbackText, state: 'focused' };
     }
 
+    runtime.setEnergy(systemReply.visual?.energy ?? 0.35);
     runtime.setFlowDirection(systemReply.visual?.flowDirection ?? 'outward');
     runtime.renderText(systemReply.text, systemReply.state);
   });

--- a/first_use_surface/particle_text_renderer.js
+++ b/first_use_surface/particle_text_renderer.js
@@ -3,6 +3,7 @@ const DEFAULT_OPTIONS = {
   sampleStep: 4,
   maxParticles: 3200,
   ease: 0.09,
+  morphDuration: 1.35,
   damping: 0.84,
   jitter: 0.35,
   alphaThreshold: 64,
@@ -11,6 +12,12 @@ const DEFAULT_OPTIONS = {
 
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
+}
+
+
+function easeInOutCubic(t) {
+  if (t < 0.5) return 4 * t * t * t;
+  return 1 - ((-2 * t + 2) ** 3) / 2;
 }
 
 function wrapLines(ctx, message, maxWidth) {
@@ -53,6 +60,7 @@ export function createParticleTextRenderer(canvas, options = {}) {
 
   const particles = [];
   let targets = [];
+  let morphStartTime = globalThis.performance.now();
   let rafId = 0;
   let palette = { r: 127, g: 228, b: 255 };
   let flowDirection = config.flowDirection;
@@ -126,6 +134,8 @@ export function createParticleTextRenderer(canvas, options = {}) {
         vy: 0,
         tx: targets[idx].x,
         ty: targets[idx].y,
+        sx: canvas.width * 0.5 + (Math.random() - 0.5) * 120,
+        sy: canvas.height * 0.65 + (Math.random() - 0.5) * 120,
         alpha: 0,
         life: Math.random() * 120,
       });
@@ -140,16 +150,25 @@ export function createParticleTextRenderer(canvas, options = {}) {
     }
   };
 
+  let energyLevel = 0.35;
+  let mouse = { x: canvas.width * 0.5, y: canvas.height * 0.5, active: false };
+
   const animate = () => {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const now = globalThis.performance.now();
+    const morphT = clamp((now - morphStartTime) / (config.morphDuration * 1000), 0, 1);
+    const easedMorph = easeInOutCubic(morphT);
 
     for (let i = particles.length - 1; i >= 0; i -= 1) {
       const p = particles[i];
       const active = i < targets.length;
 
       if (active) {
-        const dx = p.tx - p.x;
-        const dy = p.ty - p.y;
+        const morphX = p.sx + (p.tx - p.sx) * easedMorph;
+        const morphY = p.sy + (p.ty - p.sy) * easedMorph;
+        const dx = morphX - p.x;
+        const dy = morphY - p.y;
         const radialDx = p.x - canvas.width * 0.5;
         const radialDy = p.y - canvas.height * 0.5;
         const radialScale = config.ease * 0.18;
@@ -178,14 +197,42 @@ export function createParticleTextRenderer(canvas, options = {}) {
         continue;
       }
 
+      let bloomStrength = 0;
+      if (mouse.active) {
+        const dist = Math.hypot(mouse.x - p.x, mouse.y - p.y);
+        const bloomRadius = 96 + energyLevel * 72;
+        const proximity = clamp(1 - dist / bloomRadius, 0, 1);
+        bloomStrength = proximity * (0.12 + energyLevel * 0.28);
+      }
+
+      const easedAlpha = clamp(p.alpha + easedMorph * 0.08, 0, 0.98);
       ctx.beginPath();
-      ctx.fillStyle = `rgba(${palette.r}, ${palette.g}, ${palette.b}, ${p.alpha})`;
-      ctx.arc(p.x, p.y, 1.25, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(${palette.r}, ${palette.g}, ${palette.b}, ${easedAlpha})`;
+      ctx.arc(p.x, p.y, 1.25 + bloomStrength * 2.4, 0, Math.PI * 2);
       ctx.fill();
+
+      if (bloomStrength > 0.01) {
+        ctx.beginPath();
+        ctx.fillStyle = `rgba(${palette.r}, ${palette.g}, ${palette.b}, ${bloomStrength * 0.35})`;
+        ctx.arc(p.x, p.y, 4 + bloomStrength * 10, 0, Math.PI * 2);
+        ctx.fill();
+      }
     }
 
     rafId = globalThis.requestAnimationFrame(animate);
   };
+
+
+  const onPointerMove = (event) => {
+    mouse = { x: event.clientX, y: event.clientY, active: true };
+  };
+  const onPointerLeave = () => {
+    mouse = { ...mouse, active: false };
+  };
+
+  canvas.addEventListener('pointermove', onPointerMove);
+  canvas.addEventListener('pointerdown', onPointerMove);
+  canvas.addEventListener('pointerleave', onPointerLeave);
 
   resize();
   animate();
@@ -195,6 +242,18 @@ export function createParticleTextRenderer(canvas, options = {}) {
     renderText(message = '', mood = 'neutral') {
       palette = moodPalette(mood);
       targets = pointCloudFromMask(message);
+      morphStartTime = globalThis.performance.now();
+      for (let i = 0; i < particles.length; i += 1) {
+        particles[i].sx = particles[i].x;
+        particles[i].sy = particles[i].y;
+      }
+      syncParticles();
+    },
+    setEnergy(energy = 0.35) {
+      energyLevel = clamp(Number(energy) || 0, 0, 1);
+    },
+    setMorphDuration(seconds = config.morphDuration) {
+      config.morphDuration = clamp(Number(seconds) || DEFAULT_OPTIONS.morphDuration, 0.2, 8);
     },
     setFlowDirection(direction = 'outward') {
       const normalized = String(direction).toLowerCase();
@@ -203,6 +262,9 @@ export function createParticleTextRenderer(canvas, options = {}) {
     destroy() {
       globalThis.cancelAnimationFrame(rafId);
       globalThis.removeEventListener('resize', resize);
+      canvas.removeEventListener('pointermove', onPointerMove);
+      canvas.removeEventListener('pointerdown', onPointerMove);
+      canvas.removeEventListener('pointerleave', onPointerLeave);
     },
   };
 }


### PR DESCRIPTION
### Motivation

- Improve particle morphing in the frontend runtime so transitions between the current and new target shapes are smoother and more organic by using an easing progression instead of a simple linear/velocity-driven approach.
- Provide a time-driven, adjustable morph control so different runtime modes can tune how quickly particles settle into new targets via a `morphDuration` parameter.
- Add a subtle, energy-driven bloom effect near the pointer to give local emphasis when the user interacts with the particle field.

### Description

- Added an `easeInOutCubic` easing function and time-based morph progression (using `morphStartTime` and `morphDuration`) to `first_use_surface/particle_text_renderer.js` to blend per-particle start positions (`sx`,`sy`) into new targets using eased interpolation.
- Introduced `morphDuration` default option and runtime setter `setMorphDuration(seconds)` and added `setEnergy(energy)` to control bloom intensity scaling from code paths.
- Implemented a subtle cursor-proximity bloom computed from particle-to-mouse distance and `energy` that enlarges and softens nearby particles, and added pointer handlers (`pointermove`, `pointerdown`, `pointerleave`) to update cursor state.
- Wired frontend bootstrap (`clean-first-surface.js`) to set runtime `energy` from the cognitive response and to set `morphDuration` per `runtimeMode` (`calm`, `balanced`, `vivid`) via `setMorphDuration` so UX modes tune morph timing.
- Changes are rendering-only and limited to `first_use_surface/particle_text_renderer.js` and `clean-first-surface.js` (no API/schema changes). Files touched: `first_use_surface/particle_text_renderer.js`, `clean-first-surface.js`.

### Testing

- Ran lint with `npm run lint` and the lint check passed.
- Ran unit tests with `npm test` (vitest): test run failed due to pre-existing workspace test issues including ESM/CommonJS mismatch and multiple UI test failures (examples: `createApp is not a function`, several `blank_home_settings_workspace` assertions, and test files reporting "No test suite found"), which appear unrelated to these rendering-only changes.
- Manual smoke: renderer API additions (`renderText`, `setFlowDirection`) remain compatible and new setters (`setEnergy`, `setMorphDuration`) are optional and default-preserving.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6aa2898508320a89e38125b315920)